### PR TITLE
Fixed some ManipulationPreconditions not handling not_supported responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - the occurrence of the sequence ']]>' in the content of CDATA sections in the result xmls
+- that preconditions of the following requirements could not handle the T2IAPI manipulation result RESULT_NOT_SUPPORTED: biceps:R0029_0 biceps:R0116 biceps:5-4-7_0_0 biceps:5-4-7_1 biceps:5-4-7_2 biceps:5-4-7_3 biceps:5-4-7_4 biceps:5-4-7_5 biceps:5-4-7_6_0 biceps:5-4-7_7 biceps:5-4-7_8 biceps:5-4-7_9 biceps:5-4-7_10 biceps:5-4-7_11 biceps:5-4-7_12_0 biceps:5-4-7_13 biceps:5-4-7_14 biceps:5-4-7_15 biceps:5-4-7_16 biceps:5-4-7_17
 
 ## [7.0.1] - 2023-03-17
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -517,11 +517,25 @@ public class ManipulationPreconditions {
                 final AlertActivation activationState) {
             LOG.debug("Setting the activation state {} for handle {}", activationState, handle);
             var manipulationResult = manipulations.setAlertActivation(handle, activationState);
-            if (manipulationResult != ResponseTypes.Result.RESULT_SUCCESS) {
-                LOG.error("Setting the activation state {} for handle {} failed", activationState, handle);
-            } else if (!verifyStatePresentAndAlertSet(device, handle, activationState)) {
-                LOG.error("Validation for alert system {} failed", handle);
-                manipulationResult = ResponseTypes.Result.RESULT_FAIL;
+            switch (manipulationResult) {
+                case RESULT_SUCCESS -> {
+                    LOG.debug("Setting the activation state {} for handle {} was successful", activationState, handle);
+                    if (!verifyStatePresentAndAlertSet(device, handle, activationState)) {
+                        LOG.debug(
+                            "Validation for state with handle {} failed, because the state is"
+                                + " either not present or the activation state is not {}",
+                            handle,
+                            activationState);
+                        manipulationResult = ResponseTypes.Result.RESULT_FAIL;
+                    }
+                }
+                case RESULT_NOT_SUPPORTED -> LOG.debug(
+                    "Setting the activation state {} for handle {} is not supported", activationState, handle);
+                default -> LOG.error(
+                    "Setting the activation state {} for handle {} failed, manipulation result: {}",
+                    activationState,
+                    handle,
+                    manipulationResult);
             }
             return manipulationResult;
         }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -625,8 +625,12 @@ public class ManipulationPreconditions {
                         testClient.getSdcRemoteDevice(), manipulations, parentHandle, AlertActivation.OFF);
                 final var presenceTrueResult =
                         changePresence(testClient.getSdcRemoteDevice(), manipulations, handle, true);
-                if (alertConditionStateResult == ResponseTypes.Result.RESULT_SUCCESS
-                        && alertSystemStateResult == ResponseTypes.Result.RESULT_SUCCESS
+                // the setAlertActivation manipulations are not mandatory, but then the device must ensure that the
+                // activation states are ON when the presence is true.
+                if ((alertConditionStateResult == ResponseTypes.Result.RESULT_SUCCESS
+                                || alertConditionStateResult == ResponseTypes.Result.RESULT_NOT_SUPPORTED)
+                        && (alertSystemStateResult == ResponseTypes.Result.RESULT_SUCCESS
+                                || alertSystemStateResult == ResponseTypes.Result.RESULT_NOT_SUPPORTED)
                         && presenceTrueResult == ResponseTypes.Result.RESULT_SUCCESS) {
                     manipulationSuccessful = true;
                     // successful manipulation seen

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1791,6 +1791,93 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateON: Setting a metric with category CLC to `calculation is"
+        + " being performed` results in activation state ON.")
+    void testMetricStatusManipulationCLCActivationStateONActivationStateONGood() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateONAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateONAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateON: setComponentActivation failed.")
+    void testMetricStatusManipulationCLCActivationStateONBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateON: setMetricStatus failed.")
+    void testMetricStatusManipulationCLCActivationStateONBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationCLCActivationStateNOTRDY: Set calculations of metrics with category CLC"
             + " to currently initializing to trigger an ActivationState change to NotRdy.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYGood() {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1469,6 +1469,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateNOTRDYAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.NOT_RDY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateNOTRDYAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.NOT_RDY);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateNOTRDYBad: First Manipulation failed.")
     void testMetricStatusManipulationSETActivationStateNOTRDYBadFirstManipulationFailed() {
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1172,6 +1172,93 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("MetricStatusManipulationMSRMTActivationStateOFF: Setting a metric with category MSRMT to `measurement"
+        + " not being performed and is de-initialized` results in activation state OFF.")
+    void testMetricStatusManipulationMSRMTActivationStateOFFGood() {
+        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateOFFAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateOFFAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationMSRMTActivationStateOFF: setComponentActivation failed.")
+    void testMetricStatusManipulationMSRMTActivationStateOFFBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationMSRMTActivationStateOFF: setMetricStatus failed.")
+    void testMetricStatusManipulationMSRMTActivationStateOFFBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.OFF);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationMSRMTActivationStateFAIL: Set ActivationState "
             + "of all MSRMT-Metrics to FAIL.")
     void testMetricStatusManipulationMSRMTActivationStateFAILGood() {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1894,6 +1894,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationCLCActivationStateNOTRDY: setComponentActivation failed.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYBadFirstManipulationFailed() {
         setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -907,6 +907,93 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("MetricStatusManipulationMSRMTActivationStateON: Setting a metric with category MSRMT to `measurement is"
+        + " being performed` results in activation state ON.")
+    void testMetricStatusManipulationMSRMTActivationStateONGood() {
+        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateONAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateONAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationMSRMTActivationStateON: setComponentActivation failed.")
+    void testMetricStatusManipulationMSRMTActivationStateONBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationMSRMTActivationStateON: setMetricStatus failed.")
+    void testMetricStatusManipulationMSRMTActivationStateONBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.ON);
+    }
+
+    @Test
     @DisplayName("MetricStatusManipulationMSRMTActivationStateNOTRDY: Set metric with category MSRMT to currently"
             + " initializing which results in activation state NOT_RDY.")
     void testMetricStatusManipulationMSRMTActivationStateNOTRDYGood() {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1526,6 +1526,93 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: Set metric with category MSRMT to 'setting"
+        + " initialized, but is not being performed' which results in activation state STND_BY.")
+    void testMetricStatusManipulationSETActivationStateSTNDBYGood() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateSTNDBYAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateSTNDBYAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: setComponentActivation failed.")
+    void testMetricStatusManipulationSETActivationStateSTNDBYBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: setMetricStatus failed.")
+    void testMetricStatusManipulationSETActivationStateSTNDBYBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateSHTDN: Set SET metrics to a state where the setting is"
             + " currently de-initializing to trigger the setting of the activation state to SHTDN")
     void testMetricStatusManipulationSETActivationStateSHTDNGood() {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1275,6 +1275,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateFAILAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.FAIL);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateFAILAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.FAIL);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationMSRMTActivationStateFAIL: setComponentActivation failed.")
     void testMetricStatusManipulationMSRMTActivationStateFAILBadFirstManipulationFailed() {
         setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1702,6 +1702,95 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("testMetricStatusManipulationSETActivationStateOFF: Set SET metrics to a state where the setting"
+        + " not being performed and is de-initialized to trigger the setting of the activation state to OFF")
+    void testMetricStatusManipulationSETActivationStateOFFGood() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
+
+        assertFalse(
+            testRunObserver.isInvalid(),
+            "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateOFFAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateOFFAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("testMetricStatusManipulationSETActivationStateOFF: setComponentActivation failed.")
+    void testMetricStatusManipulationSETActivationStateOFFBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("testMetricStatusManipulationSETActivationStateOFF: setMetricStatus failed.")
+    void testMetricStatusManipulationSETActivationStateOFFBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationCLCActivationStateNOTRDY: Set calculations of metrics with category CLC"
             + " to currently initializing to trigger an ActivationState change to NotRdy.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYGood() {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -580,8 +580,6 @@ public class ManipulationPreconditionsTest {
         assertFalse(
                 ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateNOTRDY.manipulation(injector));
 
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
-
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
     }
 
@@ -597,8 +595,6 @@ public class ManipulationPreconditionsTest {
 
         assertFalse(
                 ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateNOTRDY.manipulation(injector));
-
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.NOT_RDY);
@@ -631,8 +627,6 @@ public class ManipulationPreconditionsTest {
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
 
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
-
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
 
@@ -647,8 +641,6 @@ public class ManipulationPreconditionsTest {
                 .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
-
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.FAIL);
@@ -711,7 +703,6 @@ public class ManipulationPreconditionsTest {
         assertFalse(testRunObserver.isInvalid());
         final boolean result =
                 ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector);
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
 
         // then
         assertFalse(result);
@@ -739,7 +730,6 @@ public class ManipulationPreconditionsTest {
         assertFalse(testRunObserver.isInvalid());
         final boolean result =
                 ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector);
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
 
         // then
         assertFalse(result);
@@ -774,8 +764,6 @@ public class ManipulationPreconditionsTest {
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
 
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
-
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
 
@@ -790,8 +778,6 @@ public class ManipulationPreconditionsTest {
                 .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
-
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.SHTDN);
@@ -824,8 +810,6 @@ public class ManipulationPreconditionsTest {
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
 
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
-
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
     }
 
@@ -840,8 +824,6 @@ public class ManipulationPreconditionsTest {
                 .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
-
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
@@ -877,8 +859,6 @@ public class ManipulationPreconditionsTest {
                 ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
                 "The manipulation should not have been successful.");
 
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
-
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
 
@@ -895,8 +875,6 @@ public class ManipulationPreconditionsTest {
         assertFalse(
                 ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
                 "The manipulation should not have been successful.");
-
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
@@ -929,10 +907,6 @@ public class ManipulationPreconditionsTest {
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
 
-        assertTrue(
-                testRunObserver.isInvalid(),
-                "Test run should be invalidated because the setComponentActivation manipulation failed.");
-
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
 
@@ -947,10 +921,6 @@ public class ManipulationPreconditionsTest {
                 .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
-
-        assertTrue(
-                testRunObserver.isInvalid(),
-                "Test run should be invalidated because the setMetricStatus manipulation failed.");
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
@@ -988,8 +958,6 @@ public class ManipulationPreconditionsTest {
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
 
         // then
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalidated.");
-
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
 
@@ -1004,8 +972,6 @@ public class ManipulationPreconditionsTest {
                 .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
-
-        assertTrue(testRunObserver.isInvalid(), "Test run should have been invalidated.");
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.FAIL);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -386,6 +386,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateSHTDNAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.SHTDN);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateSHTDNAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.SHTDN);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationMSRMTActivationStateSHTDNBad: First Manipulation failed.")
     void testMetricStatusManipulationMSRMTActivationStateSHTDNBadFirstManipulationFailed() {
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1967,6 +1967,93 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: Set metric with category CLC to 'calculation"
+        + " initialized, but is not being performed' which results in activation state STND_BY.")
+    void testMetricStatusManipulationCLCActivationStateSTNDBYGood() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateSTNDBYAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateSTNDBYAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: setComponentActivation failed.")
+    void testMetricStatusManipulationCLCActivationStateSTNDBYBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: setMetricStatus failed.")
+    void testMetricStatusManipulationCLCActivationStateSTNDBYBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: Set ActivationState of all SET-Metrics to FAIL.")
     void testMetricStatusManipulationSETActivationStateFAILGood() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1085,6 +1085,93 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("MetricStatusManipulationMSRMTActivationStateSTNDBY: Set metric with category MSRMT to 'measurement"
+        + " initialized, but is not being performed' which results in activation state STND_BY.")
+    void testMetricStatusManipulationMSRMTActivationStateSTNDBYGood() {
+        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateSTNDBYAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateSTNDBYAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationMSRMTActivationStateSTNDBY: setComponentActivation failed.")
+    void testMetricStatusManipulationMSRMTActivationStateSTNDBYBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationMSRMTActivationStateSTNDBY: setMetricStatus failed.")
+    void testMetricStatusManipulationMSRMTActivationStateSTNDBYBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.STND_BY);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationMSRMTActivationStateFAIL: Set ActivationState "
             + "of all MSRMT-Metrics to FAIL.")
     void testMetricStatusManipulationMSRMTActivationStateFAILGood() {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2339,6 +2339,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateFAILAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.FAIL);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateFAILAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.FAIL);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationCLCActivationStateFAIL: setComponentActivation failed.")
     void testMetricStatusManipulationCLCActivationStateFAILBadFirstManipulationFailed() {
         // given

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -387,17 +387,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateSHTDNAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN.manipulation(injector));
 
@@ -408,18 +408,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateSHTDNAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN.manipulation(injector));
 
@@ -950,8 +950,9 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateON: Setting a metric with category MSRMT to `measurement is"
-        + " being performed` results in activation state ON.")
+    @DisplayName(
+            "MetricStatusManipulationMSRMTActivationStateON: Setting a metric with category MSRMT to `measurement is"
+                    + " being performed` results in activation state ON.")
     void testMetricStatusManipulationMSRMTActivationStateONGood() {
         setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
@@ -963,17 +964,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateONAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
 
@@ -984,18 +985,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateONAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
 
@@ -1011,10 +1012,9 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
     }
@@ -1026,11 +1026,10 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.ON);
@@ -1129,7 +1128,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationMSRMTActivationStateSTNDBY: Set metric with category MSRMT to 'measurement"
-        + " initialized, but is not being performed' which results in activation state STND_BY.")
+            + " initialized, but is not being performed' which results in activation state STND_BY.")
     void testMetricStatusManipulationMSRMTActivationStateSTNDBYGood() {
         setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
@@ -1141,17 +1140,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateSTNDBYAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
 
@@ -1162,18 +1161,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateSTNDBYAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
 
@@ -1189,10 +1188,10 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
+                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
@@ -1204,11 +1203,11 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
+                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.STND_BY);
@@ -1216,7 +1215,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationMSRMTActivationStateOFF: Setting a metric with category MSRMT to `measurement"
-        + " not being performed and is de-initialized` results in activation state OFF.")
+            + " not being performed and is de-initialized` results in activation state OFF.")
     void testMetricStatusManipulationMSRMTActivationStateOFFGood() {
         setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
@@ -1228,17 +1227,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateOFFAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
 
@@ -1249,18 +1248,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateOFFAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
 
@@ -1276,10 +1275,9 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
@@ -1291,11 +1289,10 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.OFF);
@@ -1319,17 +1316,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateFAILAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
 
@@ -1340,18 +1337,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateFAILAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
 
@@ -1392,7 +1389,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationSETActivationStateON: Setting a metric with category SET to `setting is"
-        + " currently being applied` results in activation state ON.")
+            + " currently being applied` results in activation state ON.")
     void testMetricStatusManipulationSETActivationStateONGood() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
@@ -1404,17 +1401,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateONAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
 
@@ -1425,18 +1422,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateONAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
 
@@ -1452,10 +1449,9 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
     }
@@ -1467,11 +1463,10 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
@@ -1513,17 +1508,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateNOTRDYAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector));
 
@@ -1534,18 +1529,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateNOTRDYAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector));
 
@@ -1613,7 +1608,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: Set metric with category MSRMT to 'setting"
-        + " initialized, but is not being performed' which results in activation state STND_BY.")
+            + " initialized, but is not being performed' which results in activation state STND_BY.")
     void testMetricStatusManipulationSETActivationStateSTNDBYGood() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
@@ -1625,17 +1620,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateSTNDBYAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
 
@@ -1646,18 +1641,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateSTNDBYAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
 
@@ -1673,10 +1668,9 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
@@ -1688,11 +1682,10 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
@@ -1716,17 +1709,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateSHTDNAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
 
@@ -1737,18 +1730,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateSHTDNAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
 
@@ -1789,15 +1782,15 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateOFF: Set SET metrics to a state where the setting"
-        + " not being performed and is de-initialized to trigger the setting of the activation state to OFF")
+            + " not being performed and is de-initialized to trigger the setting of the activation state to OFF")
     void testMetricStatusManipulationSETActivationStateOFFGood() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
 
         assertFalse(
-            testRunObserver.isInvalid(),
-            "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
+                testRunObserver.isInvalid(),
+                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
@@ -1805,17 +1798,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateOFFAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
 
@@ -1826,18 +1819,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateOFFAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
 
@@ -1853,7 +1846,7 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
 
@@ -1867,8 +1860,8 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
 
@@ -1878,7 +1871,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationCLCActivationStateON: Setting a metric with category CLC to `calculation is"
-        + " being performed` results in activation state ON.")
+            + " being performed` results in activation state ON.")
     void testMetricStatusManipulationCLCActivationStateONActivationStateONGood() {
         setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
@@ -1890,17 +1883,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateONAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
 
@@ -1911,18 +1904,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateONAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
 
@@ -1938,10 +1931,9 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
     }
@@ -1953,11 +1945,10 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
@@ -1981,17 +1972,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
 
@@ -2002,18 +1993,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
 
@@ -2054,7 +2045,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: Set metric with category CLC to 'calculation"
-        + " initialized, but is not being performed' which results in activation state STND_BY.")
+            + " initialized, but is not being performed' which results in activation state STND_BY.")
     void testMetricStatusManipulationCLCActivationStateSTNDBYGood() {
         setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
@@ -2066,17 +2057,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateSTNDBYAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
 
@@ -2087,18 +2078,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateSTNDBYAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
 
@@ -2114,10 +2105,9 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
@@ -2129,11 +2119,10 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
@@ -2155,19 +2144,20 @@ public class ManipulationPreconditionsTest {
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
     }
+
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateFAILAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector));
 
@@ -2178,18 +2168,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateFAILAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector));
 
@@ -2250,17 +2240,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateSHTDNAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
 
@@ -2271,18 +2261,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateSHTDNAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
 
@@ -2323,7 +2313,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationCLCActivationStateOFF: Set CLC metrics to a state where the `calculation"
-        + " not being performed and is de-initialized` to trigger the setting of the activation state to OFF")
+            + " not being performed and is de-initialized` to trigger the setting of the activation state to OFF")
     void testMetricStatusManipulationCLCActivationStateOFFGood() {
         setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
@@ -2335,17 +2325,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateOFFAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
 
@@ -2356,18 +2346,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateOFFAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
 
@@ -2383,7 +2373,7 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
 
@@ -2397,8 +2387,8 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
 
@@ -2426,17 +2416,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateFAILAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
 
@@ -2447,18 +2437,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateFAILAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1348,6 +1348,93 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateON: Setting a metric with category SET to `setting is"
+        + " currently being applied` results in activation state ON.")
+    void testMetricStatusManipulationSETActivationStateONGood() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateONAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateONAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateON: setComponentActivation failed.")
+    void testMetricStatusManipulationSETActivationStateONBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateON: setMetricStatus failed.")
+    void testMetricStatusManipulationSETActivationStateONBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateNOTRDYGood: Set ActivationState "
             + "of all SET-Metrics to NOTRDY.")
     void testMetricStatusManipulationSETActivationStateNOTRDYGood() {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2163,6 +2163,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateSHTDNAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateSHTDNAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
+    }
+
+    @Test
     @DisplayName("MetricStatusManipulationCLCActivationStateSHTDN: setComponentActivation failed.")
     void testMetricStatusManipulationCLCActivationStateSHTDNBadFirstManipulationFailed() {
         setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1852,6 +1852,48 @@ public class ManipulationPreconditionsTest {
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
     }
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateFAILAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateFAILAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
+    }
 
     @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: setComponentActivation failed.")

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2236,6 +2236,91 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateOFF: Set CLC metrics to a state where the `calculation"
+        + " not being performed and is de-initialized` to trigger the setting of the activation state to OFF")
+    void testMetricStatusManipulationCLCActivationStateOFFGood() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateOFFAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateOFFAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateOFF: setComponentActivation failed.")
+    void testMetricStatusManipulationCLCActivationStateOFFBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateOFF: setMetricStatus failed.")
+    void testMetricStatusManipulationCLCActivationStateOFFBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationCLCActivationStateFAIL: Set ActivationState of all CLC-Metrics to FAIL.")
     void testMetricStatusManipulationCLCActivationStateFAILGood() {
         // given

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1629,6 +1629,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateSHTDNAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.SHTDN);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateSHTDNAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.SHTDN);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateSHTDN: setComponentActivation failed.")
     void testMetricStatusManipulationSETActivationStateSHTDNBadFirstManipulationFailed() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);


### PR DESCRIPTION
The following ManipulationPreconditions were found to not properly handle not_supported responses and have been adjusted accordingly:

- _AlertConditionPresenceManipulation_

- _AlertSystemActivationStateManipulation_

- all Preconditions using _manipulateMetricStatus_

Missing unit tests for thesePrecondition added.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
