### PR TITLE
Fix result xmls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - requirement test execution logging
 - test for glue:R0056
 
+### Fixed
+- the occurrence of the sequence ']]>' in the content of CDATA sections in the result xmls
+
 ## [7.0.1] - 2023-03-17
 
 ### Fixed

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
@@ -49,8 +49,8 @@ public class XmlReportWriter {
     /**
      * Initializes an XmlReportWriter.
      *
-     * @param reportData list of results representing test cases
-     * @param classUtil utility
+     * @param reportData      list of results representing test cases
+     * @param classUtil       utility
      * @param testRunObserver observer which contains information on validity of test run
      */
     @AssistedInject
@@ -261,7 +261,17 @@ public class XmlReportWriter {
                 xmlWriter.writeAttribute("message", err.getMessage());
             }
             xmlWriter.writeAttribute("type", err.getClass().getCanonicalName());
-            xmlWriter.writeCData(ExceptionUtils.getStackTrace(err));
+
+            final var stackTrace = ExceptionUtils.getStackTrace(err);
+            final var stackTraceSplit = stackTrace.split("]]>");
+
+            for (int i = 0; i < stackTraceSplit.length; i++) {
+                xmlWriter.writeCData(stackTraceSplit[i]);
+                if (i < stackTraceSplit.length - 1) {
+                    xmlWriter.writeCData("]]");
+                    xmlWriter.writeCData(">");
+                }
+            }
         }
         xmlWriter.writeEndElement();
         writeNewLine(xmlWriter);

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
@@ -268,8 +268,7 @@ public class XmlReportWriter {
             final var lastIndex = stackTraceSplit.length - 1;
             for (final String x :
                     Arrays.stream(stackTraceSplit).limit(lastIndex).toArray(String[]::new)) {
-                xmlWriter.writeCData(x);
-                xmlWriter.writeCData("]]");
+                xmlWriter.writeCData(x + "]]");
                 xmlWriter.writeCData(">");
             }
             xmlWriter.writeCData(stackTraceSplit[lastIndex]);

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
@@ -18,6 +18,7 @@ import java.lang.annotation.Annotation;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.xml.stream.XMLOutputFactory;
@@ -264,14 +265,14 @@ public class XmlReportWriter {
 
             final var stackTrace = ExceptionUtils.getStackTrace(err);
             final var stackTraceSplit = stackTrace.split("]]>");
-
-            for (int i = 0; i < stackTraceSplit.length; i++) {
-                xmlWriter.writeCData(stackTraceSplit[i]);
-                if (i < stackTraceSplit.length - 1) {
-                    xmlWriter.writeCData("]]");
-                    xmlWriter.writeCData(">");
-                }
+            final var lastIndex = stackTraceSplit.length - 1;
+            for (final String x :
+                    Arrays.stream(stackTraceSplit).limit(lastIndex).toArray(String[]::new)) {
+                xmlWriter.writeCData(x);
+                xmlWriter.writeCData("]]");
+                xmlWriter.writeCData(">");
             }
+            xmlWriter.writeCData(stackTraceSplit[lastIndex]);
         }
         xmlWriter.writeEndElement();
         writeNewLine(xmlWriter);


### PR DESCRIPTION
The XmlReportWriter encapsulates ']]>' sequences in content of CDATA sections in their own CDATA sections.
Unit test for ']]>' handling added.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
