### PR TITLE
Make max wait configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - requirement test execution logging
 - test for glue:R0056
+- configuration option to change the maximum waiting time during connection establishment
 
 ## [7.0.1] - 2023-03-17
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ To select the network interface that should be used, the interface address can b
 InterfaceAddress="interfaceAddress"`
 ```
 
+The maximum waiting time in seconds to find and connect to the target device.
+```
+[SDCcc.Network]
+MaxWait="timeInSeconds"
+```
+
 ### Target Device (DUT) configuration
 In order for the test tool to connect to the DUT, the address of the target device must be set under
 ```

--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -12,6 +12,7 @@ EnabledProtocols = ["TLSv1.2", "TLSv1.3"]
 
 [SDCcc.Network]
 InterfaceAddress="127.0.0.1"
+MaxWait="10"
 
 [SDCcc.Consumer]
 Enable=true

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
@@ -47,6 +47,7 @@ public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
 
     void configureNetwork() {
         bind(TestSuiteConfig.NETWORK_INTERFACE_ADDRESS, String.class, "127.0.0.1");
+        bind(TestSuiteConfig.NETWORK_MAX_WAIT, int.class, 10);
     }
 
     void configureProvider() {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
@@ -39,6 +39,7 @@ public final class TestSuiteConfig {
      */
     private static final String NETWORK = "Network.";
     public static final String NETWORK_INTERFACE_ADDRESS = SDCCC + NETWORK + "InterfaceAddress";
+    public static final String NETWORK_MAX_WAIT = SDCCC + NETWORK + "MaxWait";
 
     /*
      * Consumer configuration

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/sdcri/testclient/TestClientImpl.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/sdcri/testclient/TestClientImpl.java
@@ -54,10 +54,10 @@ import org.somda.sdc.glue.consumer.event.WatchdogMessage;
 public class TestClientImpl extends AbstractIdleService implements TestClient, WatchdogObserver {
     private static final Logger LOG = LogManager.getLogger(TestClientImpl.class);
 
-    // max time to wait for futures
-    private static final Duration MAX_WAIT = Duration.ofSeconds(10);
     private static final String COULDN_T_CONNECT_TO_TARGET = "Couldn't connect to target";
 
+    // max time to wait for futures
+    private final Duration maxWait;
     private final Injector injector;
     private final String targetEpr;
     private final NetworkInterface networkInterface;
@@ -76,6 +76,7 @@ public class TestClientImpl extends AbstractIdleService implements TestClient, W
      *
      * @param targetDevicePr  DUT EPR address
      * @param adapterAddress  ip of the network interface to bind to
+     * @param maxWait         max waiting time to find and connect to target device
      * @param testClientUtil  test client utility
      * @param testRunObserver observer for invalidating test runs on unexpected errors
      */
@@ -83,6 +84,7 @@ public class TestClientImpl extends AbstractIdleService implements TestClient, W
     public TestClientImpl(
             @Named(TestSuiteConfig.CONSUMER_DEVICE_EPR) final String targetDevicePr,
             @Named(TestSuiteConfig.NETWORK_INTERFACE_ADDRESS) final String adapterAddress,
+            @Named(TestSuiteConfig.NETWORK_MAX_WAIT) final int maxWait,
             final TestClientUtil testClientUtil,
             final TestRunObserver testRunObserver) {
         this.injector = testClientUtil.getInjector();
@@ -90,6 +92,7 @@ public class TestClientImpl extends AbstractIdleService implements TestClient, W
         this.connector = injector.getInstance(SdcRemoteDevicesConnector.class);
         this.testRunObserver = testRunObserver;
         this.shouldBeConnected = new AtomicBoolean(false);
+        this.maxWait = Duration.ofSeconds(maxWait);
 
         // get interface for address
         try {
@@ -168,7 +171,7 @@ public class TestClientImpl extends AbstractIdleService implements TestClient, W
         client.probe(discoveryFilterBuilder.get());
 
         try {
-            targetXAddrs = xAddrs.get(MAX_WAIT.toSeconds(), TimeUnit.SECONDS);
+            targetXAddrs = xAddrs.get(maxWait.toSeconds(), TimeUnit.SECONDS);
         } catch (final InterruptedException | TimeoutException | ExecutionException e) {
             LOG.error("Couldn't find target with EPR {}", targetEpr, e);
             throw new IOException(COULDN_T_CONNECT_TO_TARGET);
@@ -181,7 +184,7 @@ public class TestClientImpl extends AbstractIdleService implements TestClient, W
 
         hostingServiceProxy = null;
         try {
-            hostingServiceProxy = hostingServiceFuture.get(MAX_WAIT.toSeconds(), TimeUnit.SECONDS);
+            hostingServiceProxy = hostingServiceFuture.get(maxWait.toSeconds(), TimeUnit.SECONDS);
         } catch (final InterruptedException | TimeoutException | ExecutionException e) {
             LOG.error("Couldn't connect to EPR {}", targetEpr, e);
             throw new IOException(COULDN_T_CONNECT_TO_TARGET);
@@ -194,7 +197,7 @@ public class TestClientImpl extends AbstractIdleService implements TestClient, W
             remoteDeviceFuture = connector.connect(
                     hostingServiceProxy,
                     ConnectConfiguration.create(ConnectConfiguration.ALL_EPISODIC_AND_WAVEFORM_REPORTS));
-            sdcRemoteDevice = remoteDeviceFuture.get(MAX_WAIT.toSeconds(), TimeUnit.SECONDS);
+            sdcRemoteDevice = remoteDeviceFuture.get(maxWait.toSeconds(), TimeUnit.SECONDS);
         } catch (final PrerequisitesException | InterruptedException | ExecutionException | TimeoutException e) {
             LOG.error("Couldn't attach to remote mdib and subscriptions for {}", targetEpr, e);
             throw new IOException("Couldn't attach to remote mdib and subscriptions");
@@ -207,11 +210,11 @@ public class TestClientImpl extends AbstractIdleService implements TestClient, W
     public synchronized void disconnect() throws TimeoutException {
         shouldBeConnected.set(false);
         if (sdcRemoteDevice != null) {
-            sdcRemoteDevice.stopAsync().awaitTerminated(MAX_WAIT.toSeconds(), TimeUnit.SECONDS);
+            sdcRemoteDevice.stopAsync().awaitTerminated(maxWait.toSeconds(), TimeUnit.SECONDS);
             sdcRemoteDevice = null;
         }
         hostingServiceProxy = null;
-        client.stopAsync().awaitTerminated(MAX_WAIT.toSeconds(), TimeUnit.SECONDS);
+        client.stopAsync().awaitTerminated(maxWait.toSeconds(), TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
Configuration option to change the maximum waiting time during connection establishment added.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
