### PR TITLE
Build (pre-) releases for tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
           options: #optional
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: retrieve jre cache
         id: jre-cache
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,12 @@ jobs:
         run: |
           zip -qq -r ${{ env.ZIP_FILE_NAME }} .
 
+      - name: Zip test results
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: sdccc/target/
+        run: |
+          zip -qq -r test-results.zip failsafe-reports surefire-reports checkstyle-result.xml spotbugsXml.xml
+
       - name: Attach artifacts to snapshot
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -93,5 +99,6 @@ jobs:
           files: |
             CHANGELOG.md
             sdccc/target/zip/${{ env.ZIP_FILE_NAME }}
+            sdccc/target/test-results.zip
           prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
           body_path: CHANGELOG.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ${{ env.ZIP_FILE_NAME }}
             CHANGELOG.md
-          prerelease: !startsWith(github.ref, 'refs/tags/v')
+            ${{ env.ZIP_FILE_NAME }}
+          prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
           body_path: CHANGELOG.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,8 +67,19 @@ jobs:
           args: zip -qq -r SDCcc-${{ env.RELEASE_VERSION }}-executable-win64.zip sdccc/target/zip/
       - name: Attach artifacts to release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
             SDCcc-${{ env.RELEASE_VERSION }}-executable-win64.zip
             CHANGELOG.md
+          body_path: CHANGELOG.md
+      - name: Attach artifacts to snapshotrelease
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v')
+        with:
+          files: |
+            SDCcc-${{ env.RELEASE_VERSION }}-${{ env.CHANGELIST }}-executable-win64.zip
+            CHANGELOG.md
+          prerelease: true
+          name: SNAPSHOT
+          body_path: CHANGELOG.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,17 @@ jobs:
           echo RELEASE_VERSION=$(cat pom.xml | grep -o -P '(?<=revision\>).*(?=\<\/revision)') >> $GITHUB_ENV
           echo "Release version is $RELEASE_VERSION"
           echo GIT_HASH_SHORT=$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_ENV
+          echo "Git revision is is $GIT_HASH_SHORT"
 
       - name: Remove SNAPSHOT suffix for release
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          echo CHANGELIST=${{ env.CHANGELIST }}.${{ env. GIT_HASH_SHORT }} >> $GITHUB_ENV
+          echo CHANGELIST= >> $GITHUB_ENV
 
       - name: Add git hash to snapshot release
         if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v')
         run: |
-          echo CHANGELIST= >> $GITHUB_ENV
+          echo CHANGELIST=${{ env.CHANGELIST }}.${{ env. GIT_HASH_SHORT }} >> $GITHUB_ENV
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,26 +60,30 @@ jobs:
           cp -r configuration sdccc/target/zip/
           cp sdccc/target/sdccc-*.exe sdccc/target/zip/
           cp README.md sdccc/target/zip/
+
+      - name: Set zip file name for release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: montudor/action-zip@v1
+        with:
+          args: ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}-executable-win64.zip >> $GITHUB_ENV
+      - name: Set zip file name for snapshot
+        if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v')
+        uses: montudor/action-zip@v1
+        with:
+          args: ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}-${{ env.CHANGELIST }}-executable-win64.zip >> $GITHUB_ENV
+
       - name: Zip executable
         if: startsWith(github.ref, 'refs/tags/')
         uses: montudor/action-zip@v1
         with:
-          args: zip -qq -r SDCcc-${{ env.RELEASE_VERSION }}-executable-win64.zip sdccc/target/zip/
-      - name: Attach artifacts to release
+          args: zip -qq -r ${{ env.ZIP_FILE_NAME }} sdccc/target/zip/
+
+      - name: Attach artifacts to snapshot
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            SDCcc-${{ env.RELEASE_VERSION }}-executable-win64.zip
+            ${{ env.ZIP_FILE_NAME }}
             CHANGELOG.md
-          body_path: CHANGELOG.md
-      - name: Attach artifacts to snapshotrelease
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v')
-        with:
-          files: |
-            SDCcc-${{ env.RELEASE_VERSION }}-${{ env.CHANGELIST }}-executable-win64.zip
-            CHANGELOG.md
-          prerelease: true
-          name: SNAPSHOT
+          prerelease: !startsWith(github.ref, 'refs/tags/v')
           body_path: CHANGELOG.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run headless test
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: mvn verify -Dchangelist=${{ env.CHANGELIST }} -f pom.xml -Dmaven.test.skip=true
+          run: mvn verify -Dchangelist=${{ env.CHANGELIST }} -f pom.xml
           working-directory: ./ #optional
           options: #optional
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,19 +58,15 @@ jobs:
           cp README.md sdccc/target/zip/
 
       - name: Set zip file name for release
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          echo ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}-executable-win64.zip >> $GITHUB_ENV
-      - name: Set zip file name for snapshot
         if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v')
         run: |
-          echo ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}-${{ env.CHANGELIST }}-executable-win64.zip >> $GITHUB_ENV
+          echo ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}${{ env.CHANGELIST }}-executable-win64.zip >> $GITHUB_ENV
 
       - name: Zip executable
         if: startsWith(github.ref, 'refs/tags/')
         uses: montudor/action-zip@v1
         with:
-          args: zip -qq -r -j ${{ env.ZIP_FILE_NAME }} sdccc/target/zip/
+          args: zip -qq -r ${{ env.ZIP_FILE_NAME }} sdccc/target/zip/
 
       - name: Attach artifacts to snapshot
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,28 @@ on:
   pull_request: # Apply to all pull requests
   push: # Apply to all branches
 
+envs:
+  CHANGELIST: -SNAPSHOT
+  RELEASE_VERSION: 0.0.0
+
 jobs:
   test-java-snapshot:
     runs-on: ubuntu-latest
     steps:
       # Run `git checkout`
       - uses: actions/checkout@v3
+      - name: Retrieve current version from pm
+        run: |
+          echo RELEASE_VERSION=$(cat pom.xml | grep -o -P '(?<=revision\>).*(?=\<\/revision)') >> $GITHUB_ENV
+          echo "Release version is $RELEASE_VERSION"
+      - name: Remove SNAPSHOT suffix for release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo CHANGELIST= >> $GITHUB_ENV
+      - name: Remove SNAPSHOT suffix for release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo CHANGELIST= >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -18,7 +34,7 @@ jobs:
       - name: Run headless test
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: mvn verify -Dchangelist=-SNAPSHOT -f pom.xml
+          run: mvn verify -Dchangelist=${{ env.CHANGELIST }} -f pom.xml -Dmaven.test.skip=true
           working-directory: ./ #optional
           options: #optional
         env:
@@ -31,10 +47,10 @@ jobs:
           key: jre-cache
       - name: Build package and download license information
         run: |
-          mvn package license:download-licenses -Dchangelist=-SNAPSHOT -DskipTests=true -f pom.xml -Pexecutable
+          mvn package license:download-licenses -Dchangelist=${{ env.CHANGELIST }} -DskipTests=true -f pom.xml -Pexecutable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Zip
+      - name: Collect executable artifacts
         run: |
           mkdir sdccc/target/zip
           cp -r sdccc/target/lib sdccc/target/zip/
@@ -44,3 +60,15 @@ jobs:
           cp -r configuration sdccc/target/zip/
           cp sdccc/target/sdccc-*.exe sdccc/target/zip/
           cp README.md sdccc/target/zip/
+      - name: Zip executable
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: montudor/action-zip@v1
+        with:
+          args: zip -qq -r SDCcc-${{ env.RELEASE_VERSION }}-executable-win64.zip sdccc/target/zip/
+      - name: Attach artifacts to release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            SDCcc-${{ env.RELEASE_VERSION }}-executable-win64.zip
+            CHANGELOG.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           cp README.md sdccc/target/zip/
 
       - name: Set zip file name for release
-        if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           echo ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}${{ env.CHANGELIST }}-executable-win64.zip >> $GITHUB_ENV
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,19 +14,29 @@ jobs:
     steps:
       # Run `git checkout`
       - uses: actions/checkout@v3
-      - name: Retrieve current version from pm
+
+      - name: Retrieve current version from pom
         run: |
           echo RELEASE_VERSION=$(cat pom.xml | grep -o -P '(?<=revision\>).*(?=\<\/revision)') >> $GITHUB_ENV
           echo "Release version is $RELEASE_VERSION"
+          echo GIT_HASH_SHORT=$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_ENV
+
       - name: Remove SNAPSHOT suffix for release
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
+          echo CHANGELIST=${{ env.CHANGELIST }}.${{ env. GIT_HASH_SHORT }} >> $GITHUB_ENV
+
+      - name: Add git hash to snapshot release
+        if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v')
+        run: |
           echo CHANGELIST= >> $GITHUB_ENV
+
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'temurin'
+
       - name: Run headless test
         uses: GabrielBB/xvfb-action@v1
         with:
@@ -41,11 +51,13 @@ jobs:
         with:
           path: sdccc/target/jre
           key: jre-cache
+
       - name: Build package and download license information
         run: |
           mvn package license:download-licenses -Dchangelist=${{ env.CHANGELIST }} -DskipTests=true -f pom.xml -Pexecutable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Collect executable artifacts
         run: |
           mkdir sdccc/target/zip
@@ -66,12 +78,12 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: montudor/action-zip@v1
 
-
       - name: Zip executable
         if: startsWith(github.ref, 'refs/tags/')
         working-directory: sdccc/target/zip
         run: |
           zip -qq -r ${{ env.ZIP_FILE_NAME }} .
+
       - name: Attach artifacts to snapshot
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,18 +62,22 @@ jobs:
         run: |
           echo ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}${{ env.CHANGELIST }}-executable-win64.zip >> $GITHUB_ENV
 
-      - name: Zip executable
+      - name: Install zip
         if: startsWith(github.ref, 'refs/tags/')
         uses: montudor/action-zip@v1
-        with:
-          args: zip -qq -r ${{ env.ZIP_FILE_NAME }} sdccc/target/zip/
 
+
+      - name: Zip executable
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: sdccc/target/zip
+        run: |
+          zip -qq -r ${{ env.ZIP_FILE_NAME }} .
       - name: Attach artifacts to snapshot
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             CHANGELOG.md
-            ${{ env.ZIP_FILE_NAME }}
+            sdccc/target/zip/${{ env.ZIP_FILE_NAME }}
           prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
           body_path: CHANGELOG.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request: # Apply to all pull requests
   push: # Apply to all branches
 
-envs:
+env:
   CHANGELIST: -SNAPSHOT
   RELEASE_VERSION: 0.0.0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: montudor/action-zip@v1
         with:
-          args: zip -qq -r ${{ env.ZIP_FILE_NAME }} sdccc/target/zip/
+          args: zip -qq -r -j ${{ env.ZIP_FILE_NAME }} sdccc/target/zip/
 
       - name: Attach artifacts to snapshot
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           echo CHANGELIST= >> $GITHUB_ENV
-      - name: Remove SNAPSHOT suffix for release
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          echo CHANGELIST= >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -63,14 +59,12 @@ jobs:
 
       - name: Set zip file name for release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: montudor/action-zip@v1
-        with:
-          args: ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}-executable-win64.zip >> $GITHUB_ENV
+        run: |
+          echo ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}-executable-win64.zip >> $GITHUB_ENV
       - name: Set zip file name for snapshot
         if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v')
-        uses: montudor/action-zip@v1
-        with:
-          args: ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}-${{ env.CHANGELIST }}-executable-win64.zip >> $GITHUB_ENV
+        run: |
+          echo ZIP_FILE_NAME=SDCcc-${{ env.RELEASE_VERSION }}-${{ env.CHANGELIST }}-executable-win64.zip >> $GITHUB_ENV
 
       - name: Zip executable
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Extends the Github Workflow to autmatically deploy executables for pushed tags. Tags starting with "v" are considered to be proper releases, e.g. "v2.4.1", and will be marked as such in the releases, while all other tags will be considered pre-releases.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
