### PR TITLE
Test for BICEPS R5053

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - test for biceps:5-4-7_13
 - support for SystemErrorReport to test case glue:R0036_0
 - test for biceps:5-4-7_15
+- test for biceps:R5053
 
 ### Fixed
 - dpws:R0013 sent a request that was not WS-Transfer compliant

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ The test tool has the following limitations. If the DUT falls under these limita
 | C-15            | TriggerReport                                               |
 | R5051           | GetRemovableDescriptors, RemoveDescriptor, InsertDescriptor |
 | R5052           | TriggerDescriptorUpdate                                     |
+| R5053           | GetRemovableDescriptors, RemoveDescriptor, InsertDescriptor |
 | 5-4-7_0_0       | SetComponentActivation, SetMetricStatus                     |
 | 5-4-7_1         | SetComponentActivation, SetMetricStatus                     |
 | 5-4-7_2         | SetComponentActivation, SetMetricStatus                     |

--- a/configuration/test_configuration.toml
+++ b/configuration/test_configuration.toml
@@ -55,6 +55,7 @@ R5041=true
 R5042=true
 R5051=false
 R5052=true
+R5053=true
 5-4-7_0_0=true
 5-4-7_1=true
 5-4-7_2=true

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
@@ -64,6 +64,7 @@ public final class EnabledTestConfig {
     public static final String BICEPS_R5042 = BICEPS + "R5042";
     public static final String BICEPS_R5051 = BICEPS + "R5051";
     public static final String BICEPS_R5052 = BICEPS + "R5052";
+    public static final String BICEPS_R5053 = BICEPS + "R5053";
 
     public static final String BICEPS_547_0_0 = BICEPS + "5-4-7_0_0";
     public static final String BICEPS_547_1 = BICEPS + "5-4-7_1";

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
@@ -317,6 +317,39 @@ public class ConditionalPreconditions {
     }
 
     /**
+     * Precondition that checks whether DescriptionModificationReport messages containing a deletion have been
+     * received, triggering description modifications otherwise.
+     */
+    public static class DescriptionModificationDelPrecondition extends SimplePrecondition {
+
+        private static final Logger LOG = LogManager.getLogger(DescriptionModificationDelPrecondition.class);
+
+        /**
+         * Creates a description modification del precondition check.
+         */
+        public DescriptionModificationDelPrecondition() {
+            super(
+                    DescriptionModificationDelPrecondition::preconditionCheck,
+                    DescriptionModificationDelPrecondition::manipulation);
+        }
+
+        static boolean preconditionCheck(final Injector injector) throws PreconditionException {
+            return descriptionModificationPreconditionCheck(injector, DescriptionModificationType.DEL);
+        }
+
+        /**
+         * Performs the removal and reinsertion of descriptors in the mdib to trigger reports.
+         *
+         * @param injector to analyze mdib on
+         * @return true if successful, false otherwise
+         * @throws PreconditionException on errors
+         */
+        static boolean manipulation(final Injector injector) throws PreconditionException {
+            return descriptionModificationManipulation(injector, LOG);
+        }
+    }
+
+    /**
      * Precondition which checks whether report messages containing state changes have been received,
      * triggering reports otherwise.
      */

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -35,7 +35,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
@@ -287,24 +286,21 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     private void checkNestedDescriptors(final AbstractDescriptor descriptor) {
         final var handle = descriptor.getHandle();
         final String errorMsg = "%s with handle %s should not have nested descriptor %s";
-        if (descriptor instanceof AlertSystemDescriptor) {
+        if (descriptor instanceof AlertSystemDescriptor alertSystem) {
             // verify that the alarm system has no alarm signals or alarm conditions
-            final var alertSystem = (AlertSystemDescriptor) descriptor;
             assertTrue(
                     alertSystem.getAlertCondition().isEmpty(),
                     String.format(errorMsg, descriptor.getClass(), handle, alertSystem.getAlertCondition()));
             assertTrue(
                     alertSystem.getAlertSignal().isEmpty(),
                     String.format(errorMsg, descriptor.getClass(), handle, alertSystem.getAlertSignal()));
-        } else if (descriptor instanceof ChannelDescriptor) {
+        } else if (descriptor instanceof ChannelDescriptor channel) {
             // verify that the channel has no metrics
-            final var channel = (ChannelDescriptor) descriptor;
             assertTrue(
                     channel.getMetric().isEmpty(),
                     String.format(errorMsg, descriptor.getClass(), handle, channel.getMetric()));
-        } else if (descriptor instanceof MdsDescriptor) {
+        } else if (descriptor instanceof MdsDescriptor mds) {
             // verify that the mds has no alert system, sco, system context, clock, batteries or vmds
-            final var mds = (MdsDescriptor) descriptor;
             assertNull(
                     mds.getAlertSystem(), String.format(errorMsg, descriptor.getClass(), handle, mds.getAlertSystem()));
             assertNull(mds.getSco(), String.format(errorMsg, descriptor.getClass(), handle, mds.getSco()));
@@ -316,16 +312,14 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                     mds.getBattery().isEmpty(),
                     String.format(errorMsg, descriptor.getClass(), handle, mds.getBattery()));
             assertTrue(mds.getVmd().isEmpty(), String.format(errorMsg, descriptor.getClass(), handle, mds.getVmd()));
-        } else if (descriptor instanceof ScoDescriptor) {
+        } else if (descriptor instanceof ScoDescriptor sco) {
             // verify that the sco has no operations
-            final var sco = (ScoDescriptor) descriptor;
             assertTrue(
                     sco.getOperation().isEmpty(),
                     String.format(errorMsg, descriptor.getClass(), handle, sco.getOperation()));
-        } else if (descriptor instanceof SystemContextDescriptor) {
+        } else if (descriptor instanceof SystemContextDescriptor systemContext) {
             // verify that the system context has no patient and location context and no ensemble, operator
             // workflow and mean contexts
-            final var systemContext = (SystemContextDescriptor) descriptor;
             assertNull(
                     systemContext.getPatientContext(),
                     String.format(errorMsg, descriptor.getClass(), handle, systemContext.getPatientContext()));
@@ -344,9 +338,8 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             assertTrue(
                     systemContext.getMeansContext().isEmpty(),
                     String.format(errorMsg, descriptor.getClass(), handle, systemContext.getMeansContext()));
-        } else if (descriptor instanceof VmdDescriptor) {
+        } else if (descriptor instanceof VmdDescriptor vmd) {
             // verify that the vmd has no channels, vmd and sco
-            final var vmd = (VmdDescriptor) descriptor;
             assertTrue(
                     vmd.getChannel().isEmpty(),
                     String.format(errorMsg, descriptor.getClass(), handle, vmd.getChannel()));
@@ -376,7 +369,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                     final var crtReportParts = reportOpt.orElseThrow().getReportPart().stream()
                             .filter(part ->
                                     ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.CRT))
-                            .collect(Collectors.toList());
+                            .toList();
                     for (var part : crtReportParts) {
                         for (var state : part.getState()) {
                             acceptableSequenceSeen.incrementAndGet();
@@ -416,7 +409,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
 
             assertTestData(
                     acceptableSequenceSeen.get(),
-                    "No report parts with description modification type crt" + " seen during test run, test failed");
+                    "No report parts with description modification type crt seen during test run, test failed");
         }
     }
 
@@ -440,7 +433,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                     final var uptReportParts = reportOpt.orElseThrow().getReportPart().stream()
                             .filter(part ->
                                     ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.UPT))
-                            .collect(Collectors.toList());
+                            .toList();
                     for (var part : uptReportParts) {
                         acceptableSequenceSeen.incrementAndGet();
                         for (var state : part.getState()) {
@@ -483,7 +476,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
 
             assertTestData(
                     acceptableSequenceSeen.get(),
-                    "No report parts with description modification type upt" + " seen during test run, test failed");
+                    "No report parts with description modification type upt seen during test run, test failed");
         }
     }
 
@@ -586,7 +579,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             + " EpisodicComponentReport.")
     @RequirePrecondition(
             simplePreconditions = {ConditionalPreconditions.TriggerEpisodicComponentReportPrecondition.class})
-    void testRequirementC12() throws NoTestData, PreprocessingException, ReportProcessingException, IOException {
+    void testRequirementC12() throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
                 messageStorage, getInjector().getInstance(TestRunObserver.class));
 
@@ -643,7 +636,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             + " EpisodicContextReport.")
     @RequirePrecondition(
             simplePreconditions = {ConditionalPreconditions.TriggerEpisodicContextReportPrecondition.class})
-    void testRequirementC13() throws NoTestData, PreprocessingException, ReportProcessingException, IOException {
+    void testRequirementC13() throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
                 messageStorage, getInjector().getInstance(TestRunObserver.class));
 
@@ -711,7 +704,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             + " whether at least one child or attribute has changed for each AbstractMetricState contained in an"
             + " EpisodicMetricReport.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerEpisodicMetricReportPrecondition.class})
-    void testRequirementC14() throws NoTestData, PreprocessingException, ReportProcessingException, IOException {
+    void testRequirementC14() throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
                 messageStorage, getInjector().getInstance(TestRunObserver.class));
 
@@ -729,11 +722,11 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                     for (final Iterator<AbstractReport> iterator = reports.iterator(); iterator.hasNext(); ) {
                         final AbstractReport report = iterator.next();
 
-                        if (report instanceof EpisodicMetricReport) {
+                        if (report instanceof EpisodicMetricReport metricReport) {
                             acceptableSequenceSeen.incrementAndGet();
                             second = mdibHistorian.applyReportOnStorage(second, report);
 
-                            for (var reportPart : ((EpisodicMetricReport) report).getReportPart()) {
+                            for (var reportPart : metricReport.getReportPart()) {
                                 for (var metricState : reportPart.getMetricState()) {
                                     final var stateBeforeReport = first.getState(
                                             metricState.getDescriptorHandle(), AbstractMetricState.class);
@@ -788,11 +781,11 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                             reportIterator.hasNext(); ) {
                         final AbstractReport report = reportIterator.next();
 
-                        if (report instanceof EpisodicOperationalStateReport) {
+                        if (report instanceof EpisodicOperationalStateReport operationalStateReport) {
                             acceptableSequenceSeen.incrementAndGet();
                             second = mdibHistorian.applyReportOnStorage(second, report);
 
-                            for (var reportPart : ((EpisodicOperationalStateReport) report).getReportPart()) {
+                            for (var reportPart : operationalStateReport.getReportPart()) {
                                 for (var operationState : reportPart.getOperationState()) {
                                     final var stateBeforeReport = first.getState(
                                             operationState.getDescriptorHandle(), AbstractOperationState.class);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
@@ -544,7 +544,7 @@ public class ConditionalPreconditionsTest {
     @Test
     @DisplayName("DescriptionModificationDelPrecondition correctly checks for precondition")
     public void testDescriptionModificationDelPreconditionCheck()
-        throws PreconditionException, IOException, JAXBException {
+            throws PreconditionException, IOException, JAXBException {
         // no messages
         assertFalse(ConditionalPreconditions.DescriptionModificationDelPrecondition.preconditionCheck(testInjector));
 
@@ -553,10 +553,10 @@ public class ConditionalPreconditionsTest {
         final var reportPartUpt = messageBuilder.buildDescriptionModificationReportReportPart();
         reportPartUpt.setModificationType(DescriptionModificationType.UPT);
         final var firstReport = messageBuilder.buildDescriptionModificationReport(
-            "SomeSequence", List.of(reportPartCrt, reportPartUpt));
+                "SomeSequence", List.of(reportPartCrt, reportPartUpt));
 
         final var messageWithoutDelReportPart = messageBuilder.createSoapMessageWithBody(
-            ActionConstants.ACTION_DESCRIPTION_MODIFICATION_REPORT, firstReport);
+                ActionConstants.ACTION_DESCRIPTION_MODIFICATION_REPORT, firstReport);
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, messageWithoutDelReportPart);
         // no report part with modification type del
@@ -565,10 +565,10 @@ public class ConditionalPreconditionsTest {
         final var reportPartDel = messageBuilder.buildDescriptionModificationReportReportPart();
         reportPartDel.setModificationType(DescriptionModificationType.DEL);
         final var secondReport =
-            messageBuilder.buildDescriptionModificationReport("SomeSequence", List.of(reportPartDel));
+                messageBuilder.buildDescriptionModificationReport("SomeSequence", List.of(reportPartDel));
 
         final var messageWithDelReportPart = messageBuilder.createSoapMessageWithBody(
-            ActionConstants.ACTION_DESCRIPTION_MODIFICATION_REPORT, secondReport);
+                ActionConstants.ACTION_DESCRIPTION_MODIFICATION_REPORT, secondReport);
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, messageWithDelReportPart);
         assertTrue(ConditionalPreconditions.DescriptionModificationDelPrecondition.preconditionCheck(testInjector));
@@ -584,8 +584,8 @@ public class ConditionalPreconditionsTest {
         final var descriptor2Handle = "handle;Süper;";
 
         final var presenceMap = new HashMap<>(Map.of(
-            descriptor1Handle, false,
-            descriptor2Handle, true));
+                descriptor1Handle, false,
+                descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptors()).thenReturn(List.of(descriptor1Handle, descriptor2Handle));
 
@@ -598,14 +598,14 @@ public class ConditionalPreconditionsTest {
             return ResponseTypes.Result.RESULT_SUCCESS;
         });
         when(testClient.getSdcRemoteDevice().getMdibAccess().getEntity(anyString()))
-            .thenAnswer((Answer<Optional<MdibEntity>>) invocation -> {
-                final String handle = invocation.getArgument(0);
-                if (presenceMap.get(handle)) {
-                    return Optional.of(mock(MdibEntity.class));
-                } else {
-                    return Optional.empty();
-                }
-            });
+                .thenAnswer((Answer<Optional<MdibEntity>>) invocation -> {
+                    final String handle = invocation.getArgument(0);
+                    if (presenceMap.get(handle)) {
+                        return Optional.of(mock(MdibEntity.class));
+                    } else {
+                        return Optional.empty();
+                    }
+                });
 
         assertTrue(ConditionalPreconditions.DescriptionModificationDelPrecondition.manipulation(testInjector));
 
@@ -616,26 +616,26 @@ public class ConditionalPreconditionsTest {
         verify(mockManipulations, times(2)).removeDescriptor(removeCaptor.capture());
 
         assertEquals(
-            2,
-            insertCaptor.getAllValues().stream()
-                .filter(descriptor1Handle::equals)
-                .count());
+                2,
+                insertCaptor.getAllValues().stream()
+                        .filter(descriptor1Handle::equals)
+                        .count());
         assertEquals(
-            1,
-            insertCaptor.getAllValues().stream()
-                .filter(descriptor2Handle::equals)
-                .count());
+                1,
+                insertCaptor.getAllValues().stream()
+                        .filter(descriptor2Handle::equals)
+                        .count());
 
         assertEquals(
-            1,
-            removeCaptor.getAllValues().stream()
-                .filter(descriptor1Handle::equals)
-                .count());
+                1,
+                removeCaptor.getAllValues().stream()
+                        .filter(descriptor1Handle::equals)
+                        .count());
         assertEquals(
-            1,
-            removeCaptor.getAllValues().stream()
-                .filter(descriptor2Handle::equals)
-                .count());
+                1,
+                removeCaptor.getAllValues().stream()
+                        .filter(descriptor2Handle::equals)
+                        .count());
     }
 
     /**

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
@@ -535,6 +535,110 @@ public class ConditionalPreconditionsTest {
     }
 
     /**
+     * Tests whether DescriptionModificationCrtPrecondition correctly checks for precondition.
+     *
+     * @throws PreconditionException on precondition exceptions
+     * @throws IOException           on io exceptions
+     * @throws JAXBException         on marshalling failures
+     */
+    @Test
+    @DisplayName("DescriptionModificationDelPrecondition correctly checks for precondition")
+    public void testDescriptionModificationDelPreconditionCheck()
+        throws PreconditionException, IOException, JAXBException {
+        // no messages
+        assertFalse(ConditionalPreconditions.DescriptionModificationDelPrecondition.preconditionCheck(testInjector));
+
+        final var reportPartCrt = messageBuilder.buildDescriptionModificationReportReportPart();
+        reportPartCrt.setModificationType(DescriptionModificationType.CRT);
+        final var reportPartUpt = messageBuilder.buildDescriptionModificationReportReportPart();
+        reportPartUpt.setModificationType(DescriptionModificationType.UPT);
+        final var firstReport = messageBuilder.buildDescriptionModificationReport(
+            "SomeSequence", List.of(reportPartCrt, reportPartUpt));
+
+        final var messageWithoutDelReportPart = messageBuilder.createSoapMessageWithBody(
+            ActionConstants.ACTION_DESCRIPTION_MODIFICATION_REPORT, firstReport);
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, messageWithoutDelReportPart);
+        // no report part with modification type del
+        assertFalse(ConditionalPreconditions.DescriptionModificationDelPrecondition.preconditionCheck(testInjector));
+
+        final var reportPartDel = messageBuilder.buildDescriptionModificationReportReportPart();
+        reportPartDel.setModificationType(DescriptionModificationType.DEL);
+        final var secondReport =
+            messageBuilder.buildDescriptionModificationReport("SomeSequence", List.of(reportPartDel));
+
+        final var messageWithDelReportPart = messageBuilder.createSoapMessageWithBody(
+            ActionConstants.ACTION_DESCRIPTION_MODIFICATION_REPORT, secondReport);
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, messageWithDelReportPart);
+        assertTrue(ConditionalPreconditions.DescriptionModificationDelPrecondition.preconditionCheck(testInjector));
+    }
+
+    /**
+     * Tests whether DescriptionModificationDelPrecondition correctly calls manipulation.
+     */
+    @Test
+    @DisplayName("DescriptionModificationDelPrecondition correctly calls manipulation")
+    public void testDescriptionModificationDelManipulation() throws PreconditionException {
+        final var descriptor1Handle = "superHandle";
+        final var descriptor2Handle = "handle;Süper;";
+
+        final var presenceMap = new HashMap<>(Map.of(
+            descriptor1Handle, false,
+            descriptor2Handle, true));
+
+        when(mockManipulations.getRemovableDescriptors()).thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+            presenceMap.put(invocation.getArgument(0), true);
+            return ResponseTypes.Result.RESULT_SUCCESS;
+        });
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+            presenceMap.put(invocation.getArgument(0), false);
+            return ResponseTypes.Result.RESULT_SUCCESS;
+        });
+        when(testClient.getSdcRemoteDevice().getMdibAccess().getEntity(anyString()))
+            .thenAnswer((Answer<Optional<MdibEntity>>) invocation -> {
+                final String handle = invocation.getArgument(0);
+                if (presenceMap.get(handle)) {
+                    return Optional.of(mock(MdibEntity.class));
+                } else {
+                    return Optional.empty();
+                }
+            });
+
+        assertTrue(ConditionalPreconditions.DescriptionModificationDelPrecondition.manipulation(testInjector));
+
+        final var insertCaptor = ArgumentCaptor.forClass(String.class);
+        final var removeCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockManipulations, times(1)).getRemovableDescriptors();
+        verify(mockManipulations, times(3)).insertDescriptor(insertCaptor.capture());
+        verify(mockManipulations, times(2)).removeDescriptor(removeCaptor.capture());
+
+        assertEquals(
+            2,
+            insertCaptor.getAllValues().stream()
+                .filter(descriptor1Handle::equals)
+                .count());
+        assertEquals(
+            1,
+            insertCaptor.getAllValues().stream()
+                .filter(descriptor2Handle::equals)
+                .count());
+
+        assertEquals(
+            1,
+            removeCaptor.getAllValues().stream()
+                .filter(descriptor1Handle::equals)
+                .count());
+        assertEquals(
+            1,
+            removeCaptor.getAllValues().stream()
+                .filter(descriptor2Handle::equals)
+                .count());
+    }
+
+    /**
      * Tests whether DescriptionModificationPrecondition throws exception if no removable descriptors are present.
      */
     @Test

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTestTest.java
@@ -814,7 +814,8 @@ public class InvariantMessageModelAnnexTestTest {
         final var deletePart = buildDescriptionModificationReportPart(DescriptionModificationType.DEL);
         final var createPart = buildDescriptionModificationReportPart(DescriptionModificationType.CRT);
         final var updatePart = buildDescriptionModificationReportPart(DescriptionModificationType.UPT);
-        final var descriptionModificationReport = buildDescriptionModificationReport(SEQUENCE_ID, BigInteger.ONE, deletePart, createPart, updatePart);
+        final var descriptionModificationReport =
+                buildDescriptionModificationReport(SEQUENCE_ID, BigInteger.ONE, deletePart, createPart, updatePart);
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReport);
 
@@ -830,13 +831,14 @@ public class InvariantMessageModelAnnexTestTest {
     @Test
     public void testRequirementR5053BadNoDelParts() throws Exception {
         final var alertCondition = mdibBuilder.buildAlertCondition(
-            MDS_ALERT_CONDITION_HANDLE, AlertConditionKind.OTH, AlertConditionPriority.ME, AlertActivation.ON);
+                MDS_ALERT_CONDITION_HANDLE, AlertConditionKind.OTH, AlertConditionPriority.ME, AlertActivation.ON);
         alertCondition.getLeft().setDescriptorVersion(BigInteger.ONE);
         alertCondition.getRight().setDescriptorVersion(BigInteger.ONE);
 
         final var createPart = buildDescriptionModificationReportPart(DescriptionModificationType.CRT, alertCondition);
         final var updatePart = buildDescriptionModificationReportPart(DescriptionModificationType.UPT, alertCondition);
-        final var reportWithoutDelPart = buildDescriptionModificationReport(SEQUENCE_ID, BigInteger.ONE, createPart, updatePart);
+        final var reportWithoutDelPart =
+                buildDescriptionModificationReport(SEQUENCE_ID, BigInteger.ONE, createPart, updatePart);
         messageStorageUtil.addInboundSecureHttpMessage(storage, reportWithoutDelPart);
         // no report part with modification type del
         assertThrows(NoTestData.class, testClass::testRequirementR5053);
@@ -851,7 +853,7 @@ public class InvariantMessageModelAnnexTestTest {
     @Test
     public void testRequirementR5053BadStatesPresent() throws Exception {
         final var alertCondition = mdibBuilder.buildAlertCondition(
-            MDS_ALERT_CONDITION_HANDLE, AlertConditionKind.OTH, AlertConditionPriority.ME, AlertActivation.ON);
+                MDS_ALERT_CONDITION_HANDLE, AlertConditionKind.OTH, AlertConditionPriority.ME, AlertActivation.ON);
         alertCondition.getLeft().setDescriptorVersion(BigInteger.ONE);
         alertCondition.getRight().setDescriptorVersion(BigInteger.ONE);
 
@@ -860,7 +862,8 @@ public class InvariantMessageModelAnnexTestTest {
         reportPart.getDescriptor().add(alertCondition.getLeft());
         // states should be omitted for description modification type del
         reportPart.getState().add(alertCondition.getRight());
-        messageStorageUtil.addInboundSecureHttpMessage(storage, buildDescriptionModificationReport(SEQUENCE_ID, BigInteger.TWO, reportPart));
+        messageStorageUtil.addInboundSecureHttpMessage(
+                storage, buildDescriptionModificationReport(SEQUENCE_ID, BigInteger.TWO, reportPart));
         assertThrows(AssertionError.class, testClass::testRequirementR5053);
     }
 


### PR DESCRIPTION
Implemented a test for biceps R5053.
Added a precondition to trigger description modifications with modification type delete.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
