### PR TITLE
Disable storing the executable as an artifact of the ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,3 @@ jobs:
           cp -r configuration sdccc/target/zip/
           cp sdccc/target/sdccc-*.exe sdccc/target/zip/
           cp README.md sdccc/target/zip/
-      - name: Archive built executable
-        uses: actions/upload-artifact@v3
-        with:
-          name: executable
-          path: sdccc/target/zip


### PR DESCRIPTION
Artifacts have a storage limit of [500MB for free accounts](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes), which we will reach with just three deployed executable artifacts. Disable artifact deployment for now to avoid this.