### PR TITLE
Made multicastTTL configurable in SDCcc config.toml.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - message encoding errors are summarized by default, but all information is available via the configuration option
   SDCcc.SummarizeMessageEncodingErrors.
 - checking for message encoding errors can be disabled using the configuration option SDCcc.EnableMessageEncodingCheck.
+- configuration option SDCcc.Network.MulticastTTL to configure the Time To Live of the Multicast Packets used for Discovery.
 
 ### Changed
 - SDCri version 4.1.0-SNAPSHOT

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ The maximum waiting time in seconds to find and connect to the target device.
 MaxWait=timeInSeconds
 ```
 
+The time to live (the number of routers an IP packet may pass before it is discarded) of multicast packets used for
+Discovery defaults to 128. When other values are needed, it can be configured using the following option
+```
+[SDCcc.Network]
+MulticastTTL=196
+```
+
 ### Target Device (DUT) configuration
 In order for the test tool to connect to the DUT, the address of the target device must be set under
 ```

--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -15,6 +15,7 @@ EnabledProtocols = ["TLSv1.2", "TLSv1.3"]
 [SDCcc.Network]
 InterfaceAddress="127.0.0.1"
 MaxWait=10
+MulticastTTL=128
 
 [SDCcc.Consumer]
 Enable=true

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -82,6 +82,7 @@ import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 import org.somda.sdc.common.guice.AbstractConfigurationModule;
+import org.somda.sdc.dpws.DpwsConfig;
 import org.somda.sdc.dpws.soap.exception.TransportException;
 import org.somda.sdc.dpws.soap.interception.InterceptorException;
 import org.somda.sdc.glue.common.WsdlConstants;
@@ -460,6 +461,24 @@ public class TestSuite {
             final var configModuleParser = new TomlConfigParser(TestSuiteConfig.class);
             configModuleParser.parseToml(configFileStream, configModule);
         }
+
+
+        // read multicast TTL from config
+        var configInjector = Guice.createInjector(Modules.override(
+                                new DefaultTestSuiteConfig())
+                            .with(configModule));
+
+        var multicast_TTL = configInjector.getInstance(Key.get(Long.class, Names.named(TestSuiteConfig.NETWORK_MULTICAST_TTL)));
+
+        // configure SDC-ri to use the multicastTTL
+        var sdcriConfigModule = new AbstractConfigurationModule() {
+
+            @Override
+            protected void defaultConfigure() {
+                bind(DpwsConfig.MULTICAST_TTL, Integer.class, multicast_TTL.intValue());
+            }
+        };
+
         try (final var testConfigFileStream =
                 new FileInputStream(cmdLine.getTestConfigPath().toFile())) {
             final var testConfigModuleParser = new TomlConfigParser(EnabledTestConfig.class);
@@ -468,7 +487,7 @@ public class TestSuite {
 
         // cli overrides
         final var configurationModule =
-                Modules.override(configModule, testConfigModule).with(cliOverrideModule);
+                Modules.override(configModule, testConfigModule).with(cliOverrideModule, sdcriConfigModule);
 
         return createInjector(configurationModule, new TestRunConfig(testRunDir));
     }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -462,20 +462,19 @@ public class TestSuite {
             configModuleParser.parseToml(configFileStream, configModule);
         }
 
-
         // read multicast TTL from config
-        var configInjector = Guice.createInjector(Modules.override(
-                                new DefaultTestSuiteConfig())
-                            .with(configModule));
+        final var configInjector = Guice.createInjector(
+                Modules.override(new DefaultTestSuiteConfig()).with(configModule));
 
-        var multicast_TTL = configInjector.getInstance(Key.get(Long.class, Names.named(TestSuiteConfig.NETWORK_MULTICAST_TTL)));
+        final var multicastTTL =
+                configInjector.getInstance(Key.get(Long.class, Names.named(TestSuiteConfig.NETWORK_MULTICAST_TTL)));
 
         // configure SDC-ri to use the multicastTTL
-        var sdcriConfigModule = new AbstractConfigurationModule() {
+        final var sdcriConfigModule = new AbstractConfigurationModule() {
 
             @Override
             protected void defaultConfigure() {
-                bind(DpwsConfig.MULTICAST_TTL, Integer.class, multicast_TTL.intValue());
+                bind(DpwsConfig.MULTICAST_TTL, Integer.class, multicastTTL.intValue());
             }
         };
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
@@ -51,6 +51,7 @@ public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
     void configureNetwork() {
         bind(TestSuiteConfig.NETWORK_INTERFACE_ADDRESS, String.class, "127.0.0.1");
         bind(TestSuiteConfig.NETWORK_MAX_WAIT, long.class, 10L);
+        bind(TestSuiteConfig.NETWORK_MULTICAST_TTL, long.class, 128L);
     }
 
     void configureProvider() {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
@@ -42,6 +42,7 @@ public final class TestSuiteConfig {
     private static final String NETWORK = "Network.";
     public static final String NETWORK_INTERFACE_ADDRESS = SDCCC + NETWORK + "InterfaceAddress";
     public static final String NETWORK_MAX_WAIT = SDCCC + NETWORK + "MaxWait";
+    public static final String NETWORK_MULTICAST_TTL = SDCCC + NETWORK + "MulticastTTL";  // should be between 0 and 255
 
     /*
      * Consumer configuration

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
@@ -42,7 +42,7 @@ public final class TestSuiteConfig {
     private static final String NETWORK = "Network.";
     public static final String NETWORK_INTERFACE_ADDRESS = SDCCC + NETWORK + "InterfaceAddress";
     public static final String NETWORK_MAX_WAIT = SDCCC + NETWORK + "MaxWait";
-    public static final String NETWORK_MULTICAST_TTL = SDCCC + NETWORK + "MulticastTTL";  // should be between 0 and 255
+    public static final String NETWORK_MULTICAST_TTL = SDCCC + NETWORK + "MulticastTTL"; // should be between 0 and 255
 
     /*
      * Consumer configuration

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/sdcri/testclient/TestClientUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/sdcri/testclient/TestClientUtil.java
@@ -22,6 +22,7 @@ import com.google.inject.util.Modules;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.inject.Named;
 import javax.net.ssl.HostnameVerifier;
 import org.somda.sdc.biceps.guice.DefaultBicepsConfigModule;
 import org.somda.sdc.biceps.guice.DefaultBicepsModule;
@@ -58,7 +59,8 @@ public class TestClientUtil {
     public TestClientUtil(
             final CryptoSettings cryptoSettings,
             final CommunicationLogMessageStorage communicationLogMessageStorage,
-            final TestRunObserver testRunObserver) {
+            final TestRunObserver testRunObserver,
+            @Named(DpwsConfig.MULTICAST_TTL) final Integer multicastTTL) {
 
         injector = createClientInjector(List.of(
                 new AbstractConfigurationModule() {
@@ -71,6 +73,7 @@ public class TestClientUtil {
                                 (hostname, session) -> true);
                         bind(DpwsConfig.HTTPS_SUPPORT, Boolean.class, true);
                         bind(DpwsConfig.HTTP_SUPPORT, Boolean.class, false);
+                        bind(DpwsConfig.MULTICAST_TTL, Integer.class, multicastTTL);
                     }
                 },
                 new AbstractModule() {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/sdcri/testclient/TestClientUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/sdcri/testclient/TestClientUtil.java
@@ -7,6 +7,7 @@
 
 package com.draeger.medical.sdccc.sdcri.testclient;
 
+import com.draeger.medical.sdccc.configuration.TestSuiteConfig;
 import com.draeger.medical.sdccc.messages.MessageStorage;
 import com.draeger.medical.sdccc.sdcri.CommunicationLogMessageStorage;
 import com.draeger.medical.sdccc.tests.util.MdibHistorian;
@@ -62,7 +63,7 @@ public class TestClientUtil {
             final CryptoSettings cryptoSettings,
             final CommunicationLogMessageStorage communicationLogMessageStorage,
             final TestRunObserver testRunObserver,
-            @Named(DpwsConfig.MULTICAST_TTL) final Integer multicastTTL) {
+            @Named(TestSuiteConfig.NETWORK_MULTICAST_TTL) final Long multicastTTL) {
 
         injector = createClientInjector(List.of(
                 new AbstractConfigurationModule() {
@@ -75,7 +76,7 @@ public class TestClientUtil {
                                 (hostname, session) -> true);
                         bind(DpwsConfig.HTTPS_SUPPORT, Boolean.class, true);
                         bind(DpwsConfig.HTTP_SUPPORT, Boolean.class, false);
-                        bind(DpwsConfig.MULTICAST_TTL, Integer.class, multicastTTL);
+                        bind(DpwsConfig.MULTICAST_TTL, Integer.class, multicastTTL.intValue());
                     }
                 },
                 new AbstractModule() {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/sdcri/testclient/TestClientUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/sdcri/testclient/TestClientUtil.java
@@ -54,6 +54,8 @@ public class TestClientUtil {
      * @param cryptoSettings                 crypto setting
      * @param communicationLogMessageStorage connector to the {@linkplain MessageStorage} to write to
      * @param testRunObserver                observer for invalidating test runs on unexpected errors
+     * @param multicastTTL                   TTL for multicast packets used in Discovery.
+     *                                       Values from 1 to 255 are valid.
      */
     @Inject
     public TestClientUtil(

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
@@ -70,6 +70,7 @@ import org.junit.jupiter.api.Timeout;
 import org.somda.sdc.biceps.common.storage.PreprocessingException;
 import org.somda.sdc.common.guice.AbstractConfigurationModule;
 import org.somda.sdc.dpws.CommunicationLog;
+import org.somda.sdc.dpws.DpwsConfig;
 import org.somda.sdc.dpws.crypto.CryptoSettings;
 import org.somda.sdc.dpws.factory.CommunicationLogFactory;
 import org.somda.sdc.dpws.factory.TransportBindingFactory;
@@ -393,6 +394,7 @@ public class TestSuiteIT {
             bind(TestSuiteConfig.PROVIDER_DEVICE_EPR, String.class, DUT_EPR);
 
             bind(TestSuiteConfig.NETWORK_INTERFACE_ADDRESS, String.class, "127.0.0.1");
+            bind(DpwsConfig.MULTICAST_TTL, Integer.class, 128);
 
             bind(HibernateConfig.class).to(HibernateConfigInMemoryImpl.class).in(Singleton.class);
             install(new FactoryModuleBuilder()


### PR DESCRIPTION
Added the configuration Option  SDCcc.Network.MulticastTTL with a default value of 128 to the config.toml to allow users to configure the Time To Live of the Multicast Packets used in Discovery.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
