### PR TITLE
Add limitation to readme about not supporting MDPWS safe data transmission

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The test tool has the following limitations. If the DUT falls under these limita
 | The SDCcc tool does not support the following HTTP Headers in test cases which use messages stored in the database: <ul><li>transfer-encoding</li><li>content-length</li><li>content-encoding</li><li>content-type: multipart/related</li></ul> |
 | The ArchiveService is not supported and will be ignored by the test tool.                                                                                                                                                                       |
 | SDCcc only supports decoding messages encoded in UTF-8.                                                                                                                                                                                         |
+| Safe data transmission (MDPWS Ch. 9) is not supported                                                                                                                                                                                           |
 
 [MDPWS]
 


### PR DESCRIPTION
Add a new limitation to the README.md that MDPWS safe data transmission is not supported by the tool.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
