### PR TITLE
fix biceps r0034 descriptor reinsert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - the occurrence of the sequence ']]>' in the content of CDATA sections in the result xmls
 - setComponentActivation stores incorrect manipulation data in the database resulting in no test data being available for 5-4-7_* tests
+- biceps:R0034_0 does not track changes when reinserting descriptors.
 
 ## [7.0.1] - 2023-03-17
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTest.java
@@ -62,8 +62,8 @@ public class InvariantParticipantModelVersioningTest extends InjectorTestBase {
             "The version of %s has been decremented in" + " MdibVersion %s. It was %s and is now %s.";
 
     public static final String DESCRIPTOR_REINSERTION_PREFIX =
-            "Descriptor version has not been incremented by one, but descriptor has changed after" +
-                    " reinsertion into mdib.";
+            "Descriptor version has not been incremented by one, but descriptor has changed after"
+                    + " reinsertion into mdib.";
 
     public static final String DESCRIPTOR_UPDATE_PREFIX =
             "Descriptor version has not been incremented by one, but descriptor has changed.";
@@ -189,8 +189,7 @@ public class InvariantParticipantModelVersioningTest extends InjectorTestBase {
                                     descriptorChanges.incrementAndGet();
                                     assertTrue(
                                             isIncrementedVersion(
-                                                    ImpliedValueUtil.getDescriptorVersion(
-                                                            oldVersion, impliedValueMap),
+                                                    ImpliedValueUtil.getDescriptorVersion(oldVersion, impliedValueMap),
                                                     ImpliedValueUtil.getDescriptorVersion(
                                                             descriptor.getDescriptor(), impliedValueMap)),
                                             DESCRIPTOR_REINSERTION_PREFIX
@@ -199,7 +198,6 @@ public class InvariantParticipantModelVersioningTest extends InjectorTestBase {
                                                     + ". Old Descriptor " + oldVersion
                                                     + " Inserted Descriptor " + descriptor.getDescriptor());
                                 }
-
                             }
 
                             final var nextDescriptorOpt = second.getEntity(descriptor.getHandle());

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTest.java
@@ -60,6 +60,13 @@ public class InvariantParticipantModelVersioningTest extends InjectorTestBase {
             "Handle %s has an implied value, but was already seen" + " without an implied value.";
     public static final String DECREMENTED_VERSION_ERROR_MESSAGE =
             "The version of %s has been decremented in" + " MdibVersion %s. It was %s and is now %s.";
+
+    public static final String DESCRIPTOR_REINSERTION_PREFIX =
+            "Descriptor version has not been incremented by one, but descriptor has changed after" +
+                    " reinsertion into mdib.";
+
+    public static final String DESCRIPTOR_UPDATE_PREFIX =
+            "Descriptor version has not been incremented by one, but descriptor has changed.";
     private MessageStorage messageStorage;
     private MdibHistorianFactory mdibHistorianFactory;
 
@@ -158,6 +165,7 @@ public class InvariantParticipantModelVersioningTest extends InjectorTestBase {
         try (final Stream<String> sequenceIds = mdibHistorian.getKnownSequenceIds()) {
             sequenceIds.forEach(sequenceId -> {
                 final var impliedValueMap = new InitialImpliedValue();
+                final var lastDescriptorMap = new HashMap<String, AbstractDescriptor>();
                 try (final MdibHistorian.HistorianResult history =
                                 mdibHistorian.episodicReportBasedHistory(sequenceId);
                         final MdibHistorian.HistorianResult historyNext =
@@ -172,10 +180,35 @@ public class InvariantParticipantModelVersioningTest extends InjectorTestBase {
                     while (second != null) {
                         final var currentDescriptors = first.findEntitiesByType(AbstractDescriptor.class);
                         for (MdibEntity descriptor : currentDescriptors) {
+                            // check if this was previously deleted and returned
+                            final var oldVersion = lastDescriptorMap.remove(descriptor.getHandle());
+                            if (oldVersion != null) {
+                                final var descriptorChanged =
+                                        hasDescriptorChanged(oldVersion, descriptor.getDescriptor());
+                                if (descriptorChanged) {
+                                    descriptorChanges.incrementAndGet();
+                                    assertTrue(
+                                            isIncrementedVersion(
+                                                    ImpliedValueUtil.getDescriptorVersion(
+                                                            oldVersion, impliedValueMap),
+                                                    ImpliedValueUtil.getDescriptorVersion(
+                                                            descriptor.getDescriptor(), impliedValueMap)),
+                                            DESCRIPTOR_REINSERTION_PREFIX
+                                                    + " MdibVersions of insertion " + first.getMdibVersion()
+                                                    + ". Descriptor handle " + descriptor.getHandle()
+                                                    + ". Old Descriptor " + oldVersion
+                                                    + " Inserted Descriptor " + descriptor.getDescriptor());
+                                }
+
+                            }
+
                             final var nextDescriptorOpt = second.getEntity(descriptor.getHandle());
                             if (nextDescriptorOpt.isEmpty()) {
+                                // descriptor was removed, add to storage
+                                lastDescriptorMap.put(descriptor.getHandle(), descriptor.getDescriptor());
                                 continue;
                             }
+
                             final var nextDescriptor = nextDescriptorOpt.orElseThrow();
                             // compare children of current and next descriptor one by one
                             final var descriptorChanged =
@@ -191,7 +224,7 @@ public class InvariantParticipantModelVersioningTest extends InjectorTestBase {
                                                     descriptor.getDescriptor(), impliedValueMap),
                                             ImpliedValueUtil.getDescriptorVersion(
                                                     nextDescriptor.getDescriptor(), impliedValueMap)),
-                                    "Descriptor version has not been incremented by one, but descriptor has changed."
+                                    DESCRIPTOR_UPDATE_PREFIX
                                             + " MdibVersions " + first.getMdibVersion()
                                             + " and " + second.getMdibVersion()
                                             + ". Descriptor handle " + descriptor.getHandle()

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTestTest.java
@@ -7,10 +7,9 @@
 
 package com.draeger.medical.sdccc.tests.biceps.invariant;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.draeger.medical.sdccc.tests.biceps.invariant.InvariantParticipantModelVersioningTest.DESCRIPTOR_REINSERTION_PREFIX;
+import static com.draeger.medical.sdccc.tests.biceps.invariant.InvariantParticipantModelVersioningTest.DESCRIPTOR_UPDATE_PREFIX;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -568,8 +567,74 @@ public class InvariantParticipantModelVersioningTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, firstUpdate);
         messageStorageUtil.addInboundSecureHttpMessage(storage, secondUpdate);
 
-        assertThrows(AssertionError.class, testClass::testRequirementR0034);
+        final var thrown = assertThrows(AssertionError.class, testClass::testRequirementR0034);
+        assertTrue(thrown.getMessage().startsWith(DESCRIPTOR_UPDATE_PREFIX));
     }
+
+
+    /**
+     * Tests whether deleting and inserting a descriptor with a change fails the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementR0034Bad2() throws Exception {
+        final var initial = buildMdib(null, BigInteger.ZERO);
+
+        final var stringMetric = buildStringMetric(STRING_METRIC_HANDLE, null, null);
+        final var changedStringMetric = buildStringMetric(STRING_METRIC_HANDLE, null, null);
+
+        // change metric
+        changedStringMetric.getKey().setType(
+                mdibBuilder.buildCodedValue("changedTypeTestRequirementR0034Bad2")
+        );
+        assertNotEquals(stringMetric.getKey(), changedStringMetric.getKey());
+        assertEquals(stringMetric.getKey().getDescriptorVersion(), changedStringMetric.getKey().getDescriptorVersion());
+
+        final var firstUpdate = buildDescriptionModificationReportWithParts(
+            SEQUENCE_ID,
+            BigInteger.ONE,
+            buildDescriptionModificationReportPart(
+                    DescriptionModificationType.DEL,
+                    CHANNEL_HANDLE,
+                    stringMetric
+            )
+        );
+
+        // one message in between to test the storage mechanism
+        final var secondUpdate = buildEpisodicContextReport(
+                SEQUENCE_ID, BigInteger.TWO, PATIENT_CONTEXT_DESCRIPTOR_HANDLE, "pat1", null);
+
+
+        final var thirdUpdate = buildDescriptionModificationReportWithParts(
+            SEQUENCE_ID, BigInteger.valueOf(3),
+            buildDescriptionModificationReportPart(
+                    DescriptionModificationType.CRT,
+                    CHANNEL_HANDLE,
+                    changedStringMetric
+            )
+        );
+
+        // fourth update to make sure a descriptor change was observed during the test
+        final var fourthUpdate = buildDescriptionModificationReportWithParts(
+                SEQUENCE_ID, BigInteger.valueOf(4),
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.UPT,
+                        VMD_HANDLE,
+                        buildChannel(CHANNEL_HANDLE, BigInteger.ONE, BigInteger.ONE)
+                )
+        );
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, firstUpdate);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, secondUpdate);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, thirdUpdate);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, fourthUpdate);
+
+        final var thrown = assertThrows(AssertionError.class, testClass::testRequirementR0034);
+        assertTrue(thrown.getMessage().startsWith(DESCRIPTOR_REINSERTION_PREFIX));
+    }
+
 
     /**
      * Tests whether insufficient test data fails the test.
@@ -1555,6 +1620,19 @@ public class InvariantParticipantModelVersioningTestTest {
             channel.getRight().setStateVersion(stateVersion);
         }
         return channel;
+    }
+
+    Pair<com.draeger.medical.biceps.model.participant.StringMetricDescriptor, com.draeger.medical.biceps.model.participant.StringMetricState> buildStringMetric(
+            final String handle,
+            @Nullable final BigInteger descriptorVersion,
+            @Nullable final BigInteger stateVersion) {
+        final var metric = mdibBuilder.buildStringMetric(handle, MetricCategory.CLC, MetricAvailability.INTR, mdibBuilder.buildCodedValue("abc"));
+        metric.getLeft().setDescriptorVersion(descriptorVersion);
+        metric.getRight().setDescriptorVersion(descriptorVersion);
+        if (stateVersion != null) {
+            metric.getRight().setStateVersion(stateVersion);
+        }
+        return metric;
     }
 
     @SafeVarargs

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTestTest.java
@@ -9,7 +9,11 @@ package com.draeger.medical.sdccc.tests.biceps.invariant;
 
 import static com.draeger.medical.sdccc.tests.biceps.invariant.InvariantParticipantModelVersioningTest.DESCRIPTOR_REINSERTION_PREFIX;
 import static com.draeger.medical.sdccc.tests.biceps.invariant.InvariantParticipantModelVersioningTest.DESCRIPTOR_UPDATE_PREFIX;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -571,7 +575,6 @@ public class InvariantParticipantModelVersioningTestTest {
         assertTrue(thrown.getMessage().startsWith(DESCRIPTOR_UPDATE_PREFIX));
     }
 
-
     /**
      * Tests whether deleting and inserting a descriptor with a change fails the test.
      *
@@ -585,45 +588,35 @@ public class InvariantParticipantModelVersioningTestTest {
         final var changedStringMetric = buildStringMetric(STRING_METRIC_HANDLE, null, null);
 
         // change metric
-        changedStringMetric.getKey().setType(
-                mdibBuilder.buildCodedValue("changedTypeTestRequirementR0034Bad2")
-        );
+        changedStringMetric.getKey().setType(mdibBuilder.buildCodedValue("changedTypeTestRequirementR0034Bad2"));
         assertNotEquals(stringMetric.getKey(), changedStringMetric.getKey());
-        assertEquals(stringMetric.getKey().getDescriptorVersion(), changedStringMetric.getKey().getDescriptorVersion());
+        assertEquals(
+                stringMetric.getKey().getDescriptorVersion(),
+                changedStringMetric.getKey().getDescriptorVersion());
 
         final var firstUpdate = buildDescriptionModificationReportWithParts(
-            SEQUENCE_ID,
-            BigInteger.ONE,
-            buildDescriptionModificationReportPart(
-                    DescriptionModificationType.DEL,
-                    CHANNEL_HANDLE,
-                    stringMetric
-            )
-        );
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildDescriptionModificationReportPart(DescriptionModificationType.DEL, CHANNEL_HANDLE, stringMetric));
 
         // one message in between to test the storage mechanism
         final var secondUpdate = buildEpisodicContextReport(
                 SEQUENCE_ID, BigInteger.TWO, PATIENT_CONTEXT_DESCRIPTOR_HANDLE, "pat1", null);
 
-
         final var thirdUpdate = buildDescriptionModificationReportWithParts(
-            SEQUENCE_ID, BigInteger.valueOf(3),
-            buildDescriptionModificationReportPart(
-                    DescriptionModificationType.CRT,
-                    CHANNEL_HANDLE,
-                    changedStringMetric
-            )
-        );
+                SEQUENCE_ID,
+                BigInteger.valueOf(3),
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.CRT, CHANNEL_HANDLE, changedStringMetric));
 
         // fourth update to make sure a descriptor change was observed during the test
         final var fourthUpdate = buildDescriptionModificationReportWithParts(
-                SEQUENCE_ID, BigInteger.valueOf(4),
+                SEQUENCE_ID,
+                BigInteger.valueOf(4),
                 buildDescriptionModificationReportPart(
                         DescriptionModificationType.UPT,
                         VMD_HANDLE,
-                        buildChannel(CHANNEL_HANDLE, BigInteger.ONE, BigInteger.ONE)
-                )
-        );
+                        buildChannel(CHANNEL_HANDLE, BigInteger.ONE, BigInteger.ONE)));
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
         messageStorageUtil.addInboundSecureHttpMessage(storage, firstUpdate);
@@ -634,7 +627,6 @@ public class InvariantParticipantModelVersioningTestTest {
         final var thrown = assertThrows(AssertionError.class, testClass::testRequirementR0034);
         assertTrue(thrown.getMessage().startsWith(DESCRIPTOR_REINSERTION_PREFIX));
     }
-
 
     /**
      * Tests whether insufficient test data fails the test.
@@ -1622,11 +1614,15 @@ public class InvariantParticipantModelVersioningTestTest {
         return channel;
     }
 
-    Pair<com.draeger.medical.biceps.model.participant.StringMetricDescriptor, com.draeger.medical.biceps.model.participant.StringMetricState> buildStringMetric(
-            final String handle,
-            @Nullable final BigInteger descriptorVersion,
-            @Nullable final BigInteger stateVersion) {
-        final var metric = mdibBuilder.buildStringMetric(handle, MetricCategory.CLC, MetricAvailability.INTR, mdibBuilder.buildCodedValue("abc"));
+    Pair<
+                    com.draeger.medical.biceps.model.participant.StringMetricDescriptor,
+                    com.draeger.medical.biceps.model.participant.StringMetricState>
+            buildStringMetric(
+                    final String handle,
+                    @Nullable final BigInteger descriptorVersion,
+                    @Nullable final BigInteger stateVersion) {
+        final var metric = mdibBuilder.buildStringMetric(
+                handle, MetricCategory.CLC, MetricAvailability.INTR, mdibBuilder.buildCodedValue("abc"));
         metric.getLeft().setDescriptorVersion(descriptorVersion);
         metric.getRight().setDescriptorVersion(descriptorVersion);
         if (stateVersion != null) {


### PR DESCRIPTION
Add tracking of deleted descriptors to biceps:R0034_0, update tests to reflect this change.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [x] Reviewer
