### PR TITLE
Feature/test biceps r0098 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - test for biceps:5-4-7_17
 - support for SystemErrorReport to test case glue:R0036_0
 - test for biceps:5-4-7_15
+- test for biceps:R0098_0
 
 ### Fixed
 - dpws:R0013 sent a request that was not WS-Transfer compliant

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The test tool has the following limitations. If the DUT falls under these limita
 | R0034_0         | GetRemovableDescriptors, RemoveDescriptor, InsertDescriptor |
 | R0038_0         | TriggerReport                                               |
 | R0097           | CreateContextStateWithAssociation                           |
+| R0098_0         | GetRemovableDescriptors, RemoveDescriptor, InsertDescriptor |
 | R0116           | SetAlertActivation                                          |
 | R0124           | CreateContextStateWithAssociation                           |
 | R0125           | CreateContextStateWithAssociation                           |

--- a/configuration/test_configuration.toml
+++ b/configuration/test_configuration.toml
@@ -23,6 +23,7 @@ R0066=true
 R0068=true
 R0069=true
 R0097=true
+R0098_0=true
 R0100=false
 R0101=true
 R0104=true

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
@@ -29,6 +29,7 @@ public final class EnabledTestConfig {
     public static final String BICEPS_R0068 = BICEPS + "R0068";
     public static final String BICEPS_R0069 = BICEPS + "R0069";
     public static final String BICEPS_R0097 = BICEPS + "R0097";
+    public static final String BICEPS_R0098_0 = BICEPS + "R0098_0";
     public static final String BICEPS_R0100 = BICEPS + "R0100";
     public static final String BICEPS_R0101 = BICEPS + "R0101";
     public static final String BICEPS_R0104 = BICEPS + "R0104";

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -14,14 +14,12 @@ import com.draeger.medical.sdccc.tests.util.ImpliedValueUtil;
 import com.draeger.medical.sdccc.util.TestRunObserver;
 import com.draeger.medical.t2iapi.ResponseTypes;
 import com.google.inject.Injector;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.somda.sdc.biceps.common.MdibEntity;
@@ -1450,13 +1448,22 @@ public class ManipulationPreconditions {
         }
     }
 
+    /**
+     * Removes and reinserts descriptors with the same handle.
+     */
     public static class RemoveAndReinsertDescriptorManipulation extends ManipulationPrecondition {
         private static final Logger LOG = LogManager.getLogger(RemoveAndReinsertDescriptorManipulation.class);
 
+        /**
+         * Creates a remove and reinsert precondition.
+         */
         public RemoveAndReinsertDescriptorManipulation() {
             super(RemoveAndReinsertDescriptorManipulation::manipulation);
         }
 
+        /**
+         * @return true if successful, false otherwise
+         */
         static boolean manipulation(final Injector injector) {
             final var manipulations = injector.getInstance(Manipulations.class);
             final var testClient = injector.getInstance(TestClient.class);
@@ -1512,16 +1519,15 @@ public class ManipulationPreconditions {
                 LOG.debug("Descriptor {} presence: {}", handle, descriptorEntity.isPresent());
 
                 if (manipulationResults.contains(ResponseTypes.Result.RESULT_FAIL)) {
-                    testRunObserver.invalidateTestRun(
-                        String.format("Could not successfully modify descriptor %s, stopping the precondition",
-                            handle));
+                    testRunObserver.invalidateTestRun(String.format(
+                            "Could not successfully modify descriptor %s, stopping the precondition", handle));
                     break;
                 }
             }
 
             return !manipulationResults.contains(ResponseTypes.Result.RESULT_FAIL)
-                && !manipulationResults.contains(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED)
-                && manipulationResults.contains(ResponseTypes.Result.RESULT_SUCCESS);
+                    && !manipulationResults.contains(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED)
+                    && manipulationResults.contains(ResponseTypes.Result.RESULT_SUCCESS);
         }
     }
 }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelHandleTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelHandleTest.java
@@ -26,7 +26,6 @@ import com.draeger.medical.sdccc.tests.util.NoTestData;
 import com.draeger.medical.sdccc.tests.util.guice.MdibHistorianFactory;
 import com.draeger.medical.sdccc.util.Constants;
 import com.draeger.medical.sdccc.util.TestRunObserver;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -36,7 +35,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
@@ -187,29 +185,30 @@ public class InvariantParticipantModelHandleTest extends InjectorTestBase {
 
     @Test
     @DisplayName("If a SERVICE PROVIDER inserts an ELEMENT with a HANDLE that has been used in a previous MDIB version"
-        + " of the same MDIB sequence, this ELEMENT SHALL be of the same XML Schema datatype as every ELEMENT that"
-        + " previously carried the HANDLE.")
+            + " of the same MDIB sequence, this ELEMENT SHALL be of the same XML Schema datatype as every ELEMENT that"
+            + " previously carried the HANDLE.")
     @TestIdentifier(EnabledTestConfig.BICEPS_R0098_0)
     @TestDescription("Starting from the initially retrieved mdib, applies each description modification report to the"
-        + " mdib and verifies that each created descriptor in each description modification part that reuses a handle"
-        + " is of the same type as the descriptors that previously used the same handle.")
+            + " mdib and verifies that each created descriptor in each description modification part that reuses a handle"
+            + " is of the same type as the descriptors that previously used the same handle.")
     @RequirePrecondition(
-        manipulationPreconditions = {ManipulationPreconditions.RemoveAndReinsertDescriptorManipulation.class})
+            manipulationPreconditions = {ManipulationPreconditions.RemoveAndReinsertDescriptorManipulation.class})
     void testRequirementR00980() throws NoTestData, IOException {
-        final var sequenceIds = messageStorage.getUniqueSequenceIds().filter(Objects::nonNull).toList();
+        final var sequenceIds =
+                messageStorage.getUniqueSequenceIds().filter(Objects::nonNull).toList();
 
         final var reinsertionSeen = new AtomicInteger(0);
 
         for (var sequenceId : sequenceIds) {
-            try (final var messages = messageStorage.getInboundMessagesByBodyTypeAndSequenceId(sequenceId,
-                Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+            try (final var messages = messageStorage.getInboundMessagesByBodyTypeAndSequenceId(
+                    sequenceId, Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
 
                 final var deletedDescriptors = new HashMap<String, AbstractDescriptor>();
 
                 messages.getStream().forEach(messageContent -> {
                     try {
-                        final var soapMessage = marshalling.unmarshal(
-                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                        final var soapMessage = marshalling.unmarshal(new ByteArrayInputStream(
+                                messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                         final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                         final var reportParts = reportOpt.orElseThrow().getReportPart();
                         for (var part : reportParts) {
@@ -233,15 +232,17 @@ public class InvariantParticipantModelHandleTest extends InjectorTestBase {
                 });
             }
         }
-        assertTestData(reinsertionSeen.get(),
-            "No reinsertion of descriptors seen during the test run, test failed.");
+        assertTestData(reinsertionSeen.get(), "No reinsertion of descriptors seen during the test run, test failed.");
     }
 
-    private void checkReinsertedDescriptor(final AbstractDescriptor insertedDescriptor,
-                                           final AbstractDescriptor deletedDescriptor) {
-        assertEquals(deletedDescriptor.getClass(), insertedDescriptor.getClass(), String.format(
-            "The reinserted descriptor with handle %s should have the class %s but has the class %s",
-            insertedDescriptor.getHandle(), deletedDescriptor.getClass(), insertedDescriptor.getClass()));
+    private void checkReinsertedDescriptor(
+            final AbstractDescriptor insertedDescriptor, final AbstractDescriptor deletedDescriptor) {
+        assertEquals(
+                deletedDescriptor.getClass(),
+                insertedDescriptor.getClass(),
+                String.format(
+                        "The reinserted descriptor with handle %s should have the class %s but has the class %s",
+                        insertedDescriptor.getHandle(), deletedDescriptor.getClass(), insertedDescriptor.getClass()));
     }
 
     /**

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelHandleTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelHandleTest.java
@@ -189,8 +189,9 @@ public class InvariantParticipantModelHandleTest extends InjectorTestBase {
             + " previously carried the HANDLE.")
     @TestIdentifier(EnabledTestConfig.BICEPS_R0098_0)
     @TestDescription("Starting from the initially retrieved mdib, applies each description modification report to the"
-            + " mdib and verifies that each created descriptor in each description modification part that reuses a handle"
-            + " is of the same type as the descriptors that previously used the same handle.")
+            + " mdib and verifies that each created descriptor in each description modification part that"
+            + " reuses a handle is of the same type as the descriptors that previously used the same handle"
+            + " during the same mdib sequence.")
     @RequirePrecondition(
             manipulationPreconditions = {ManipulationPreconditions.RemoveAndReinsertDescriptorManipulation.class})
     void testRequirementR00980() throws NoTestData, IOException {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1017,8 +1017,9 @@ public class ManipulationPreconditionsTest {
         setupRemoveAndReinsertDescriptor(SOME_HANDLE, List.of(SOME_HANDLE));
 
         assertTrue(ManipulationPreconditions.RemoveAndReinsertDescriptorManipulation.manipulation(injector));
-        assertFalse(testRunObserver.isInvalid(),
-            "Test run should not have been invalidated." + testRunObserver.getReasons());
+        assertFalse(
+                testRunObserver.isInvalid(),
+                "Test run should not have been invalidated." + testRunObserver.getReasons());
 
         verify(mockManipulations).getRemovableDescriptors();
         verify(mockManipulations).removeDescriptor(SOME_HANDLE);
@@ -1030,20 +1031,21 @@ public class ManipulationPreconditionsTest {
     void testRemoveAndReinsertDescriptorManipulation2() {
         setupRemoveAndReinsertDescriptor(SOME_HANDLE, List.of(SOME_HANDLE));
 
-        when(mockManipulations.insertDescriptor(
-            any(String.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_SUCCESS).thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+        when(mockManipulations.insertDescriptor(any(String.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
+                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         when(mockDevice.getMdibAccess().getEntity(anyString()))
-            .thenReturn(Optional.empty())
-            .thenReturn(Optional.of(mockEntity))
-            .thenReturn(Optional.empty())
-            .thenReturn(Optional.of(mockEntity));
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(mockEntity))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(mockEntity));
 
         assertTrue(ManipulationPreconditions.RemoveAndReinsertDescriptorManipulation.manipulation(injector));
-        assertFalse(testRunObserver.isInvalid(),
-            "Test run should not have been invalidated." + testRunObserver.getReasons());
+        assertFalse(
+                testRunObserver.isInvalid(),
+                "Test run should not have been invalidated." + testRunObserver.getReasons());
 
         verify(mockManipulations).getRemovableDescriptors();
         verify(mockManipulations).removeDescriptor(SOME_HANDLE);
@@ -1091,21 +1093,22 @@ public class ManipulationPreconditionsTest {
         verify(mockManipulations).insertDescriptor(SOME_HANDLE);
     }
 
-    private void setupRemoveAndReinsertDescriptor(final String descriptorHandle,
-                                                  final List<String> removableDescriptors) {
-        when(mockManipulations.getRemovableDescriptors())
-            .thenReturn(removableDescriptors);
+    private void setupRemoveAndReinsertDescriptor(
+            final String descriptorHandle, final List<String> removableDescriptors) {
+        when(mockManipulations.getRemovableDescriptors()).thenReturn(removableDescriptors);
 
-        when(mockManipulations.removeDescriptor(
-            any(String.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_SUCCESS).thenReturn(ResponseTypes.Result.RESULT_FAIL);
+        when(mockManipulations.removeDescriptor(any(String.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        when(mockManipulations.insertDescriptor(
-            any(String.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_SUCCESS).thenReturn(ResponseTypes.Result.RESULT_FAIL);
+        when(mockManipulations.insertDescriptor(any(String.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         when(mockEntity.getHandle()).thenReturn(descriptorHandle);
         when(mockDevice.getMdibAccess().getEntity(anyString()))
-            .thenReturn(Optional.of(mockEntity)).thenReturn(Optional.empty()).thenReturn(Optional.of(mockEntity));
+                .thenReturn(Optional.of(mockEntity))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(mockEntity));
     }
 }

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelHandleTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelHandleTestTest.java
@@ -7,6 +7,12 @@
 
 package com.draeger.medical.sdccc.tests.biceps.invariant;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.draeger.medical.biceps.model.message.AbstractContextReport;
 import com.draeger.medical.biceps.model.message.DescriptionModificationReport;
 import com.draeger.medical.biceps.model.message.DescriptionModificationType;
@@ -27,6 +33,12 @@ import com.draeger.medical.sdccc.util.MessageStorageUtil;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import jakarta.xml.bind.JAXBException;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,19 +49,6 @@ import org.somda.sdc.biceps.provider.preprocessing.HandleDuplicatedException;
 import org.somda.sdc.dpws.helper.JaxbMarshalling;
 import org.somda.sdc.dpws.soap.SoapMarshalling;
 import org.somda.sdc.glue.common.ActionConstants;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.math.BigInteger;
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.TimeoutException;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit test for the BICEPS {@linkplain InvariantParticipantModelHandleTest}.
@@ -289,20 +288,20 @@ public class InvariantParticipantModelHandleTestTest {
 
         // channelHandle and systemHandle are the same
         final var mdib = buildMdib(
-            MDS_HANDLE,
-            VMD_HANDLE,
-            NON_UNIQUE_HANDLE,
-            NON_UNIQUE_HANDLE,
-            LOCATION_DESC_HANDLE,
-            LOCATION_STATE_HANDLE);
+                MDS_HANDLE,
+                VMD_HANDLE,
+                NON_UNIQUE_HANDLE,
+                NON_UNIQUE_HANDLE,
+                LOCATION_DESC_HANDLE,
+                LOCATION_STATE_HANDLE);
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, mdib);
 
         final RuntimeException exception = assertThrows(RuntimeException.class, testClass::testRequirementR0007);
         assertTrue(exception.getMessage().contains(NON_UNIQUE_HANDLE));
         assertTrue(
-            exception.getCause() instanceof HandleDuplicatedException,
-            "Wrong kind of Exception: " + exception.getCause());
+                exception.getCause() instanceof HandleDuplicatedException,
+                "Wrong kind of Exception: " + exception.getCause());
     }
 
     /**
@@ -313,7 +312,7 @@ public class InvariantParticipantModelHandleTestTest {
 
         // locationDescHandle and locationStateHandle are the same
         final var mdib = buildMdib(
-            MDS_HANDLE, VMD_HANDLE, CHANNEL_HANDLE, SYSTEM_CONTEXT_HANDLE, NON_UNIQUE_HANDLE, NON_UNIQUE_HANDLE);
+                MDS_HANDLE, VMD_HANDLE, CHANNEL_HANDLE, SYSTEM_CONTEXT_HANDLE, NON_UNIQUE_HANDLE, NON_UNIQUE_HANDLE);
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, mdib);
 
@@ -367,13 +366,16 @@ public class InvariantParticipantModelHandleTestTest {
         final var secondReport = buildDescriptionModificationReport(SEQUENCE_ID, BigInteger.TWO, createPart);
         messageStorageUtil.addInboundSecureHttpMessage(storage, secondReport);
 
-        final var deleteAgainReport = buildDescriptionModificationReport(SEQUENCE_ID, BigInteger.valueOf(3), deletePart);
+        final var deleteAgainReport =
+                buildDescriptionModificationReport(SEQUENCE_ID, BigInteger.valueOf(3), deletePart);
         messageStorageUtil.addInboundSecureHttpMessage(storage, deleteAgainReport);
 
         final var otherDescriptor =
-            mdibBuilder.buildAlertSignalDescriptor(NON_UNIQUE_HANDLE, AlertSignalManifestation.VIS, true);
-        final var createOtherPart = buildDescriptionModificationReportPart(DescriptionModificationType.CRT, otherDescriptor);
-        final var createSomethingNewReport = buildDescriptionModificationReport("123457", BigInteger.valueOf(4), createOtherPart);
+                mdibBuilder.buildAlertSignalDescriptor(NON_UNIQUE_HANDLE, AlertSignalManifestation.VIS, true);
+        final var createOtherPart =
+                buildDescriptionModificationReportPart(DescriptionModificationType.CRT, otherDescriptor);
+        final var createSomethingNewReport =
+                buildDescriptionModificationReport("123457", BigInteger.valueOf(4), createOtherPart);
         messageStorageUtil.addInboundSecureHttpMessage(storage, createSomethingNewReport);
 
         testClass.testRequirementR00980();
@@ -392,7 +394,7 @@ public class InvariantParticipantModelHandleTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, report);
 
         final var otherDescriptor =
-            mdibBuilder.buildAlertSignalDescriptor(NON_UNIQUE_HANDLE, AlertSignalManifestation.VIS, true);
+                mdibBuilder.buildAlertSignalDescriptor(NON_UNIQUE_HANDLE, AlertSignalManifestation.VIS, true);
         final var createPart = buildDescriptionModificationReportPart(DescriptionModificationType.CRT, otherDescriptor);
         final var secondReport = buildDescriptionModificationReport(SEQUENCE_ID, BigInteger.TWO, createPart);
         messageStorageUtil.addInboundSecureHttpMessage(storage, secondReport);
@@ -404,12 +406,12 @@ public class InvariantParticipantModelHandleTestTest {
      * build mdib with configurable handles
      */
     Envelope buildMdib(
-        final String mdsHandle,
-        final String vmdHandle,
-        final String channelHandle,
-        final String systemContextHandle,
-        final String locationDescriptorHandle,
-        final String locationStateHandle) {
+            final String mdsHandle,
+            final String vmdHandle,
+            final String channelHandle,
+            final String systemContextHandle,
+            final String locationDescriptorHandle,
+            final String locationStateHandle) {
         final var mds = mdibBuilder.buildMds(mdsHandle);
 
         final var mdDescription = mdibBuilder.buildMdDescription();
@@ -447,13 +449,12 @@ public class InvariantParticipantModelHandleTestTest {
         getMdibResponse.setMdib(mdib);
 
         return messageBuilder.createSoapMessageWithBody(
-            ActionConstants.getResponseAction(ActionConstants.ACTION_GET_MDIB), getMdibResponse);
+                ActionConstants.getResponseAction(ActionConstants.ACTION_GET_MDIB), getMdibResponse);
     }
-    
+
     @SafeVarargs
     final DescriptionModificationReport.ReportPart buildDescriptionModificationReportPart(
-        final DescriptionModificationType modificationType,
-        final AbstractDescriptor... modifications) {
+            final DescriptionModificationType modificationType, final AbstractDescriptor... modifications) {
         final var reportPart = messageBuilder.buildDescriptionModificationReportReportPart();
         reportPart.setModificationType(modificationType);
         for (var modification : modifications) {
@@ -463,9 +464,9 @@ public class InvariantParticipantModelHandleTestTest {
     }
 
     Envelope buildDescriptionModificationReport(
-        final String sequenceId,
-        final @Nullable BigInteger mdibVersion,
-        final DescriptionModificationReport.ReportPart... reportParts) {
+            final String sequenceId,
+            final @Nullable BigInteger mdibVersion,
+            final DescriptionModificationReport.ReportPart... reportParts) {
         final var report = messageBuilder.buildDescriptionModificationReport(sequenceId, List.of(reportParts));
         report.setMdibVersion(mdibVersion);
         return messageBuilder.createSoapMessageWithBody(ActionConstants.ACTION_DESCRIPTION_MODIFICATION_REPORT, report);


### PR DESCRIPTION
Added test and unit tests for biceps R0098_0.
Added manipulation precondition to delete and reinsert a descriptor with the same handle.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
