### PR TITLE
Fix Wrong manipulation data for setComponentActivation in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - the occurrence of the sequence ']]>' in the content of CDATA sections in the result xmls
+- setComponentActivation stores incorrect manipulation data in the database resulting in no test data being available for 5-4-7_* tests
 
 ## [7.0.1] - 2023-03-17
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
@@ -291,7 +291,7 @@ public class GRpcManipulations implements Manipulations {
                 List.of(
                         new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
                         new ImmutablePair<>(
-                                Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activationState.toString())));
+                                Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activationState.value())));
     }
 
     @Override
@@ -330,7 +330,7 @@ public class GRpcManipulations implements Manipulations {
                         new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
                         new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, category.value()),
                         new ImmutablePair<>(
-                                Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activation.toString())));
+                                Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activation.value())));
     }
 
     @Override

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
@@ -369,11 +369,7 @@ public class GRpcManipulations implements Manipulations {
         final var methodName = walker.walk(
                 s -> s.map(StackWalker.StackFrame::getMethodName).skip(1).findFirst());
         final var manipulation = manipulationInfoFactory.create(
-                startTime,
-                endTime,
-                getResultForPersisting(result),
-                methodName.orElseThrow(),
-                parameter.getParameterData());
+                startTime, endTime, getResultForPersisting(result), methodName.orElseThrow(), parameter);
         manipulation.addToStorage();
         return result;
     }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
@@ -9,6 +9,7 @@ package com.draeger.medical.sdccc.manipulation;
 
 import com.draeger.medical.sdccc.configuration.TestSuiteConfig;
 import com.draeger.medical.sdccc.messages.guice.ManipulationInfoFactory;
+import com.draeger.medical.sdccc.tests.util.ManipulationParameterUtil;
 import com.draeger.medical.sdccc.util.Constants;
 import com.draeger.medical.t2iapi.BasicRequests;
 import com.draeger.medical.t2iapi.BasicResponses;
@@ -35,14 +36,11 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.StringValue;
 import io.grpc.Channel;
 import io.grpc.ManagedChannelBuilder;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.xml.namespace.QName;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.somda.sdc.biceps.model.participant.AbstractDescriptor;
@@ -131,16 +129,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.setLocationDetail(locationDetail),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_LOCATION_DETAIL,
-                        String.format(
-                                "poC=%s, " + "room=%s, " + "bed=%s, " + "facility=%s, " + "building=%s, " + "floor=%s",
-                                locationDetail.getPoC(),
-                                locationDetail.getRoom(),
-                                locationDetail.getBed(),
-                                locationDetail.getFacility(),
-                                locationDetail.getBuilding(),
-                                locationDetail.getFloor()))));
+                ManipulationParameterUtil.buildLocationDetailManipulationParameterData(locationDetail));
     }
 
     @Override
@@ -159,7 +148,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.getRemovableDescriptorsOfClass(descriptorClass),
                 res -> res.getStatus().getResult(),
                 DeviceResponses.GetRemovableDescriptorsResponse::getHandleList,
-                Collections.emptyList());
+                ManipulationParameterUtil.buildEmptyManipulationParameterData());
     }
 
     @Override
@@ -171,7 +160,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.removeDescriptor(handle),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle)));
+                ManipulationParameterUtil.buildHandleManipulationParameterData(handle));
     }
 
     @Override
@@ -183,7 +172,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.insertDescriptor(handle),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle)));
+                ManipulationParameterUtil.buildHandleManipulationParameterData(handle));
     }
 
     @Override
@@ -193,7 +182,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.sendHello(),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                Collections.emptyList());
+                ManipulationParameterUtil.buildEmptyManipulationParameterData());
     }
 
     @Override
@@ -214,10 +203,8 @@ public class GRpcManipulations implements Manipulations {
                     }
                     return Optional.of(msg.getContextStateHandle());
                 },
-                List.of(
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, descriptorHandle),
-                        new ImmutablePair<>(
-                                Constants.MANIPULATION_PARAMETER_CONTEXT_ASSOCIATION, association.value())));
+                ManipulationParameterUtil.buildContextAssociationManipulationParameterData(
+                        descriptorHandle, association));
     }
 
     @Override
@@ -232,10 +219,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.setAlertActivation(handle, activationState),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
-                        new ImmutablePair<>(
-                                Constants.MANIPULATION_PARAMETER_ALERT_ACTIVATION, activationState.value())));
+                ManipulationParameterUtil.buildAlertActivationManipulationParameterData(handle, activationState));
     }
 
     @Override
@@ -250,9 +234,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.setAlertConditionPresence(handle, presence),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_PRESENCE, String.format("%s", presence))));
+                ManipulationParameterUtil.buildAlertConditionPresenceManipulationParameterData(handle, presence));
     }
 
     @Override
@@ -269,11 +251,8 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.setSystemSignalActivation(handle, manifestation, activation),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
-                        new ImmutablePair<>(
-                                Constants.MANIPULATION_PARAMETER_ALERT_SIGNAL_ACTIVATION, manifestation.value()),
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_ALERT_ACTIVATION, activation.value())));
+                ManipulationParameterUtil.buildSystemSignalActivationManipulationParameterData(
+                        handle, manifestation, activation));
     }
 
     @Override
@@ -288,10 +267,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.setComponentActivation(handle, activationState),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
-                        new ImmutablePair<>(
-                                Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activationState.value())));
+                ManipulationParameterUtil.buildComponentActivationManipulationParameterData(handle, activationState));
     }
 
     @Override
@@ -306,9 +282,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.setMetricQualityValidity(handle, validity),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_MEASUREMENT_VALIDITY, validity.value())));
+                ManipulationParameterUtil.buildMetricQualityValidityManipulationParameterData(handle, validity));
     }
 
     @Override
@@ -326,11 +300,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.setMetricStatus(handle, category, activation),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, category.value()),
-                        new ImmutablePair<>(
-                                Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activation.value())));
+                ManipulationParameterUtil.buildMetricStatusManipulationParameterData(handle, category, activation));
     }
 
     @Override
@@ -343,7 +313,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.triggerDescriptorUpdate(handle),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_QNAME, handle)));
+                ManipulationParameterUtil.buildHandleManipulationParameterData(handle));
     }
 
     @Override
@@ -359,7 +329,7 @@ public class GRpcManipulations implements Manipulations {
                 v -> fallback.triggerReport(report),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                List.of(new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_QNAME, report.toString())));
+                ManipulationParameterUtil.buildTriggerReportManipulationParameterData(report));
     }
 
     private Optional<MetricTypes.MetricStatus> getMetricStatus(final ComponentActivation activation) {
@@ -392,14 +362,18 @@ public class GRpcManipulations implements Manipulations {
             final Function<Void, RES> fallbackFunc,
             final Function<GRES, ResponseTypes.Result> statusExtractor,
             final Function<GRES, RES> responseExtractor,
-            final List<Pair<String, String>> parameter) {
+            final ManipulationParameterUtil.ManipulationParameterData parameter) {
         final var startTime = System.nanoTime();
         final var result = performCall(func, fallbackFunc, statusExtractor, responseExtractor);
         final var endTime = System.nanoTime();
         final var methodName = walker.walk(
                 s -> s.map(StackWalker.StackFrame::getMethodName).skip(1).findFirst());
         final var manipulation = manipulationInfoFactory.create(
-                startTime, endTime, getResultForPersisting(result), methodName.orElseThrow(), parameter);
+                startTime,
+                endTime,
+                getResultForPersisting(result),
+                methodName.orElseThrow(),
+                parameter.getParameterData());
         manipulation.addToStorage();
         return result;
     }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/ManipulationInfo.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/ManipulationInfo.java
@@ -7,6 +7,7 @@
 
 package com.draeger.medical.sdccc.messages;
 
+import com.draeger.medical.sdccc.tests.util.ManipulationParameterUtil;
 import com.draeger.medical.t2iapi.ResponseTypes;
 import com.google.inject.assistedinject.Assisted;
 import java.util.List;
@@ -32,14 +33,14 @@ public class ManipulationInfo implements DatabaseEntry {
             @Assisted(value = "stopTime") final long finishTimestamp,
             @Assisted final ResponseTypes.Result result,
             @Assisted(value = "methodName") final String methodName,
-            @Assisted final List<Pair<String, String>> parameters,
+            @Assisted final ManipulationParameterUtil.ManipulationParameterData parameters,
             final MessageStorage messageStorage) {
 
         this.startTimestamp = startTimestamp;
         this.finishTimestamp = finishTimestamp;
         this.result = result;
         this.methodName = methodName;
-        this.parameters = parameters;
+        this.parameters = parameters.getParameterData();
         storage = messageStorage;
     }
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
@@ -19,6 +19,7 @@ import com.draeger.medical.sdccc.messages.mapping.MdibVersionGroupEntity;
 import com.draeger.medical.sdccc.messages.mapping.MdibVersionGroupEntity_;
 import com.draeger.medical.sdccc.messages.mapping.MessageContent;
 import com.draeger.medical.sdccc.messages.mapping.MessageContent_;
+import com.draeger.medical.sdccc.tests.util.ManipulationParameterUtil;
 import com.draeger.medical.sdccc.util.Constants;
 import com.draeger.medical.sdccc.util.TestRunObserver;
 import com.draeger.medical.sdccc.util.XPathExtractor;
@@ -1617,19 +1618,20 @@ public class MessageStorage implements AutoCloseable {
      * <p>
      * Manipulations are sorted by their timestamp.
      *
-     * @param parameters       of the manipulation
+     * @param parameter       of the manipulation
      * @param manipulationName to match manipulation data against
      * @return container with stream of all matching {@linkplain ManipulationData}s
      * @throws IOException if storage is closed
      */
     public GetterResult<ManipulationData> getManipulationDataByParametersAndManipulation(
-            final List<Pair<String, String>> parameters, final String manipulationName) throws IOException {
+            final ManipulationParameterUtil.ManipulationParameterData parameter, final String manipulationName)
+            throws IOException {
         if (this.closed.get()) {
             LOG.error(GET_MANIPULATION_DATA_BY_MANIPULATION);
             throw new IOException(GET_MANIPULATION_DATA_BY_MANIPULATION);
         }
 
-        if (parameters.isEmpty()) {
+        if (parameter.getParameterData().isEmpty()) {
             return getManipulationDataByManipulation(manipulationName);
         }
 
@@ -1647,7 +1649,7 @@ public class MessageStorage implements AutoCloseable {
 
             final List<Predicate> parameterExistPredicates = new ArrayList<>();
 
-            for (var parameter : parameters) {
+            for (var parameterData : parameter.getParameterData()) {
                 final var parameterSubquery = criteria.subquery(ManipulationParameter.class);
                 final Root<ManipulationParameter> manipulationParameterRoot =
                         parameterSubquery.from(ManipulationParameter.class);
@@ -1660,10 +1662,10 @@ public class MessageStorage implements AutoCloseable {
                                 criteriaBuilder.and(
                                         criteriaBuilder.equal(
                                                 manipulationParameterRoot.get(ManipulationParameter_.parameterName),
-                                                parameter.getKey()),
+                                                parameterData.getKey()),
                                         criteriaBuilder.equal(
                                                 manipulationParameterRoot.get(ManipulationParameter_.parameterValue),
-                                                parameter.getValue()))));
+                                                parameterData.getValue()))));
                 parameterExistPredicates.add(criteriaBuilder.exists(parameterSubquery));
             }
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
@@ -69,7 +69,6 @@ import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.input.BOMInputStream;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.Session;
@@ -804,7 +803,7 @@ public class MessageStorage implements AutoCloseable {
             final long finishTime,
             final ResponseTypes.Result result,
             final String name,
-            final List<Pair<String, String>> parameters) {
+            final ManipulationParameterUtil.ManipulationParameterData parameters) {
         final var manipulation = new ManipulationInfo(startTime, finishTime, result, name, parameters, this);
         manipulation.addToStorage();
     }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/guice/ManipulationInfoFactory.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/guice/ManipulationInfoFactory.java
@@ -8,10 +8,9 @@
 package com.draeger.medical.sdccc.messages.guice;
 
 import com.draeger.medical.sdccc.messages.ManipulationInfo;
+import com.draeger.medical.sdccc.tests.util.ManipulationParameterUtil;
 import com.draeger.medical.t2iapi.ResponseTypes;
 import com.google.inject.assistedinject.Assisted;
-import java.util.List;
-import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Guice factory for {@linkplain ManipulationInfo}.
@@ -32,5 +31,5 @@ public interface ManipulationInfoFactory {
             @Assisted(value = "stopTime") long stopTimestamp,
             @Assisted ResponseTypes.Result result,
             @Assisted(value = "methodName") String methodName,
-            @Assisted List<Pair<String, String>> parameters);
+            @Assisted ManipulationParameterUtil.ManipulationParameterData parameters);
 }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
@@ -21,16 +21,15 @@ import com.draeger.medical.sdccc.tests.annotations.RequirePrecondition;
 import com.draeger.medical.sdccc.tests.annotations.TestDescription;
 import com.draeger.medical.sdccc.tests.annotations.TestIdentifier;
 import com.draeger.medical.sdccc.tests.util.ImpliedValueUtil;
+import com.draeger.medical.sdccc.tests.util.ManipulationParameterUtil;
 import com.draeger.medical.sdccc.tests.util.NoTestData;
 import com.draeger.medical.sdccc.util.Constants;
 import com.draeger.medical.t2iapi.ResponseTypes;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -363,9 +362,7 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
             throws NoTestData {
         final var successfulReportsSeen = new AtomicBoolean(false);
         try (final var manipulations = messageStorage.getManipulationDataByParametersAndManipulation(
-                List.of(
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, category.value()),
-                        new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activation.value())),
+                ManipulationParameterUtil.buildMetricStatusManipulationParameterDataWithoutHandle(category, activation),
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS)) {
             assertTestData(
                     manipulations.areObjectsPresent(), String.format(NO_SET_METRIC_STATUS_MANIPULATION, category));

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ManipulationParameterUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ManipulationParameterUtil.java
@@ -1,0 +1,214 @@
+/*
+ * This Source Code Form is subject to the terms of the MIT License.
+ * Copyright (c) 2023 Draegerwerk AG & Co. KGaA.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.draeger.medical.sdccc.tests.util;
+
+import com.draeger.medical.sdccc.util.Constants;
+import java.util.Collections;
+import java.util.List;
+import javax.xml.namespace.QName;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.somda.sdc.biceps.model.participant.AlertActivation;
+import org.somda.sdc.biceps.model.participant.AlertSignalManifestation;
+import org.somda.sdc.biceps.model.participant.ComponentActivation;
+import org.somda.sdc.biceps.model.participant.ContextAssociation;
+import org.somda.sdc.biceps.model.participant.LocationDetail;
+import org.somda.sdc.biceps.model.participant.MeasurementValidity;
+import org.somda.sdc.biceps.model.participant.MetricCategory;
+
+/**
+ * Utility which provides manipulation parameter.
+ */
+public final class ManipulationParameterUtil {
+
+    private ManipulationParameterUtil() {}
+
+    /**
+     * Build empty manipulation parameter data when the manipulation call does not need any parameters.
+     *
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildEmptyManipulationParameterData() {
+        return new ManipulationParameterData(Collections.emptyList());
+    }
+
+    /**
+     * Build manipulation parameter data containing just the handle that is needed for the manipulation.
+     *
+     * @param handle for which manipulation parameter data will be built.
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildHandleManipulationParameterData(final String handle) {
+        return new ManipulationParameterData(
+                List.of(new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle)));
+    }
+
+    /**
+     * Build manipulation parameter data containing the location detail that is needed for the manipulation.
+     *
+     * @param locationDetail for which manipulation parameter data will be built.
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildLocationDetailManipulationParameterData(
+            final LocationDetail locationDetail) {
+        return new ManipulationParameterData(List.of(new ImmutablePair<>(
+                Constants.MANIPULATION_PARAMETER_LOCATION_DETAIL,
+                String.format(
+                        "poC=%s, " + "room=%s, " + "bed=%s, " + "facility=%s, " + "building=%s, " + "floor=%s",
+                        locationDetail.getPoC(),
+                        locationDetail.getRoom(),
+                        locationDetail.getBed(),
+                        locationDetail.getFacility(),
+                        locationDetail.getBuilding(),
+                        locationDetail.getFloor()))));
+    }
+
+    /**
+     * Build manipulation parameter data containing the handle and the context association for the context state with
+     * association to be created.
+     *
+     * @param handle of the context state
+     * @param association of the context state
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildContextAssociationManipulationParameterData(
+            final String handle, final ContextAssociation association) {
+        return new ManipulationParameterData(List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_CONTEXT_ASSOCIATION, association.value())));
+    }
+
+    /**
+     * Build manipulation parameter data containing the handle of the alert and the alert activation to set.
+     *
+     * @param handle of the alert
+     * @param alertActivation to which the alert should be set
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildAlertActivationManipulationParameterData(
+            final String handle, final AlertActivation alertActivation) {
+        return new ManipulationParameterData(List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_ALERT_ACTIVATION, alertActivation.value())));
+    }
+
+    /**
+     * Build manipulation parameter data containing the handle of the alert condition and the presence to set.
+     *
+     * @param handle of the alert condition
+     * @param presence to which the alert condition should be set
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildAlertConditionPresenceManipulationParameterData(
+            final String handle, final boolean presence) {
+        return new ManipulationParameterData(List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_PRESENCE, String.format("%s", presence))));
+    }
+
+    /**
+     * Build manipulation parameter data containing the handle and manifestation of the alert system and the alert
+     * activation to set.
+     *
+     * @param handle of the alert system
+     * @param manifestation of the alert system
+     * @param activation to which the alert system should be set
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildSystemSignalActivationManipulationParameterData(
+            final String handle, final AlertSignalManifestation manifestation, final AlertActivation activation) {
+        return new ManipulationParameterData(List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_ALERT_SIGNAL_MANIFESTATION, manifestation.value()),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_ALERT_ACTIVATION, activation.value())));
+    }
+
+    /**
+     * Build manipulation parameter data containing the handle of the device component and the component activation to set.
+     *
+     * @param handle of the device component
+     * @param activation to which the component should be set
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildComponentActivationManipulationParameterData(
+            final String handle, final ComponentActivation activation) {
+        return new ManipulationParameterData(List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activation.value())));
+    }
+
+    /**
+     * Build manipulation parameter data containing the handle of the metric and the validity to set.
+     *
+     * @param handle of the metric
+     * @param validity to which the metric should be set
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildMetricQualityValidityManipulationParameterData(
+            final String handle, final MeasurementValidity validity) {
+        return new ManipulationParameterData(List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_MEASUREMENT_VALIDITY, validity.value())));
+    }
+
+    /**
+     * Build manipulation parameter data containing the handle, category and activation of the metric to set the status for.
+     *
+     * @param handle of the metric
+     * @param category of the metric
+     * @param activation of the metric
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildMetricStatusManipulationParameterData(
+            final String handle, final MetricCategory category, final ComponentActivation activation) {
+        return new ManipulationParameterData(List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, category.value()),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activation.value())));
+    }
+
+    /**
+     * Build manipulation parameter data containing the category and activation of the metric.
+     *
+     * @param category of the metric
+     * @param activation of the metric
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildMetricStatusManipulationParameterDataWithoutHandle(
+            final MetricCategory category, final ComponentActivation activation) {
+        return new ManipulationParameterData(List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, category.value()),
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activation.value())));
+    }
+
+    /**
+     * Build manipulation parameter data containing the report to trigger.
+     *
+     * @param report to trigger.
+     * @return the manipulation parameter data
+     */
+    public static ManipulationParameterData buildTriggerReportManipulationParameterData(final QName report) {
+        return new ManipulationParameterData(
+                List.of(new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_QNAME, report.toString())));
+    }
+
+    /**
+     * Wrapper for manipulation parameter.
+     */
+    public static class ManipulationParameterData {
+        private final List<Pair<String, String>> data;
+
+        ManipulationParameterData(final List<Pair<String, String>> data) {
+            this.data = data;
+        }
+
+        public List<Pair<String, String>> getParameterData() {
+            return data;
+        }
+    }
+}

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/util/Constants.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/util/Constants.java
@@ -226,7 +226,7 @@ public final class Constants {
     public static final String MANIPULATION_PARAMETER_CONTEXT_ASSOCIATION = "ContextAssociation";
     public static final String MANIPULATION_PARAMETER_ALERT_ACTIVATION = "AlertActivation";
     public static final String MANIPULATION_PARAMETER_PRESENCE = "Presence";
-    public static final String MANIPULATION_PARAMETER_ALERT_SIGNAL_ACTIVATION = "AlertSignalManifestation";
+    public static final String MANIPULATION_PARAMETER_ALERT_SIGNAL_MANIFESTATION = "AlertSignalManifestation";
     public static final String MANIPULATION_PARAMETER_METRIC_CATEGORY = "MetricCategory";
     public static final String MANIPULATION_PARAMETER_COMPONENT_ACTIVATION = "ComponentActivation";
     public static final String MANIPULATION_PARAMETER_MEASUREMENT_VALIDITY = "MeasurementValidity";

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.draeger.medical.biceps.model.participant.ComponentActivation;
 import com.draeger.medical.sdccc.messages.guice.MessageFactory;
 import com.draeger.medical.sdccc.messages.mapping.ManipulationData;
 import com.draeger.medical.sdccc.messages.mapping.ManipulationParameter;
@@ -51,7 +50,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.xml.namespace.QName;
 import org.apache.commons.io.ByteOrderMark;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -1282,13 +1280,28 @@ public class TestMessageStorage {
             final var expectedMethodName = "someManipulation";
 
             final var manipulation = new ManipulationInfo(
-                    startTime1, finishTime1, result, expectedMethodName, List.of(), messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    expectedMethodName,
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             manipulation.addToStorage();
             final var manipulation2 = new ManipulationInfo(
-                    startTime1, finishTime1, result, expectedMethodName, List.of(), messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    expectedMethodName,
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             manipulation2.addToStorage();
             final var manipulation3 = new ManipulationInfo(
-                    startTime1, finishTime1, result, expectedMethodName, List.of(), messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    expectedMethodName,
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             manipulation3.addToStorage();
             messageStorage.flush();
 
@@ -1348,7 +1361,12 @@ public class TestMessageStorage {
             }
 
             final var manipulation = new ManipulationInfo(
-                    1000, 2000, ResponseTypes.Result.RESULT_SUCCESS, "setMetricStatus", List.of(), messageStorage);
+                    1000,
+                    2000,
+                    ResponseTypes.Result.RESULT_SUCCESS,
+                    "setMetricStatus",
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             manipulation.addToStorage();
 
             assertTimeoutPreemptively(
@@ -1505,10 +1523,8 @@ public class TestMessageStorage {
             final var finishTime1 = 1500;
             final var result = ResponseTypes.Result.RESULT_SUCCESS;
             final var methodName1 = "setMetricStatus";
-            final List<Pair<String, String>> parameters1 = List.of(
-                    new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, "someHandle"),
-                    new ImmutablePair<>(
-                            Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+            final var parameters1 = ManipulationParameterUtil.buildComponentActivationManipulationParameterData(
+                    "someHandle", org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
             final var manipulationInfo =
                     new ManipulationInfo(startTime1, finishTime1, result, methodName1, parameters1, messageStorage);
             manipulationInfo.addToStorage();
@@ -1517,7 +1533,12 @@ public class TestMessageStorage {
             final var finishTime2 = 1300;
             final var methodName2 = "sendHello";
             final var manipulationInfo2 = new ManipulationInfo(
-                    startTime2, finishTime2, result, methodName2, Collections.emptyList(), messageStorage);
+                    startTime2,
+                    finishTime2,
+                    result,
+                    methodName2,
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             manipulationInfo2.addToStorage();
 
             messageStorage.flush();
@@ -1571,17 +1592,17 @@ public class TestMessageStorage {
             final var expectedParameters = ManipulationParameterUtil.buildComponentActivationManipulationParameterData(
                     "someHandle", org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
             final var expectedManipulationInfo = new ManipulationInfo(
-                    startTime1,
-                    finishTime1,
-                    result,
-                    expectedMethodName,
-                    expectedParameters.getParameterData(),
-                    messageStorage);
+                    startTime1, finishTime1, result, expectedMethodName, expectedParameters, messageStorage);
             expectedManipulationInfo.addToStorage();
 
             // same manipulation without parameter
             final var manipulationWithoutParams = new ManipulationInfo(
-                    startTime1, finishTime1, result, expectedMethodName, Collections.emptyList(), messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    expectedMethodName,
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             manipulationWithoutParams.addToStorage();
 
             // same manipulation with different handle parameter
@@ -1589,26 +1610,21 @@ public class TestMessageStorage {
                     "someOtherHandle", org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
 
             final var manipulationDifferentHandle = new ManipulationInfo(
-                    startTime1,
-                    finishTime1,
-                    result,
-                    expectedMethodName,
-                    parameters2.getParameterData(),
-                    messageStorage);
+                    startTime1, finishTime1, result, expectedMethodName, parameters2, messageStorage);
             manipulationDifferentHandle.addToStorage();
 
             // different manipulation with same parameter
             final var differentManipulationSameParam = new ManipulationInfo(
-                    startTime1,
-                    finishTime1,
-                    result,
-                    "setComponentActivation",
-                    expectedParameters.getParameterData(),
-                    messageStorage);
+                    startTime1, finishTime1, result, "setComponentActivation", expectedParameters, messageStorage);
             differentManipulationSameParam.addToStorage();
 
-            final var otherManipulation =
-                    new ManipulationInfo(1200, 1300, result, "sendHello", Collections.emptyList(), messageStorage);
+            final var otherManipulation = new ManipulationInfo(
+                    1200,
+                    1300,
+                    result,
+                    "sendHello",
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             otherManipulation.addToStorage();
 
             messageStorage.flush();
@@ -1637,12 +1653,7 @@ public class TestMessageStorage {
             }
             // add second manipulation
             final var secondManipulation = new ManipulationInfo(
-                    startTime1,
-                    finishTime1,
-                    result,
-                    expectedMethodName,
-                    expectedParameters.getParameterData(),
-                    messageStorage);
+                    startTime1, finishTime1, result, expectedMethodName, expectedParameters, messageStorage);
             secondManipulation.addToStorage();
             messageStorage.flush();
             {
@@ -1673,54 +1684,49 @@ public class TestMessageStorage {
             final var finishTime1 = 1500;
             final var result = ResponseTypes.Result.RESULT_SUCCESS;
             final var expectedMethodName = "setMetricStatus";
-            final var expectedParameters = ManipulationParameterUtil.buildHandleManipulationParameterData("someHandle");
+            final var expectedHandle = "someHandle";
+            final var expectedParameters =
+                    ManipulationParameterUtil.buildHandleManipulationParameterData(expectedHandle);
+            final var expectedParameters2 = ManipulationParameterUtil.buildComponentActivationManipulationParameterData(
+                    expectedHandle, org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
 
             final var expectedManipulationInfo = new ManipulationInfo(
-                    startTime1,
-                    finishTime1,
-                    result,
-                    expectedMethodName,
-                    List.of(
-                            expectedParameters.getParameterData().get(0),
-                            new ImmutablePair<>(
-                                    Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
-                                    ComponentActivation.ON.value())),
-                    messageStorage);
+                    startTime1, finishTime1, result, expectedMethodName, expectedParameters2, messageStorage);
             expectedManipulationInfo.addToStorage();
 
             // same manipulation without parameter
             final var manipulationWithoutParams = new ManipulationInfo(
-                    startTime1, finishTime1, result, expectedMethodName, List.of(), messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    expectedMethodName,
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             manipulationWithoutParams.addToStorage();
 
             // same manipulation with different handle parameter
             final var parameters2 = ManipulationParameterUtil.buildComponentActivationManipulationParameterData(
                     "someOtherHandle", org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
             final var manipulationDifferentHandle = new ManipulationInfo(
-                    startTime1,
-                    finishTime1,
-                    result,
-                    expectedMethodName,
-                    parameters2.getParameterData(),
-                    messageStorage);
+                    startTime1, finishTime1, result, expectedMethodName, parameters2, messageStorage);
             manipulationDifferentHandle.addToStorage();
 
             // different manipulation with same parameter
             final var methodName3 = "setComponentActivation";
             final var differentManipulationSameParam = new ManipulationInfo(
-                    startTime1,
-                    finishTime1,
-                    result,
-                    methodName3,
-                    expectedParameters.getParameterData(),
-                    messageStorage);
+                    startTime1, finishTime1, result, methodName3, expectedParameters, messageStorage);
             differentManipulationSameParam.addToStorage();
 
             final var startTime2 = 1200;
             final var finishTime2 = 1300;
             final var methodName2 = "sendHello";
             final var otherManipulation = new ManipulationInfo(
-                    startTime2, finishTime2, result, methodName2, Collections.emptyList(), messageStorage);
+                    startTime2,
+                    finishTime2,
+                    result,
+                    methodName2,
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             otherManipulation.addToStorage();
 
             messageStorage.flush();
@@ -1766,10 +1772,14 @@ public class TestMessageStorage {
             final var finishTime1 = 1500;
             final var result = ResponseTypes.Result.RESULT_SUCCESS;
             final var methodName1 = "setMetricStatus";
-            final List<Pair<String, String>> parameters1 =
-                    List.of(new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, "someHandle"));
-            final var manipulation1 =
-                    new ManipulationInfo(startTime1, finishTime1, result, methodName1, List.of(), messageStorage);
+            final var parameters1 = ManipulationParameterUtil.buildHandleManipulationParameterData("someHandle");
+            final var manipulation1 = new ManipulationInfo(
+                    startTime1,
+                    finishTime1,
+                    result,
+                    methodName1,
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             manipulation1.addToStorage();
 
             // same manipulation without parameter
@@ -1778,21 +1788,29 @@ public class TestMessageStorage {
             manipulation2.addToStorage();
 
             // same manipulation with different handle parameter
-            final List<Pair<String, String>> parameters2 = List.of(
-                    new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, "someOtherHandle"),
-                    new ImmutablePair<>(
-                            Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+            final var parameters2 = ManipulationParameterUtil.buildComponentActivationManipulationParameterData(
+                    "someOtherHandle", org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
             final var manipulation3 =
                     new ManipulationInfo(startTime1, finishTime1, result, methodName1, parameters2, messageStorage);
             manipulation3.addToStorage();
 
             // different manipulation with same parameter
             final var manipulation4 = new ManipulationInfo(
-                    startTime1, finishTime1, result, "setComponentActivation", List.of(), messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    "setComponentActivation",
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             manipulation4.addToStorage();
 
-            final var manipulation5 =
-                    new ManipulationInfo(1200, 1300, result, "sendHello", Collections.emptyList(), messageStorage);
+            final var manipulation5 = new ManipulationInfo(
+                    1200,
+                    1300,
+                    result,
+                    "sendHello",
+                    ManipulationParameterUtil.buildEmptyManipulationParameterData(),
+                    messageStorage);
             manipulation5.addToStorage();
 
             messageStorage.flush();

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
@@ -26,6 +26,7 @@ import com.draeger.medical.sdccc.messages.guice.MessageFactory;
 import com.draeger.medical.sdccc.messages.mapping.ManipulationData;
 import com.draeger.medical.sdccc.messages.mapping.ManipulationParameter;
 import com.draeger.medical.sdccc.messages.mapping.MessageContent;
+import com.draeger.medical.sdccc.tests.util.ManipulationParameterUtil;
 import com.draeger.medical.sdccc.util.CertificateUtil;
 import com.draeger.medical.sdccc.util.Constants;
 import com.draeger.medical.sdccc.util.TestRunObserver;
@@ -1567,12 +1568,15 @@ public class TestMessageStorage {
             final var finishTime1 = 1500;
             final var result = ResponseTypes.Result.RESULT_SUCCESS;
             final var expectedMethodName = "setMetricStatus";
-            final List<Pair<String, String>> expectedParameters = List.of(
-                    new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, "someHandle"),
-                    new ImmutablePair<>(
-                            Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+            final var expectedParameters = ManipulationParameterUtil.buildComponentActivationManipulationParameterData(
+                    "someHandle", org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
             final var expectedManipulationInfo = new ManipulationInfo(
-                    startTime1, finishTime1, result, expectedMethodName, expectedParameters, messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    expectedMethodName,
+                    expectedParameters.getParameterData(),
+                    messageStorage);
             expectedManipulationInfo.addToStorage();
 
             // same manipulation without parameter
@@ -1581,17 +1585,26 @@ public class TestMessageStorage {
             manipulationWithoutParams.addToStorage();
 
             // same manipulation with different handle parameter
-            final List<Pair<String, String>> parameters2 = List.of(
-                    new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, "someOtherHandle"),
-                    new ImmutablePair<>(
-                            Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+            final var parameters2 = ManipulationParameterUtil.buildComponentActivationManipulationParameterData(
+                    "someOtherHandle", org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
+
             final var manipulationDifferentHandle = new ManipulationInfo(
-                    startTime1, finishTime1, result, expectedMethodName, parameters2, messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    expectedMethodName,
+                    parameters2.getParameterData(),
+                    messageStorage);
             manipulationDifferentHandle.addToStorage();
 
             // different manipulation with same parameter
             final var differentManipulationSameParam = new ManipulationInfo(
-                    startTime1, finishTime1, result, "setComponentActivation", expectedParameters, messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    "setComponentActivation",
+                    expectedParameters.getParameterData(),
+                    messageStorage);
             differentManipulationSameParam.addToStorage();
 
             final var otherManipulation =
@@ -1624,7 +1637,12 @@ public class TestMessageStorage {
             }
             // add second manipulation
             final var secondManipulation = new ManipulationInfo(
-                    startTime1, finishTime1, result, expectedMethodName, expectedParameters, messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    expectedMethodName,
+                    expectedParameters.getParameterData(),
+                    messageStorage);
             secondManipulation.addToStorage();
             messageStorage.flush();
             {
@@ -1655,8 +1673,7 @@ public class TestMessageStorage {
             final var finishTime1 = 1500;
             final var result = ResponseTypes.Result.RESULT_SUCCESS;
             final var expectedMethodName = "setMetricStatus";
-            final List<Pair<String, String>> expectedParameters =
-                    List.of(new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, "someHandle"));
+            final var expectedParameters = ManipulationParameterUtil.buildHandleManipulationParameterData("someHandle");
 
             final var expectedManipulationInfo = new ManipulationInfo(
                     startTime1,
@@ -1664,7 +1681,7 @@ public class TestMessageStorage {
                     result,
                     expectedMethodName,
                     List.of(
-                            expectedParameters.get(0),
+                            expectedParameters.getParameterData().get(0),
                             new ImmutablePair<>(
                                     Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION,
                                     ComponentActivation.ON.value())),
@@ -1677,18 +1694,26 @@ public class TestMessageStorage {
             manipulationWithoutParams.addToStorage();
 
             // same manipulation with different handle parameter
-            final List<Pair<String, String>> parameters2 = List.of(
-                    new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, "someOtherHandle"),
-                    new ImmutablePair<>(
-                            Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+            final var parameters2 = ManipulationParameterUtil.buildComponentActivationManipulationParameterData(
+                    "someOtherHandle", org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
             final var manipulationDifferentHandle = new ManipulationInfo(
-                    startTime1, finishTime1, result, expectedMethodName, parameters2, messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    expectedMethodName,
+                    parameters2.getParameterData(),
+                    messageStorage);
             manipulationDifferentHandle.addToStorage();
 
             // different manipulation with same parameter
             final var methodName3 = "setComponentActivation";
             final var differentManipulationSameParam = new ManipulationInfo(
-                    startTime1, finishTime1, result, methodName3, expectedParameters, messageStorage);
+                    startTime1,
+                    finishTime1,
+                    result,
+                    methodName3,
+                    expectedParameters.getParameterData(),
+                    messageStorage);
             differentManipulationSameParam.addToStorage();
 
             final var startTime2 = 1200;
@@ -1709,7 +1734,7 @@ public class TestMessageStorage {
                         assertEquals(expectedManipulationInfo.getFinishTimestamp(), message.getFinishTimestamp());
                         assertEquals(expectedManipulationInfo.getResult(), message.getResult());
                         assertEquals(expectedManipulationInfo.getMethodName(), message.getMethodName());
-                        for (var parameter : expectedParameters) {
+                        for (var parameter : expectedParameters.getParameterData()) {
                             assertTrue(message.getParameters().stream()
                                     .map(ManipulationParameter::getParameterName)
                                     .anyMatch(it -> it.equals(parameter.getKey())));
@@ -1774,7 +1799,7 @@ public class TestMessageStorage {
 
             {
                 try (final var inboundMessages = messageStorage.getManipulationDataByParametersAndManipulation(
-                        Collections.emptyList(), methodName1)) {
+                        ManipulationParameterUtil.buildEmptyManipulationParameterData(), methodName1)) {
                     final var count = new AtomicInteger(0);
                     inboundMessages.getStream().forEach(message -> {
                         assertEquals(methodName1, message.getMethodName());

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
@@ -25,6 +25,7 @@ import com.draeger.medical.sdccc.sdcri.testclient.TestClient;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClientUtil;
 import com.draeger.medical.sdccc.tests.InjectorTestBase;
 import com.draeger.medical.sdccc.tests.test_util.InjectorUtil;
+import com.draeger.medical.sdccc.tests.util.ManipulationParameterUtil;
 import com.draeger.medical.sdccc.tests.util.NoTestData;
 import com.draeger.medical.sdccc.util.CertificateUtil;
 import com.draeger.medical.sdccc.util.Constants;
@@ -48,8 +49,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -156,12 +155,11 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        // Component activation should be ON to be relevant for testRequirement54700.
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                // Component activation should be ON to be relevant for testRequirement54700.
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -200,11 +198,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -234,11 +231,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -266,11 +262,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -300,11 +295,11 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, RTSA_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                RTSA_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
+
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -331,11 +326,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -344,11 +338,10 @@ public class InvariantParticipantModelStatePartTestTest {
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START2,
@@ -379,11 +372,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -413,11 +405,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -449,11 +440,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be on
@@ -482,11 +472,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -515,11 +504,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -552,11 +540,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -586,11 +573,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -618,11 +604,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -653,11 +638,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, RTSA_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                RTSA_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -684,11 +668,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -697,11 +680,10 @@ public class InvariantParticipantModelStatePartTestTest {
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START2,
@@ -732,11 +714,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -766,11 +747,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -802,11 +782,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be on
@@ -835,11 +814,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -868,11 +846,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -905,11 +882,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -939,11 +915,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -971,11 +946,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -1003,17 +977,15 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
 
         messageStorageUtil.addManipulation(
                 storage,
@@ -1052,11 +1024,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -1086,11 +1057,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -1122,11 +1092,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be stndby
@@ -1155,11 +1124,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -1187,11 +1155,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -1224,11 +1191,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -1258,11 +1224,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -1290,11 +1255,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -1322,17 +1286,15 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
 
         messageStorageUtil.addManipulation(
                 storage,
@@ -1371,11 +1333,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -1405,11 +1366,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -1441,11 +1401,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be shtdn
@@ -1474,11 +1433,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -1506,11 +1464,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -1543,11 +1500,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -1577,11 +1533,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -1609,11 +1564,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -1642,17 +1596,15 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -1691,11 +1643,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -1725,11 +1676,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -1761,11 +1711,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be OFF
@@ -1794,11 +1743,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -1826,11 +1774,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -1863,11 +1810,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -1897,11 +1843,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -1929,11 +1874,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -1962,17 +1906,15 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -2011,11 +1953,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -2045,11 +1986,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -2081,11 +2021,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be FAIL
@@ -2114,11 +2053,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -2146,11 +2084,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -2183,11 +2120,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -2217,11 +2153,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -2248,11 +2183,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -2285,11 +2219,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -2297,11 +2230,10 @@ public class InvariantParticipantModelStatePartTestTest {
                 ResponseTypes.Result.RESULT_SUCCESS,
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START2,
@@ -2332,11 +2264,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -2366,11 +2297,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -2402,11 +2332,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be on
@@ -2435,11 +2364,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -2467,11 +2395,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -2504,11 +2431,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -2538,11 +2464,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -2569,11 +2494,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -2606,11 +2530,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -2619,11 +2542,10 @@ public class InvariantParticipantModelStatePartTestTest {
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START2,
@@ -2655,11 +2577,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -2689,11 +2610,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -2725,11 +2645,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be NotRdy
@@ -2758,11 +2677,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -2790,11 +2708,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -2827,11 +2744,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -2861,11 +2777,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -2892,11 +2807,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -2929,11 +2843,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -2942,11 +2855,10 @@ public class InvariantParticipantModelStatePartTestTest {
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START2,
@@ -2978,11 +2890,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -3012,11 +2923,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -3048,11 +2958,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be stndby
@@ -3081,11 +2990,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -3113,11 +3021,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -3150,11 +3057,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -3184,11 +3090,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -3215,11 +3120,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -3251,11 +3155,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -3264,11 +3167,10 @@ public class InvariantParticipantModelStatePartTestTest {
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START2,
@@ -3300,11 +3202,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -3334,11 +3235,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -3370,11 +3270,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be shtdn
@@ -3403,11 +3302,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -3435,11 +3333,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -3472,11 +3369,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -3508,11 +3404,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -3539,11 +3434,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -3571,11 +3465,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -3584,11 +3477,10 @@ public class InvariantParticipantModelStatePartTestTest {
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START2,
@@ -3619,11 +3511,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -3653,11 +3544,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -3689,11 +3579,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be OFF
@@ -3722,11 +3611,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -3754,11 +3642,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -3791,11 +3678,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -3827,11 +3713,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -3858,11 +3743,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -3890,11 +3774,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -3903,11 +3786,10 @@ public class InvariantParticipantModelStatePartTestTest {
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START2,
@@ -3938,11 +3820,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -3972,11 +3853,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -4008,11 +3888,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be FAIL
@@ -4041,11 +3920,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -4073,11 +3951,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -4110,11 +3987,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -4144,11 +4020,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -4175,11 +4050,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -4208,11 +4082,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -4220,11 +4093,10 @@ public class InvariantParticipantModelStatePartTestTest {
                 ResponseTypes.Result.RESULT_SUCCESS,
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START2,
@@ -4255,11 +4127,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -4289,11 +4160,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -4325,11 +4195,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be on
@@ -4358,11 +4227,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -4390,11 +4258,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.ON.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -4427,11 +4294,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -4461,11 +4327,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, MSRMT_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.MSRMT.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MSRMT_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -4492,11 +4357,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -4526,11 +4390,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -4538,11 +4401,10 @@ public class InvariantParticipantModelStatePartTestTest {
                 ResponseTypes.Result.RESULT_SUCCESS,
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START2,
@@ -4573,11 +4435,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -4607,11 +4468,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -4643,11 +4503,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be not_rdy
@@ -4676,11 +4535,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -4708,11 +4566,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.NOT_RDY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -4745,11 +4602,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -4779,11 +4635,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -4810,11 +4665,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -4842,17 +4696,15 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
 
         messageStorageUtil.addManipulation(
                 storage,
@@ -4891,11 +4743,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -4925,11 +4776,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -4961,11 +4811,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be stndby
@@ -4994,11 +4843,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -5026,11 +4874,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.STND_BY.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -5063,11 +4910,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -5097,11 +4943,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -5128,11 +4973,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -5160,17 +5004,15 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
 
         messageStorageUtil.addManipulation(
                 storage,
@@ -5209,11 +5051,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -5243,11 +5084,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -5279,11 +5119,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be shtdn
@@ -5312,11 +5151,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -5344,11 +5182,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.SHTDN.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -5381,11 +5218,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -5415,11 +5251,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -5446,11 +5281,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -5479,17 +5313,15 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -5528,11 +5360,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -5562,11 +5393,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -5598,11 +5428,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be OFF
@@ -5631,11 +5460,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -5663,11 +5491,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.OFF.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -5700,11 +5527,10 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         // add manipulation data with result fail
         messageStorageUtil.addManipulation(
                 storage,
@@ -5734,11 +5560,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, SET_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.SET.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                SET_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.SET,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(
@@ -5765,11 +5590,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -5798,17 +5622,15 @@ public class InvariantParticipantModelStatePartTestTest {
         final var initial = buildMdib(SEQUENCE_ID);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
 
-        final List<Pair<String, String>> parameters2 = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE2),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE2,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -5847,11 +5669,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // this metric report is not in the time interval of the setMetricStatus manipulation
@@ -5881,11 +5702,10 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(
                 storage,
                 TIMESTAMP_START,
@@ -5917,11 +5737,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // activation state should be FAIL
@@ -5950,11 +5769,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         // good report in time interval
@@ -5982,11 +5800,10 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
-        final List<Pair<String, String>> parameters = List.of(
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, CLC_METRIC_HANDLE),
-                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, MetricCategory.CLC.value()),
-                new ImmutablePair<>(
-                        Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, ComponentActivation.FAIL.value()));
+        final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                CLC_METRIC_HANDLE,
+                org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
+                org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
         messageStorageUtil.addManipulation(storage, TIMESTAMP_START, TIMESTAMP_FINISH, result, methodName, parameters);
 
         final var metricReport = buildMetricReport(

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/util/MessageStorageUtil.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/util/MessageStorageUtil.java
@@ -11,6 +11,7 @@ import com.draeger.medical.dpws.soap.model.Envelope;
 import com.draeger.medical.sdccc.marshalling.SoapMarshalling;
 import com.draeger.medical.sdccc.messages.Message;
 import com.draeger.medical.sdccc.messages.MessageStorage;
+import com.draeger.medical.sdccc.tests.util.ManipulationParameterUtil;
 import com.draeger.medical.t2iapi.ResponseTypes;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
@@ -25,7 +26,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.lang3.tuple.Pair;
 import org.somda.sdc.dpws.CommunicationLog;
 import org.somda.sdc.dpws.DpwsConstants;
 import org.somda.sdc.dpws.soap.ApplicationInfo;
@@ -189,7 +189,7 @@ public class MessageStorageUtil {
             final long finishTime,
             final ResponseTypes.Result result,
             final String name,
-            final List<Pair<String, String>> parameters)
+            final ManipulationParameterUtil.ManipulationParameterData parameters)
             throws IOException {
         final long previous_count;
         try (final var manipulations = storage.getManipulationDataByManipulation(name)) {


### PR DESCRIPTION
Fixed issue #94 
Added ManipulationParameterUtil to align the handling of manipulation parameters.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
