### PR TITLE
Add missing permission to release deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   test-java-snapshot:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       # Run `git checkout`
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   test-java-snapshot:
     runs-on: ubuntu-latest
     permissions:
-      packages: write
+      contents: write
     steps:
       # Run `git checkout`
       - uses: actions/checkout@v3


### PR DESCRIPTION
The permissions to add releases was missing from the release publishing in github actions, added it.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
