### PR TITLE
requirement test execution logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- requirement test execution logging
+
 ## [7.0.1] - 2023-03-17
 
 ### Fixed

--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -1,6 +1,7 @@
 [SDCcc]
 CIMode=false
 GraphicalPopups=true
+TestExecutionLogging=true
 
 [SDCcc.TLS]
 FileDirectory="./configuration"

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
@@ -33,6 +33,8 @@ public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
         bind(TestSuiteConfig.CI_MODE, Boolean.class, false);
 
         bind(TestSuiteConfig.GRAPHICAL_POPUPS, Boolean.class, true);
+
+        bind(TestSuiteConfig.TEST_EXECUTION_LOGGING, Boolean.class, false);
     }
 
     void configureTLS() {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
@@ -22,6 +22,7 @@ public final class TestSuiteConfig {
     private static final String SDCCC = "SDCcc.";
     public static final String CI_MODE = SDCCC + "CIMode";
     public static final String GRAPHICAL_POPUPS = SDCCC + "GraphicalPopups";
+    public static final String TEST_EXECUTION_LOGGING = SDCCC + "TestExecutionLogging";
 
     /*
      * TLS configuration


### PR DESCRIPTION
Added a config entry to enable requirement test execution logging.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
