### PR TITLE
A SOAPFault with a 413 status code is an acceptable answer for a GetLocalizedText Request

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/util/MessageGeneratingUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/util/MessageGeneratingUtil.java
@@ -497,12 +497,25 @@ public class MessageGeneratingUtil {
             service.sendRequestResponse(message);
         } catch (final TransportException e) {
             if (e.getCause() != null && e.getCause() instanceof HttpException) {
-                LOG.debug("TransportException with HttpException cause");
                 if (((HttpException) e.getCause()).getStatusCode() == Constants.HTTP_PAYLOAD_TOO_LARGE) {
                     LOG.debug(
                             "TransportException with HttpException cause and {} status code",
                             Constants.HTTP_PAYLOAD_TOO_LARGE);
                     return;
+                } else {
+                    LOG.debug("TransportException with HttpException cause");
+                }
+            }
+            throw e;
+        } catch (final SoapFaultException e) {
+            if (e.getCause() != null && e.getCause() instanceof HttpException) {
+                if (((HttpException) e.getCause()).getStatusCode() == Constants.HTTP_PAYLOAD_TOO_LARGE) {
+                    LOG.debug(
+                        "TransportException with HttpException cause and {} status code",
+                        Constants.HTTP_PAYLOAD_TOO_LARGE);
+                    return;
+                } else {
+                    LOG.debug("SoapFaultException with HttpException cause");
                 }
             }
             throw e;


### PR DESCRIPTION
The current implementation expects a TransportException, but S31 answers with a SOAPFault, which causes a SOAPFaultException instead. Since the body of the message is irrelevant, the answer from S31 should also be acceptable and not fail the BasicMessagingCheck.


// Describe the purpose of the pull request here and remove this line. Keep the checklist.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
