### PR TITLE
Added test case for biceps 5-4-7_14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - references to standards to test_configuration.toml
 - Java 17 support
 - test for biceps:5-4-7_12_0
+- test for biceps:5-4-7_14
 
 ### Fixed
 - missing request bodies in glue:R0036 test

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The test tool has the following limitations. If the DUT falls under these limita
 | 5-4-7_8         | SetComponentActivation, SetMetricStatus                     |
 | 5-4-7_10        | SetComponentActivation, SetMetricStatus                     |
 | 5-4-7_12_0      | SetComponentActivation, SetMetricStatus                     |
+| 5-4-7_14        | SetComponentActivation, SetMetricStatus                     |
 
 [MDPWS]
 

--- a/configuration/test_configuration.toml
+++ b/configuration/test_configuration.toml
@@ -61,6 +61,7 @@ C-62=true
 5-4-7_8=true
 5-4-7_10=true
 5-4-7_12_0=true
+5-4-7_14=true
 
 [DPWS]         # OASIS DPWS 1.1 - http://docs.oasis-open.org/ws-dd/dpws/wsdd-dpws-1.1-spec.html
 R0001=true

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
@@ -71,6 +71,7 @@ public final class EnabledTestConfig {
     public static final String BICEPS_547_8 = BICEPS + "5-4-7_8";
     public static final String BICEPS_547_10 = BICEPS + "5-4-7_10";
     public static final String BICEPS_547_12_0 = BICEPS + "5-4-7_12_0";
+    public static final String BICEPS_547_14 = BICEPS + "5-4-7_14";
 
     // MDPWS
     private static final String MDPWS = "MDPWS.";

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -1167,4 +1167,31 @@ public class ManipulationPreconditions {
         }
     }
 
+    /**
+     * Sets the activation state for every metric with category 'Clc' to 'On' and then the status to 'calculation
+     * initialized, but is not being performed' to trigger an activation state change to 'StndBy'.
+     */
+    public static class MetricStatusManipulationCLCActivationStateSTNDBY extends ManipulationPrecondition {
+
+        private static final Logger LOG = LogManager.getLogger(
+            MetricStatusManipulationCLCActivationStateSTNDBY.class);
+
+        /**
+         * Creates a metric status precondition.
+         */
+        public MetricStatusManipulationCLCActivationStateSTNDBY() {
+            super(MetricStatusManipulationCLCActivationStateSTNDBY::manipulation);
+        }
+
+        /**
+         * @return true if successful, false otherwise
+         */
+        static boolean manipulation(final Injector injector) {
+            final var metricCategory = MetricCategory.CLC;
+            final var activationState = ComponentActivation.STND_BY;
+            final var startingActivationState = ComponentActivation.ON;
+            return manipulateMetricStatus(injector, LOG, metricCategory, activationState, startingActivationState);
+        }
+    }
+
 }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
@@ -179,6 +179,21 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
         testRequirement547(metricCategory, activationState);
     }
 
+    @Test
+    @DisplayName("If pm:AbstractMetricDescriptor/@MetricCategory = Clc and the calculation for the METRIC has been"
+        + " initialized, but is not being performed, the SERVICE PROVIDER SHALL set"
+        + " pm:AbstractMetricState/@ActivationState = StndBy.")
+    @TestIdentifier(EnabledTestConfig.BICEPS_547_14)
+    @TestDescription("For each metric with the category CLC, the device is manipulated to perform calculations and"
+        + " then it is verified that the ActivationState of the metric is set to StndBy.")
+    @RequirePrecondition(manipulationPreconditions =
+        {ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.class})
+    void testRequirement54714() throws NoTestData {
+        final var metricCategory = MetricCategory.CLC;
+        final var activationState = ComponentActivation.STND_BY;
+        testRequirement547(metricCategory, activationState);
+    }
+
     private void testRequirement547(final MetricCategory category, final ComponentActivation activation)
         throws NoTestData {
         final var successfulReportsSeen = new AtomicBoolean(false);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
@@ -2175,6 +2175,291 @@ public class InvariantParticipantModelStatePartTestTest {
         assertThrows(AssertionError.class, testClass::testRequirement547120);
     }
 
+    /**
+     * Tests whether no test data fails the test.
+     */
+    @Test
+    public void testRequirement54714NoTestData() {
+        assertThrows(NoTestData.class, testClass::testRequirement54714);
+    }
+
+    /**
+     * Tests whether the test fails when no manipulation data with ResponseTypes.Result.RESULT_SUCCESS is in storage.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54714NoSuccessfulManipulation() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.STND_BY.value()));
+        // add manipulation data with result fail
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, ResponseTypes.Result.RESULT_FAIL,
+            Constants.MANIPULATION_NAME_SET_METRIC_STATUS, parameters);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.STND_BY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(NoTestData.class, testClass::testRequirement54714);
+        assertTrue(error.getMessage().contains(InvariantParticipantModelStatePartTest.NO_SUCCESSFUL_MANIPULATION));
+    }
+
+    /**
+     * Test whether the test fails, when no manipulation data with category 'Clc' is in storage.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54714BadWrongMetricCategory() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.STND_BY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.STND_BY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        // no manipulation with category clc in storage
+        final var error = assertThrows(NoTestData.class, testClass::testRequirement54714);
+        assertTrue(error.getMessage().contains(
+            String.format(InvariantParticipantModelStatePartTest.NO_SET_METRIC_STATUS_MANIPULATION,
+                MetricCategory.CLC)));
+    }
+
+    /**
+     * Tests whether the test passes, when for each manipulation data for 'setMetricStatus' manipulations and metrics
+     * with category 'Clc' a metric report containing the manipulated metric with the expected activation state exists
+     * and is in the time interval of the manipulation data.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54714Good() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.STND_BY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result,
+            Constants.MANIPULATION_NAME_SET_METRIC_STATUS, parameters);
+
+        final var unrelatedPart = buildMetricReportPart(BigInteger.ONE, SET_METRIC_HANDLE, ComponentActivation.STND_BY);
+        final var relatedPart = buildMetricReportPart(BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.STND_BY);
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            unrelatedPart, relatedPart);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        testClass.testRequirement54714();
+    }
+
+    /**
+     * Tests whether the test correctly retrieves the first relevant report in the time interval for each manipulation
+     * data with category 'Clc'.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54714GoodOverlappingTimeInterval() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.STND_BY.value()));
+
+        final List<Pair<String, String>> parameters2 = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE2),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.STND_BY.value()));
+
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH,
+            ResponseTypes.Result.RESULT_SUCCESS, Constants.MANIPULATION_NAME_SET_METRIC_STATUS, parameters2);
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START2, TIMESTAMP_FINISH2,
+            ResponseTypes.Result.RESULT_SUCCESS, Constants.MANIPULATION_NAME_SET_METRIC_STATUS, parameters);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.STND_BY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+        final var metricReport2 = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE2, ComponentActivation.STND_BY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL2, metricReport2));
+
+        testClass.testRequirement54714();
+    }
+
+    /**
+     * Tests whether the test fails, when no metric report is present in the time interval of a manipulation data.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54714BadNoMetricReportFollowingManipulation() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.STND_BY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        // this metric report is not in the time interval of the setMetricStatus manipulation
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.STND_BY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_NOT_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(AssertionError.class, testClass::testRequirement54714);
+        assertTrue(error.getCause() instanceof NoTestData);
+        assertTrue(error.getCause().getMessage().contains(String.format(InvariantParticipantModelStatePartTest
+            .NO_REPORT_IN_TIME_INTERVAL, methodName, TIMESTAMP_START, TIMESTAMP_FINISH)));
+    }
+
+    /**
+     * Tests whether the test fails, when no reports with the expected handle from the manipulation data are in storage.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54714NoReportsWithExpectedHandle() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.STND_BY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result,
+            Constants.MANIPULATION_NAME_SET_METRIC_STATUS, parameters);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE2, ComponentActivation.STND_BY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(AssertionError.class, testClass::testRequirement54714);
+        assertTrue(error.getMessage().contains(
+            String.format(InvariantParticipantModelStatePartTest.NO_REPORT_WITH_EXPECTED_HANDLE, CLC_METRIC_HANDLE)));
+    }
+
+    /**
+     * Tests whether the test fails, when the metric from the manipulation data has the wrong activation state in the
+     * following metric report.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54714BadWrongActivationInFollowingReport() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.STND_BY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        // activation state should be stndby
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.OFF);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(AssertionError.class, testClass::testRequirement54714);
+        assertTrue(error.getMessage().contains(String.format(
+            InvariantParticipantModelStatePartTest.WRONG_ACTIVATION_STATE, CLC_METRIC_HANDLE,
+            ComponentActivation.STND_BY, ComponentActivation.OFF)));
+    }
+
+    /**
+     * Tests whether the test retrieves the first metric report in the time interval of a manipulation data.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54714GoodMultipleReportsInInterval() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.STND_BY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        // good report in time interval
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.STND_BY);
+        // should not fail the test, since the first report in the time interval is relevant for the test
+        final var metricReport2 = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.OFF);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL2, metricReport2));
+
+        testClass.testRequirement54714();
+    }
+
+    /**
+     * Tests whether the test do not pass when the first report in the time interval is bad, even if followed by a
+     * report that would pass the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54714BadMultipleReportsInInterval() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.STND_BY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.STND_BY);
+        final var metricReport2 = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.OFF);
+
+        // the first report in the time interval has the wrong activation state
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport2));
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL2, metricReport));
+
+        assertThrows(AssertionError.class, testClass::testRequirement54714);
+    }
+
     private Message buildTestMessage(final long timestamp, final Envelope envelope) throws Exception {
         final var message = mock(Message.class);
         when(message.getDirection()).thenReturn(CommunicationLog.Direction.INBOUND);


### PR DESCRIPTION
Implemented a test for biceps 5-4-7_14.
Added a precondition to set the status of metrics with category 'clc' to 'calculation initialized, but is not being performed'.
Added unit tests for biceps 5-4-7_14 

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
