### PR TITLE
Configure surefire plugin to use a max. HEAP size of 3072MB.

### DIFF
--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -325,7 +325,7 @@
                     </excludes>
                     <!-- workaround for bug in the attach api required for certain JDK builds -->
                     <!-- see also: https://stackoverflow.com/a/25439003 -->
-                    <argLine>-Xmx2048m -XX:+StartAttachListener</argLine>
+                    <argLine>-Xmx3072m -XX:+StartAttachListener</argLine>
                 </configuration>
             </plugin>
 

--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -325,7 +325,7 @@
                     </excludes>
                     <!-- workaround for bug in the attach api required for certain JDK builds -->
                     <!-- see also: https://stackoverflow.com/a/25439003 -->
-                    <argLine>-XX:+StartAttachListener</argLine>
+                    <argLine>-Xmx2048m -XX:+StartAttachListener</argLine>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
The purpose of this PR is to fix the build problems we are currently experiencing across all our branches.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
