### PR TITLE
Feature/test biceps5 4 7 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - references to standards to test_configuration.toml
 - Java 17 support
 - test for biceps:5-4-7_12_0
+- test for biceps:5-4-7_16
 
 ### Fixed
 - missing request bodies in glue:R0036 test

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The test tool has the following limitations. If the DUT falls under these limita
 | 5-4-7_8         | SetComponentActivation, SetMetricStatus                     |
 | 5-4-7_10        | SetComponentActivation, SetMetricStatus                     |
 | 5-4-7_12_0      | SetComponentActivation, SetMetricStatus                     |
+| 5-4-7_16        | SetComponentActivation, SetMetricStatus                     |
 
 [MDPWS]
 

--- a/configuration/test_configuration.toml
+++ b/configuration/test_configuration.toml
@@ -61,6 +61,7 @@ C-62=true
 5-4-7_8=true
 5-4-7_10=true
 5-4-7_12_0=true
+5-4-7_16=true
 
 [DPWS]         # OASIS DPWS 1.1 - http://docs.oasis-open.org/ws-dd/dpws/wsdd-dpws-1.1-spec.html
 R0001=true

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
@@ -71,6 +71,7 @@ public final class EnabledTestConfig {
     public static final String BICEPS_547_8 = BICEPS + "5-4-7_8";
     public static final String BICEPS_547_10 = BICEPS + "5-4-7_10";
     public static final String BICEPS_547_12_0 = BICEPS + "5-4-7_12_0";
+    public static final String BICEPS_547_16 = BICEPS + "5-4-7_16";
 
     // MDPWS
     private static final String MDPWS = "MDPWS.";

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -1167,4 +1167,29 @@ public class ManipulationPreconditions {
         }
     }
 
+    /**
+     * Sets the activation state for every metric with category 'Clc' to 'On' and then the status to 'calculation
+     * not being performed and is de-initialized,' to trigger an activation state change to 'Off'.
+     */
+    public static class MetricStatusManipulationCLCActivationStateOFF extends ManipulationPrecondition {
+
+        private static final Logger LOG = LogManager.getLogger(MetricStatusManipulationCLCActivationStateOFF.class);
+
+        /**
+         * Creates a metric status precondition.
+         */
+        public MetricStatusManipulationCLCActivationStateOFF() {
+            super(MetricStatusManipulationCLCActivationStateOFF::manipulation);
+        }
+
+        /**
+         * @return true if successful, false otherwise
+         */
+        static boolean manipulation(final Injector injector) {
+            final var metricCategory = MetricCategory.CLC;
+            final var activationState = ComponentActivation.OFF;
+            final var startingActivationState = ComponentActivation.ON;
+            return manipulateMetricStatus(injector, LOG, metricCategory, activationState, startingActivationState);
+        }
+    }
 }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -1196,7 +1196,7 @@ public class ManipulationPreconditions {
 
     /**
      * Sets the activation state for every metric with category 'Clc' to 'On' and then the status to 'calculation
-     * not being performed and is de-initialized,' to trigger an activation state change to 'Off'.
+     * not being performed and is de-initialized' to trigger an activation state change to 'Off'.
      */
     public static class MetricStatusManipulationCLCActivationStateOFF extends ManipulationPrecondition {
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
@@ -179,6 +179,22 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
         testRequirement547(metricCategory, activationState);
     }
 
+    @Test
+    @DisplayName("If pm:AbstractMetricDescriptor/@MetricCategory = Clc and the calculation for the METRIC is not being"
+        + " performed and is de-initialized, the SERVICE PROVIDER SHALL set pm:AbstractMetricState/@ActivationState"
+        + " = Off.")
+    @TestIdentifier(EnabledTestConfig.BICEPS_547_16)
+    @TestDescription("For each metric with the category CLC, the device is manipulated so that the calculation of"
+        + " the metric is de-initialized and no calculation is performed and then it is verified that the"
+        + " ActivationState of the metric is set to Off.")
+    @RequirePrecondition(manipulationPreconditions =
+        {ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.class})
+    void testRequirement54716() throws NoTestData {
+        final var metricCategory = MetricCategory.CLC;
+        final var activationState = ComponentActivation.OFF;
+        testRequirement547(metricCategory, activationState);
+    }
+
     private void testRequirement547(final MetricCategory category, final ComponentActivation activation)
         throws NoTestData {
         final var successfulReportsSeen = new AtomicBoolean(false);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
@@ -2175,6 +2175,293 @@ public class InvariantParticipantModelStatePartTestTest {
         assertThrows(AssertionError.class, testClass::testRequirement547120);
     }
 
+    /**
+     * Tests whether no test data fails the test.
+     */
+    @Test
+    public void testRequirement54716NoTestData() {
+        assertThrows(NoTestData.class, testClass::testRequirement54716);
+    }
+
+    /**
+     * Tests whether the test fails when no manipulation data with ResponseTypes.Result.RESULT_SUCCESS is in storage.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54716NoSuccessfulManipulation() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.OFF.value()));
+        // add manipulation data with result fail
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, ResponseTypes.Result.RESULT_FAIL,
+            Constants.MANIPULATION_NAME_SET_METRIC_STATUS, parameters);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.OFF);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(NoTestData.class, testClass::testRequirement54716);
+        assertTrue(error.getMessage().contains(InvariantParticipantModelStatePartTest.NO_SUCCESSFUL_MANIPULATION));
+    }
+
+    /**
+     * Test whether the test fails, when no manipulation data with category 'Clc' is in storage.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54716BadWrongMetricCategory() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.OFF.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.OFF);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        // no manipulation with category clc in storage
+        final var error = assertThrows(NoTestData.class, testClass::testRequirement54716);
+        assertTrue(error.getMessage().contains(
+            String.format(InvariantParticipantModelStatePartTest.NO_SET_METRIC_STATUS_MANIPULATION,
+                MetricCategory.CLC)));
+    }
+
+    /**
+     * Tests whether the test passes, when for each manipulation data for 'setMetricStatus' manipulations and metrics
+     * with category 'Clc' a metric report containing the manipulated metric with the expected activation state exists
+     * and is in the time interval of the manipulation data.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54716Good() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.OFF.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result,
+            Constants.MANIPULATION_NAME_SET_METRIC_STATUS, parameters);
+
+        final var relatedPart = buildMetricReportPart(BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.OFF);
+        final var unrelatedPart = buildMetricReportPart(BigInteger.ONE, CLC_METRIC_HANDLE2, ComponentActivation.OFF);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            relatedPart, unrelatedPart);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        testClass.testRequirement54716();
+    }
+
+    /**
+     * Tests whether the test correctly retrieves the first relevant report in the time interval for each manipulation
+     * data with category 'Clc'.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54716GoodOverlappingTimeInterval() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.OFF.value()));
+
+        final List<Pair<String, String>> parameters2 = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE2),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.OFF.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH,
+            ResponseTypes.Result.RESULT_SUCCESS, Constants.MANIPULATION_NAME_SET_METRIC_STATUS, parameters2);
+
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START2, TIMESTAMP_FINISH2,
+            ResponseTypes.Result.RESULT_SUCCESS, Constants.MANIPULATION_NAME_SET_METRIC_STATUS, parameters);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.OFF);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+        final var metricReport2 = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE2, ComponentActivation.OFF);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL2, metricReport2));
+
+        testClass.testRequirement54716();
+    }
+
+    /**
+     * Tests whether the test fails, when no metric report is present in the time interval of a manipulation data.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54716BadNoMetricReportFollowingManipulation() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.OFF.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        // this metric report is not in the time interval of the setMetricStatus manipulation
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.OFF);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_NOT_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(AssertionError.class, testClass::testRequirement54716);
+        assertTrue(error.getCause() instanceof NoTestData);
+        assertTrue(error.getCause().getMessage().contains(String.format(
+            InvariantParticipantModelStatePartTest.NO_REPORT_IN_TIME_INTERVAL, methodName, TIMESTAMP_START,
+            TIMESTAMP_FINISH)));
+    }
+
+    /**
+     * Tests whether the test fails, when no reports with the expected handle from the manipulation data are in storage.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54716NoReportsWithExpectedHandle() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.OFF.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result,
+            Constants.MANIPULATION_NAME_SET_METRIC_STATUS, parameters);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE2, ComponentActivation.OFF);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(AssertionError.class, testClass::testRequirement54716);
+        assertTrue(error.getMessage().contains(
+            String.format(InvariantParticipantModelStatePartTest.NO_REPORT_WITH_EXPECTED_HANDLE, CLC_METRIC_HANDLE)));
+    }
+
+    /**
+     * Tests whether the test fails, when the metric from the manipulation data has the wrong activation state in the
+     * following metric report.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54716BadWrongActivationInFollowingReport() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.OFF.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        // activation state should be OFF
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.ON);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(AssertionError.class, testClass::testRequirement54716);
+        assertTrue(error.getMessage().contains(String.format(
+            InvariantParticipantModelStatePartTest.WRONG_ACTIVATION_STATE, CLC_METRIC_HANDLE,
+            ComponentActivation.OFF, ComponentActivation.ON)));
+    }
+
+    /**
+     * Tests whether the test retrieves the first metric report in the time interval of a manipulation data.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54716GoodMultipleReportsInInterval() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.OFF.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        // good report in time interval
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.OFF);
+        // should not fail the test, since the first report in the time interval is relevant for the test
+        final var metricReport2 = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.ON);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL2, metricReport2));
+
+        testClass.testRequirement54716();
+    }
+
+    /**
+     * Tests whether the test do not pass when the first report in the time interval is bad, even if followed by a
+     * report that would pass the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement54716BadMultipleReportsInInterval() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
+            new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
+                ComponentActivation.OFF.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.OFF);
+        final var metricReport2 = buildMetricReport(SEQUENCE_ID, BigInteger.ONE,
+            BigInteger.ONE, CLC_METRIC_HANDLE, ComponentActivation.ON);
+
+        // the first report in the time interval has the wrong activation state
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport2));
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL2, metricReport));
+
+        assertThrows(AssertionError.class, testClass::testRequirement54716);
+    }
+
     private Message buildTestMessage(final long timestamp, final Envelope envelope) throws Exception {
         final var message = mock(Message.class);
         when(message.getDirection()).thenReturn(CommunicationLog.Direction.INBOUND);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
@@ -71,7 +71,6 @@ public class InvariantParticipantModelStatePartTestTest {
     private static final String CHANNEL_HANDLE = "someChannel";
     private static final String MSRMT_METRIC_HANDLE = "someMsrmtStringMetric";
     private static final String MSRMT_METRIC_HANDLE2 = "someMsrmtStringMetric2";
-
     private static final String RTSA_METRIC_HANDLE = "someRealTimeSampleArrayMetric";
     private static final String RTSA_METRIC_HANDLE2 = "someRealTimeSampleArrayMetric2";
     private static final String SET_METRIC_HANDLE = "someSetStringMetric";


### PR DESCRIPTION
Implemented a test for biceps 5-4-7_16.
Added a precondition to set the status of metrics with category 'clc' to 'calculation not being performed and is de-initialized'.
Added unit tests for biceps 5-4-7_16

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
