### PR TITLE
Feature/test biceps5 4 7 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- test for biceps:5-4-7_1
+
 ## [6.0.0] - 2022-12-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The test tool has the following limitations. If the DUT falls under these limita
 | R5051           | GetRemovableDescriptors, RemoveDescriptor, InsertDescriptor |
 | R5052           | TriggerDescriptorUpdate                                     |
 | 5-4-7_0_0       | SetComponentActivation, SetMetricStatus                     |
+| 5-4-7_1         | SetComponentActivation, SetMetricStatus                     |
 | 5-4-7_2         | SetComponentActivation, SetMetricStatus                     |
 | 5-4-7_4         | SetComponentActivation, SetMetricStatus                     |
 | 5-4-7_6_0       | SetComponentActivation, SetMetricStatus                     |

--- a/configuration/test_configuration.toml
+++ b/configuration/test_configuration.toml
@@ -56,6 +56,7 @@ R5042=true
 R5051=false
 R5052=true
 5-4-7_0_0=true
+5-4-7_1=true
 5-4-7_2=true
 5-4-7_4=true
 5-4-7_6_0=true

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
@@ -66,6 +66,7 @@ public final class EnabledTestConfig {
     public static final String BICEPS_R5052 = BICEPS + "R5052";
 
     public static final String BICEPS_547_0_0 = BICEPS + "5-4-7_0_0";
+    public static final String BICEPS_547_1 = BICEPS + "5-4-7_1";
     public static final String BICEPS_547_2 = BICEPS + "5-4-7_2";
     public static final String BICEPS_547_4 = BICEPS + "5-4-7_4";
     public static final String BICEPS_547_6_0 = BICEPS + "5-4-7_6_0";

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -998,6 +998,33 @@ public class ManipulationPreconditions {
     }
 
     /**
+     * Sets the activation state for every metric with category 'Msrmt' to 'Off' and then the status to 'measurement is
+     * currently initializing' to trigger an activation state change to 'NotRdy'.
+     */
+    public static class MetricStatusManipulationMSRMTActivationStateNOTRDY extends ManipulationPrecondition {
+
+        private static final Logger LOG =
+                LogManager.getLogger(MetricStatusManipulationMSRMTActivationStateNOTRDY.class);
+
+        /**
+         * Creates a metric status precondition.
+         */
+        public MetricStatusManipulationMSRMTActivationStateNOTRDY() {
+            super(MetricStatusManipulationMSRMTActivationStateNOTRDY::manipulation);
+        }
+
+        /**
+         * @return true if successful, false otherwise
+         */
+        static boolean manipulation(final Injector injector) {
+            final var metricCategory = MetricCategory.MSRMT;
+            final var activationState = ComponentActivation.NOT_RDY;
+            final var startingActivationState = ComponentActivation.OFF;
+            return manipulateMetricStatus(injector, LOG, metricCategory, activationState, startingActivationState);
+        }
+    }
+
+    /**
      * Sets the activation state for every metric with category 'Msrmt' to 'On' and then the status to 'measurement
      * initialized, but is not being performed' to trigger an activation state change to 'StndBy'.
      */

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
@@ -90,6 +90,23 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
     }
 
     @Test
+    @DisplayName(
+            "If pm:AbstractMetricDescriptor/@MetricCategory = Msrmt and the measurement for the METRIC  is"
+                    + " currently initializing, the SERVICE PROVIDER SHALL set pm:AbstractMetricState/@ActivationState = NotRdy.")
+    @TestIdentifier(EnabledTestConfig.BICEPS_547_1)
+    @TestDescription("For each metric with the category MSRMT, the device is manipulated to initialize measurements and"
+            + " then it is verified that the ActivationState of the metric is set to NotRdy.")
+    @RequirePrecondition(
+            manipulationPreconditions = {
+                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateNOTRDY.class
+            })
+    void testRequirement5471() throws NoTestData {
+        final var metricCategory = MetricCategory.MSRMT;
+        final var activationState = ComponentActivation.NOT_RDY;
+        testRequirement547(metricCategory, activationState);
+    }
+
+    @Test
     @DisplayName("If pm:AbstractMetricDescriptor/@MetricCategory = Msrmt and the measurement for the METRIC has been"
             + " initialized, but is not being performed, the SERVICE PROVIDER SHALL set"
             + " pm:AbstractMetricState/@ActivationState = StndBy.")

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
@@ -499,6 +499,359 @@ public class InvariantParticipantModelStatePartTestTest {
      * Tests whether no test data fails the test.
      */
     @Test
+    public void testRequirement5471NoTestData() {
+        assertThrows(NoTestData.class, testClass::testRequirement5471);
+    }
+
+    /**
+     * Tests whether the test fails when no manipulation data with ResponseTypes.Result.RESULT_SUCCESS is in storage.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement5471NoSuccessfulManipulation() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final List<Pair<String, String>> parameters = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        // add manipulation data with result fail
+        messageStorageUtil.addManipulation(
+                storage,
+                TIMESTAMP_START,
+                TIMESTAMP_FINISH,
+                ResponseTypes.Result.RESULT_FAIL,
+                Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
+                parameters);
+
+        final var metricReport = buildMetricReport(
+                SEQUENCE_ID, BigInteger.ONE, BigInteger.ONE, MSRMT_METRIC_HANDLE, ComponentActivation.NOT_RDY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(NoTestData.class, testClass::testRequirement5471);
+        assertTrue(error.getMessage().contains(InvariantParticipantModelStatePartTest.NO_SUCCESSFUL_MANIPULATION));
+    }
+
+    /**
+     * Test whether the test fails, when no manipulation data with category 'Msrmt' is in storage.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement5471BadWrongMetricCategory() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        final var metricReport = buildMetricReport(
+                SEQUENCE_ID, BigInteger.ONE, BigInteger.ONE, MSRMT_METRIC_HANDLE, ComponentActivation.NOT_RDY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        // no manipulation with category msrmt in storage
+        final var error = assertThrows(NoTestData.class, testClass::testRequirement5471);
+        assertTrue(error.getMessage()
+                .contains(String.format(
+                        InvariantParticipantModelStatePartTest.NO_SET_METRIC_STATUS_MANIPULATION,
+                        MetricCategory.MSRMT)));
+    }
+
+    /**
+     * Tests whether the test passes, when for each manipulation data for 'setMetricStatus' manipulations and metrics
+     * with category 'Msrmt' a metric report containing the manipulated metric with the expected activation state exists
+     * and is in the time interval of the manipulation data.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement5471Good() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final List<Pair<String, String>> parameters = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        messageStorageUtil.addManipulation(
+                storage,
+                TIMESTAMP_START,
+                TIMESTAMP_FINISH,
+                result,
+                Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
+                parameters);
+
+        final var relatedPart = buildMetricReportPart(BigInteger.ONE, MSRMT_METRIC_HANDLE, ComponentActivation.NOT_RDY);
+        final var unrelatedPart =
+                buildMetricReportPart(BigInteger.ONE, MSRMT_METRIC_HANDLE2, ComponentActivation.NOT_RDY);
+        final var metricReport = buildMetricReport(SEQUENCE_ID, BigInteger.ONE, relatedPart, unrelatedPart);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        testClass.testRequirement5471();
+    }
+
+    /**
+     * Tests if the test passes if for each 'setMetricStatus' manipulation for metrics with category 'Msrmt' only
+     * WaveformStream messages exist that contain the expected handle and were received within the time interval
+     * of the manipulation.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement5471GoodWaveforms() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final List<Pair<String, String>> parameters = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, RTSA_METRIC_HANDLE),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        messageStorageUtil.addManipulation(
+                storage,
+                TIMESTAMP_START,
+                TIMESTAMP_FINISH,
+                result,
+                Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
+                parameters);
+
+        final var waveformStream = buildWaveformStream(
+                SEQUENCE_ID, BigInteger.ONE, BigInteger.ONE, RTSA_METRIC_HANDLE, ComponentActivation.NOT_RDY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, waveformStream));
+
+        testClass.testRequirement5471();
+    }
+
+    /**
+     * Tests whether the test correctly retrieves the first relevant report in the time interval for each manipulation
+     * data with category 'Msrmt'.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement5471GoodOverlappingTimeInterval() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final List<Pair<String, String>> parameters = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        messageStorageUtil.addManipulation(
+                storage,
+                TIMESTAMP_START,
+                TIMESTAMP_FINISH,
+                ResponseTypes.Result.RESULT_SUCCESS,
+                Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
+                parameters);
+
+        final List<Pair<String, String>> parameters2 = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE2),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        messageStorageUtil.addManipulation(
+                storage,
+                TIMESTAMP_START2,
+                TIMESTAMP_FINISH2,
+                ResponseTypes.Result.RESULT_SUCCESS,
+                Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
+                parameters2);
+
+        final var metricReport = buildMetricReport(
+                SEQUENCE_ID, BigInteger.ONE, BigInteger.ONE, MSRMT_METRIC_HANDLE, ComponentActivation.NOT_RDY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+        final var metricReport2 = buildMetricReport(
+                SEQUENCE_ID, BigInteger.ONE, BigInteger.ONE, MSRMT_METRIC_HANDLE2, ComponentActivation.NOT_RDY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport2));
+
+        testClass.testRequirement5471();
+    }
+
+    /**
+     * Tests whether the test fails, when no metric report is present in the time interval of a manipulation data.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement5471BadNoMetricReportFollowingManipulation() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        // this metric report is not in the time interval of the setMetricStatus manipulation
+        final var metricReport = buildMetricReport(
+                SEQUENCE_ID, BigInteger.ONE, BigInteger.ONE, MSRMT_METRIC_HANDLE, ComponentActivation.NOT_RDY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_NOT_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(AssertionError.class, testClass::testRequirement5471);
+        assertTrue(error.getCause() instanceof NoTestData);
+        assertTrue(error.getCause()
+                .getMessage()
+                .contains(String.format(
+                        InvariantParticipantModelStatePartTest.NO_REPORT_IN_TIME_INTERVAL,
+                        methodName,
+                        TIMESTAMP_START,
+                        TIMESTAMP_FINISH)));
+    }
+
+    /**
+     * Tests whether the test fails, when no reports with the expected handle from the manipulation data are in storage.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement5471NoReportsWithExpectedHandle() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final List<Pair<String, String>> parameters = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        messageStorageUtil.addManipulation(
+                storage,
+                TIMESTAMP_START,
+                TIMESTAMP_FINISH,
+                result,
+                Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
+                parameters);
+
+        final var metricReport = buildMetricReport(
+                SEQUENCE_ID, BigInteger.ONE, BigInteger.ONE, MSRMT_METRIC_HANDLE2, ComponentActivation.NOT_RDY);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(AssertionError.class, testClass::testRequirement5471);
+        assertTrue(error.getMessage()
+                .contains(String.format(
+                        InvariantParticipantModelStatePartTest.NO_REPORT_WITH_EXPECTED_HANDLE, MSRMT_METRIC_HANDLE)));
+    }
+
+    /**
+     * Tests whether the test fails, when the metric from the manipulation data has the wrong activation state in the
+     * following metric report.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement5471BadWrongActivationInFollowingReport() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        // activation state should be on
+        final var metricReport = buildMetricReport(
+                SEQUENCE_ID, BigInteger.ONE, BigInteger.ONE, MSRMT_METRIC_HANDLE, ComponentActivation.OFF);
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+
+        final var error = assertThrows(AssertionError.class, testClass::testRequirement5471);
+        assertTrue(error.getMessage()
+                .contains(String.format(
+                        InvariantParticipantModelStatePartTest.WRONG_ACTIVATION_STATE,
+                        MSRMT_METRIC_HANDLE,
+                        ComponentActivation.NOT_RDY,
+                        ComponentActivation.OFF)));
+    }
+
+    /**
+     * Tests whether the test retrieves the first metric report in the time interval of a manipulation data.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement5471GoodMultipleReportsInInterval() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        // good report in time interval
+        final var metricReport = buildMetricReport(
+                SEQUENCE_ID, BigInteger.ONE, BigInteger.ONE, MSRMT_METRIC_HANDLE, ComponentActivation.NOT_RDY);
+        // should not fail the test, since the first report in the time interval is relevant for the test
+        final var metricReport2 = buildMetricReport(
+                SEQUENCE_ID, BigInteger.TWO, BigInteger.ONE, MSRMT_METRIC_HANDLE, ComponentActivation.OFF);
+
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport));
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL2, metricReport2));
+
+        testClass.testRequirement5471();
+    }
+
+    /**
+     * Tests whether the test do not pass when the first report in the time interval is bad, even if followed by a
+     * report that would pass the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirement5471BadMultipleReportsInInterval() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+
+        final var result = ResponseTypes.Result.RESULT_SUCCESS;
+        final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
+        final List<Pair<String, String>> parameters = List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
+                new ImmutablePair<>(
+                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
+
+        final var metricReport = buildMetricReport(
+                SEQUENCE_ID, BigInteger.TWO, BigInteger.ONE, MSRMT_METRIC_HANDLE, ComponentActivation.NOT_RDY);
+        final var metricReport2 = buildMetricReport(
+                SEQUENCE_ID, BigInteger.ONE, BigInteger.ONE, MSRMT_METRIC_HANDLE, ComponentActivation.OFF);
+
+        // the first report in the time interval has the wrong activation state
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL, metricReport2));
+        messageStorageUtil.addMessage(storage, buildTestMessage(TIMESTAMP_IN_INTERVAL2, metricReport));
+
+        assertThrows(AssertionError.class, testClass::testRequirement5471);
+    }
+
+    /**
+     * Tests whether no test data fails the test.
+     */
+    @Test
     public void testRequirement5472NoTestData() {
         assertThrows(NoTestData.class, testClass::testRequirement5472);
     }


### PR DESCRIPTION
Implemented a test for biceps 5-4-7_1.
Added a precondition to set the status of metrics with category 'msrmt' to 'measurement currently initializing'.
Added unit tests for biceps 5-4-7_1

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
