### PR TITLE
Add Metainformation to Log and Result XML files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - requirement test execution logging
 - test for glue:R0056
+- SDCcc version is written to the Log and into the Result XML files.
 
 ### Changed
 - SDCri version 4.1.0-SNAPSHOT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - requirement test execution logging
 - test for glue:R0056
 - configuration option to change the maximum waiting time during connection establishment
-- SDCcc version is written to the Log and into the Result XML files.
+- SDCcc version is written to the log and into the result XML files.
 
 ### Changed
 - SDCri version 4.1.0-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,31 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Build-Time>${maven.build.timestamp}</Build-Time>
+                        </manifestEntries>
+                        <manifestSections>
+                            <manifestSection>
+                                <name>Versions</name>
+                                <manifestEntries>
+                                    <Implementation-Version>${project.version}</Implementation-Version>
+                                </manifestEntries>
+                            </manifestSection>
+                        </manifestSections>
+                    </archive>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -583,7 +583,13 @@ public class TestSuite {
                     + " Please see the Log for more Details.");
         });
 
-        LOG.info("Starting SDCcc");
+        String versionString = triggerOnErrorOrWorseLogAppender.getClass().getPackage().getImplementationVersion();
+        if (versionString != null) {
+            versionString = " version " + versionString;
+        } else {
+            versionString = "";
+        }
+        LOG.info("Starting SDCcc" + versionString);
 
         try {
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -583,7 +583,8 @@ public class TestSuite {
                     + " Please see the Log for more Details.");
         });
 
-        String versionString = triggerOnErrorOrWorseLogAppender.getClass().getPackage().getImplementationVersion();
+        String versionString =
+                triggerOnErrorOrWorseLogAppender.getClass().getPackage().getImplementationVersion();
         if (versionString != null) {
             versionString = " version " + versionString;
         } else {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -590,7 +590,7 @@ public class TestSuite {
         } else {
             versionString = "";
         }
-        LOG.info("Starting SDCcc" + versionString);
+        LOG.info("Starting SDCcc {}", versionString);
 
         try {
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
@@ -140,6 +140,11 @@ public class XmlReportWriter {
         xmlWriter.writeStartElement("properties");
 
         final var properties = System.getProperties();
+        String implementationVersion = this.getClass().getPackage().getImplementationVersion();
+        if (implementationVersion == null) {
+            implementationVersion = "unknown";
+        }
+        properties.setProperty("SDCcc version", implementationVersion);
         for (String stringPropertyName : properties.stringPropertyNames()) {
             xmlWriter.writeEmptyElement("property");
             xmlWriter.writeAttribute("name", stringPropertyName);


### PR DESCRIPTION
In Standup on 2023.04.27 we decided that adding only the SDCcc version would be sufficient metainformation.
This PR hence does exactly that.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
