### PR TITLE
removed setMetricQualityValidity manipulation

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
@@ -24,7 +24,6 @@ import org.somda.sdc.biceps.model.participant.AlertSignalManifestation;
 import org.somda.sdc.biceps.model.participant.ComponentActivation;
 import org.somda.sdc.biceps.model.participant.ContextAssociation;
 import org.somda.sdc.biceps.model.participant.LocationDetail;
-import org.somda.sdc.biceps.model.participant.MeasurementValidity;
 import org.somda.sdc.biceps.model.participant.MetricCategory;
 
 /**
@@ -193,19 +192,6 @@ public class FallbackManipulations implements Manipulations {
     public ResponseTypes.Result setComponentActivation(final String handle, final ComponentActivation activationState) {
         final var interactionMessage =
                 String.format("Set activation state for handle %s to %s", handle, activationState.name());
-        final var interactionResult = interactionFactory
-                .createUserInteraction(new FilterInputStream(System.in) {
-                    @Override
-                    public void close() {}
-                })
-                .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
-    }
-
-    @Override
-    public ResponseTypes.Result setMetricQualityValidity(final String handle, final MeasurementValidity validity) {
-        final var interactionMessage =
-                String.format("Set metric quality validity for handle %s to %s", handle, validity.name());
         final var interactionResult = interactionFactory
                 .createUserInteraction(new FilterInputStream(System.in) {
                     @Override

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
@@ -271,21 +271,6 @@ public class GRpcManipulations implements Manipulations {
     }
 
     @Override
-    public ResponseTypes.Result setMetricQualityValidity(final String handle, final MeasurementValidity validity) {
-        final var message = MetricRequests.SetMetricQualityValidityRequest.newBuilder()
-                .setHandle(handle)
-                .setValidity(toApiMeasurementValidityType(validity))
-                .build();
-
-        return performCallWrapper(
-                v -> metricStub.setMetricQualityValidity(message),
-                v -> fallback.setMetricQualityValidity(handle, validity),
-                BasicResponses.BasicResponse::getResult,
-                BasicResponses.BasicResponse::getResult,
-                ManipulationParameterUtil.buildMetricQualityValidityManipulationParameterData(handle, validity));
-    }
-
-    @Override
     public ResponseTypes.Result setMetricStatus(
             final String handle, final MetricCategory category, final ComponentActivation activation) {
         final var metricStatus = getMetricStatus(activation);

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
@@ -17,7 +17,6 @@ import org.somda.sdc.biceps.model.participant.AlertSignalManifestation;
 import org.somda.sdc.biceps.model.participant.ComponentActivation;
 import org.somda.sdc.biceps.model.participant.ContextAssociation;
 import org.somda.sdc.biceps.model.participant.LocationDetail;
-import org.somda.sdc.biceps.model.participant.MeasurementValidity;
 import org.somda.sdc.biceps.model.participant.MetricCategory;
 
 /**
@@ -117,15 +116,6 @@ public interface Manipulations {
      * @return the result of the manipulation
      */
     ResponseTypes.Result setComponentActivation(String handle, ComponentActivation activationState);
-
-    /**
-     * Set the metric quality validity of an metric value.
-     *
-     * @param handle state handle to set the validity attribute of the metric quality for
-     * @param validity new validity attribute to set
-     * @return the result of the manipulation
-     */
-    ResponseTypes.Result setMetricQualityValidity(String handle, MeasurementValidity validity);
 
     /**
      * Set the metric to a specific state to trigger the setting of the ActivationState.


### PR DESCRIPTION
The manipulation setMetricQualityValidity was unused and thus removed.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
