### PR TITLE
Update sdcri version to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - t2iapi version to 2.0.0
+- SDCri version 4.0.0
 
 ### Fixed
 - dpws:R0013 sent a request that was not WS-Transfer compliant

--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junitVersion>5.6.0</junitVersion>
         <junitPlatformVersion>1.6.0</junitPlatformVersion>
-        <sdcriVersion>3.0.0</sdcriVersion>
+        <sdcriVersion>4.0.0</sdcriVersion>
         <log4jVersion>2.17.1</log4jVersion>
         <spotbugsVersion>4.7.3</spotbugsVersion>
         <checkstyleConfigDir>../checkstyle</checkstyleConfigDir>

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/MdibHistorian.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/MdibHistorian.java
@@ -123,7 +123,6 @@ public class MdibHistorian {
             protected void defaultConfigure() {
                 bind(org.somda.sdc.common.CommonConfig.INSTANCE_IDENTIFIER, String.class, "");
                 bind(CommonConfig.STORE_NOT_ASSOCIATED_CONTEXT_STATES, Boolean.class, true);
-                bind(CommonConfig.ALLOW_STATES_WITHOUT_DESCRIPTORS, Boolean.class, false);
                 bind(CommonConfig.COPY_MDIB_INPUT, Boolean.class, true);
                 bind(CommonConfig.COPY_MDIB_OUTPUT, Boolean.class, true);
                 bind(

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTestTest.java
@@ -542,13 +542,16 @@ public class InvariantMessageModelAnnexTestTest {
                         DescriptionModificationType.UPT, new ImmutablePair<>(mdsDescriptor, mdsState)));
         messageStorageUtil.addInboundSecureHttpMessage(storage, first);
 
+        final var crtPart1Handle = "second vmd";
         final Envelope second = buildDescriptionModificationReport(
                 SEQUENCE_ID,
                 BigInteger.TWO,
                 buildDescriptionModificationReportPart(
                         DescriptionModificationType.CRT,
-                        mdibBuilder.buildChannel("second channel"),
-                        mdibBuilder.buildVmd("second vmd")));
+                        MdibBuilder.DEFAULT_MDS_HANDLE,
+                        mdibBuilder.buildVmd(crtPart1Handle)),
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.CRT, crtPart1Handle, mdibBuilder.buildChannel("second channel")));
         messageStorageUtil.addInboundSecureHttpMessage(storage, second);
 
         final Envelope third = buildDescriptionModificationReport(

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTestTest.java
@@ -427,6 +427,7 @@ public class InvariantParticipantModelVersioningTestTest {
 
     /**
      * Test whether the method hasDescriptorChanged() returns false when the descriptor did not change.
+     *
      * @param a - the descriptor.
      */
     private void testHasDescriptorChangedGoodSimple(final org.somda.sdc.biceps.model.participant.AbstractDescriptor a) {
@@ -435,6 +436,7 @@ public class InvariantParticipantModelVersioningTestTest {
 
     /**
      * Test whether the method hasDescriptorChanged() returns false when the descriptor did not change.
+     *
      * @param a - the descriptor.
      */
     private <T extends org.somda.sdc.biceps.model.participant.AbstractDescriptor, V>
@@ -1177,7 +1179,9 @@ public class InvariantParticipantModelVersioningTestTest {
                         buildMds(MDS_HANDLE, BigInteger.valueOf(4), BigInteger.valueOf(4)),
                         buildVmd(VMD_HANDLE, BigInteger.valueOf(4), BigInteger.valueOf(4))),
                 buildDescriptionModificationReportPart(
-                        DescriptionModificationType.CRT, buildChannel(CHANNEL_HANDLE, BigInteger.TWO, BigInteger.TWO)));
+                        DescriptionModificationType.CRT,
+                        VMD_HANDLE,
+                        buildChannel(CHANNEL_HANDLE, BigInteger.TWO, BigInteger.TWO)));
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
         messageStorageUtil.addInboundSecureHttpMessage(storage, firstUpdate);
@@ -1557,12 +1561,23 @@ public class InvariantParticipantModelVersioningTestTest {
     final DescriptionModificationReport.ReportPart buildDescriptionModificationReportPart(
             final DescriptionModificationType modificationType,
             final Pair<? extends AbstractDescriptor, ? extends AbstractState>... modifications) {
+        return buildDescriptionModificationReportPart(modificationType, null, modifications);
+    }
+
+    @SafeVarargs
+    final DescriptionModificationReport.ReportPart buildDescriptionModificationReportPart(
+            final DescriptionModificationType modificationType,
+            final @Nullable String parentDescriptor,
+            final Pair<? extends AbstractDescriptor, ? extends AbstractState>... modifications) {
         final var reportPart = messageBuilder.buildDescriptionModificationReportReportPart();
         reportPart.setModificationType(modificationType);
+        reportPart.setParentDescriptor(parentDescriptor);
 
         for (var modification : modifications) {
             reportPart.getDescriptor().add(modification.getLeft());
-            reportPart.getState().add(modification.getRight());
+            if (modificationType != DescriptionModificationType.DEL) {
+                reportPart.getState().add(modification.getRight());
+            }
         }
         return reportPart;
     }


### PR DESCRIPTION
bumped sdcri version to 4.0.0
removed deprecated CommonConfig.ALLOW_STATES_WITHOUT_DESCRIPTORS from MdibHistorian.java

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
