### PR TITLE
Detect encoding problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - message encoding errors are summarized by default, but all information is available via the configuration option
   SDCcc.SummarizeMessageEncodingErrors.
 - checking for message encoding errors can be disabled using the configuration option SDCcc.EnableMessageEncodingCheck.
+  - when enabled, SDCcc also checks if message bodies can be decoded using the encoding specified.
 - configuration option SDCcc.Network.MulticastTTL to configure the Time To Live of the Multicast Packets used for Discovery.
-- SDCcc now checks the encodings of all messages when SDCcc.EnableMessageEncodingCheck is enabled.
 
 ### Changed
 - SDCri version 4.1.0-SNAPSHOT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SDCcc.SummarizeMessageEncodingErrors.
 - checking for message encoding errors can be disabled using the configuration option SDCcc.EnableMessageEncodingCheck.
 - configuration option SDCcc.Network.MulticastTTL to configure the Time To Live of the Multicast Packets used for Discovery.
+- SDCcc now checks the encodings of all messages when SDCcc.EnableMessageEncodingCheck is enabled.
 
 ### Changed
 - SDCri version 4.1.0-SNAPSHOT

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
@@ -281,15 +281,17 @@ public class MessageStorage implements AutoCloseable {
                 final var decodingResult = charsetDecoder.decode(ByteBuffer.wrap(message.getFinalMemory()));
                 body = decodingResult.toString();
             } catch (CharacterCodingException e) {
-                if (this.summarizeMessageEncodingErrors) {
-                    // TestRun will be invalidated in TestSuite if messageEncodingErrorCount > 0
-                    this.messageEncodingErrorCount += 1;
-                } else {
-                    this.testRunObserver.invalidateTestRun(String.format(
-                            "Encountered message encoding problem: charset %s was specified, but message "
-                                    + "cannot be decoded using this charset. Either the specified charset is incorrect, "
-                                    + "or the message contains invalid characters (Message UID='%s').",
-                            messageCharset, message.getID()));
+                if (this.enableEncodingCheck) {
+                    if (this.summarizeMessageEncodingErrors) {
+                        // TestRun will be invalidated in TestSuite if messageEncodingErrorCount > 0
+                        this.messageEncodingErrorCount += 1;
+                    } else {
+                        this.testRunObserver.invalidateTestRun(String.format(
+                                "Encountered message encoding problem: charset %s was specified, but message "
+                                        + "cannot be decoded using this charset. Either the specified charset is incorrect, "
+                                        + "or the message contains invalid characters (Message UID='%s').",
+                                messageCharset, message.getID()));
+                    }
                 }
                 body = new String(message.getFinalMemory(), messageCharset);
             }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
@@ -170,10 +170,10 @@ public class MessageStorage implements AutoCloseable {
     private final CyclicBarrier flushBarrier;
 
     private final TestRunObserver testRunObserver;
-    private boolean summarizeMessageEncodingErrors;
+    private final boolean summarizeMessageEncodingErrors;
     private long messageEncodingErrorCount;
     private int invalidMimeTypeCount;
-    private boolean enableEncodingCheck;
+    private final boolean enableEncodingCheck;
 
     @Inject
     MessageStorage(

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
@@ -2688,13 +2688,14 @@ public class TestMessageStorage {
      * @throws IOException - when something goes wrong.
      */
     @Test
-    public void testConvertToMessageContentWhenSummarizeEncodingProblemsIsEnabled(@TempDir final File dir) throws IOException {
+    public void testConvertToMessageContentWhenSummarizeEncodingProblemsIsEnabled(@TempDir final File dir)
+            throws IOException {
 
         final Charset charsetInHttpHeader = StandardCharsets.UTF_8;
         final Charset charsetInXMLDeclaration = StandardCharsets.UTF_8;
         final String mimeType = "application/xml";
 
-        MessageStorage storage;
+        final MessageStorage storage;
         try (final MessageStorage messageStorage = new MessageStorage(
                 1, true, true, mock(MessageFactory.class), new HibernateConfigImpl(dir), this.testRunObserver)) {
             // given
@@ -2734,7 +2735,8 @@ public class TestMessageStorage {
      * @throws IOException - when something goes wrong.
      */
     @Test
-    public void testConvertToMessageContentDoNotFailWhenEncodingCheckIsDisabled(@TempDir final File dir) throws IOException {
+    public void testConvertToMessageContentDoNotFailWhenEncodingCheckIsDisabled(@TempDir final File dir)
+            throws IOException {
 
         final Charset charsetInHttpHeader = StandardCharsets.UTF_8;
         final Charset charsetInXMLDeclaration = StandardCharsets.UTF_8;

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
@@ -2517,7 +2517,7 @@ public class TestMessageStorage {
      * @throws IOException - when something goes wrong.
      */
     @Test
-    public void testConvertToMessageContent(@TempDir final File dir) throws IOException {
+    public void testConvertMessageToMessageContent(@TempDir final File dir) throws IOException {
 
         final Charset charsetInHttpHeader = StandardCharsets.UTF_8;
         final Charset charsetInXMLDeclaration = StandardCharsets.UTF_8;
@@ -2550,12 +2550,13 @@ public class TestMessageStorage {
 
             // then
             assertNotNull(result);
-            assertFalse(testRunObserver.isInvalid());
+            assertEquals(content, result.getBody());
+            verifyNoInteractions(testRunObserver);
         }
     }
 
     /**
-     * Checks that convertMessageToMessageContent() works when it does not detect any decoding problems in the message.
+     * Checks that convertMessageToMessageContent() fails when it detects a decoding problem in the message.
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2596,7 +2597,7 @@ public class TestMessageStorage {
     }
 
     /**
-     * Checks that convertMessageToMessageContent() works when it does not detect any decoding problems in the message.
+     * Checks that convertMessageToMessageContent() fails when it detects a decoding problem in the message.
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2639,7 +2640,7 @@ public class TestMessageStorage {
     }
 
     /**
-     * Checks that convertMessageToMessageContent() works when it does not detect any decoding problems in the message.
+     * Checks that convertMessageToMessageContent() fails when it detects a decoding problem in the message.
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
@@ -1840,6 +1840,7 @@ public class TestMessageStorage {
 
     /**
      * Tests if determineCharsetFromMessage() correctly determines the Charset when it is given in the HTTP Header.
+     *
      * @param dir - temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -1913,6 +1914,7 @@ public class TestMessageStorage {
 
     /**
      * Ensures that no charset determination is performed if the EnableMessageEncodingCheck configuration is set to false.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -1994,6 +1996,7 @@ public class TestMessageStorage {
     /**
      * Tests if determineCharsetFromMessage() correctly detects the Charset when it is given in the HTTP Header and
      * Quotes are used.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2027,6 +2030,7 @@ public class TestMessageStorage {
     /**
      * Tests if determineCharsetFromMessage() correctly detects the Charset when it is given in the HTTP Header and
      * Double-Quotes are used.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2062,6 +2066,7 @@ public class TestMessageStorage {
     /**
      * Tests if determineCharsetFromMessage() correctly detects the Charset when it is given in the HTTP Header and
      * a boundary is given as well.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2096,6 +2101,7 @@ public class TestMessageStorage {
     /**
      * Tests if determineCharsetFromMessage() correctly detects the Charset when it is given in the HTTP Header and
      * a boundary is given as well.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2129,6 +2135,7 @@ public class TestMessageStorage {
 
     /**
      * Tests if determineCharsetFromMessage() correctly detects the Charset when it is given in the XML Declaration.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2166,6 +2173,7 @@ public class TestMessageStorage {
     /**
      * Tests if determineCharsetFromMessage() correctly detects an EBCDIC Charset when it is given in the
      * XML Declaration.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2203,6 +2211,7 @@ public class TestMessageStorage {
     /**
      * Tests if determineCharsetFromMessage() correctly detects the Charset when it is given in the XML Declaration
      * using single quotes.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2240,6 +2249,7 @@ public class TestMessageStorage {
 
     /**
      * Tests if determineCharsetFromMessage() correctly detects the Charset when it is given in the Byte Order Mark.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2295,6 +2305,7 @@ public class TestMessageStorage {
     /**
      * Tests if determineCharsetFromMessage() invalidates the TestRun when the Charset of a message cannot be
      * determined.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2334,6 +2345,7 @@ public class TestMessageStorage {
     /**
      * Ensures that determineCharsetFromMessage() does not invalidate the TestRun when there are multiple Charset
      * declarations within a message that are consistent.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2354,6 +2366,7 @@ public class TestMessageStorage {
     /**
      * Checks that determineCharsetFromMessage() invalidate the TestRun when there are multiple Charset
      * declarations within a message that are inconsistent.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2375,6 +2388,7 @@ public class TestMessageStorage {
     /**
      * Checks that determineCharsetFromMessage() invalidate the TestRun when there are multiple Charset
      * declarations within a message that are inconsistent.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2396,6 +2410,7 @@ public class TestMessageStorage {
     /**
      * Checks that determineCharsetFromMessage() invalidate the TestRun when there are multiple Charset
      * declarations within a message that are inconsistent.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2417,6 +2432,7 @@ public class TestMessageStorage {
     /**
      * Checks that determineCharsetFromMessage() invalidate the TestRun when there are multiple Charset
      * declarations within a message that are inconsistent.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2437,6 +2453,7 @@ public class TestMessageStorage {
     /**
      * Checks that determineCharsetFromMessage() invalidate the TestRun when there are multiple Charset
      * declarations within a message that are inconsistent.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2458,6 +2475,7 @@ public class TestMessageStorage {
     /**
      * Checks that determineCharsetFromMessage() invalidate the TestRun when there are multiple Charset
      * declarations within a message that are inconsistent.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2479,6 +2497,7 @@ public class TestMessageStorage {
     /**
      * Checks that determineCharsetFromMessage() invalidate the TestRun when the given Mime Type is not
      * standard-compliant.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2499,6 +2518,7 @@ public class TestMessageStorage {
     /**
      * Checks that determineCharsetFromMessage() invalidate the TestRun when there are multiple Charset
      * declarations within a message that are inconsistent.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2513,6 +2533,7 @@ public class TestMessageStorage {
 
     /**
      * Checks that convertMessageToMessageContent() works when it does not detect any decoding problems in the message.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2557,6 +2578,7 @@ public class TestMessageStorage {
 
     /**
      * Checks that convertMessageToMessageContent() fails when it detects a decoding problem in the message.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2598,6 +2620,7 @@ public class TestMessageStorage {
 
     /**
      * Checks that convertMessageToMessageContent() fails when it detects a decoding problem in the message.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2641,6 +2664,7 @@ public class TestMessageStorage {
 
     /**
      * Checks that convertMessageToMessageContent() fails when it detects a decoding problem in the message.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2685,6 +2709,7 @@ public class TestMessageStorage {
     /**
      * Checks that convertMessageToMessageContent() does not fail the TestRun, but correctly counts the encoding errors
      * when SummarizeEncodingErrors is enabled.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2732,6 +2757,7 @@ public class TestMessageStorage {
 
     /**
      * Checks that convertMessageToMessageContent() does not fail when the Encodingcheck is disabled.
+     *
      * @param dir - a temporary directory.
      * @throws IOException - when something goes wrong.
      */
@@ -2776,10 +2802,11 @@ public class TestMessageStorage {
 
     /**
      * Checks that determineCharsetFromMessage() works with the given Charsets.
-     * @param dir - a temporary directory.
-     * @param charsetInHttpHeader - the Charset contained in the HTTP Header.
-     * @param bom   - the ByteOrderMark in the message body.
-     * @param charsetInXMLDeclaration - the Charset declared in the XML Declaration.
+     *
+     * @param dir                             - a temporary directory.
+     * @param charsetInHttpHeader             - the Charset contained in the HTTP Header.
+     * @param bom                             - the ByteOrderMark in the message body.
+     * @param charsetInXMLDeclaration         - the Charset declared in the XML Declaration.
      * @param charsetInXMLDeclarationEncoding - the Charset in which the XML Declaration is encoded.
      * @throws IOException - when something goes wrong.
      */

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
@@ -9,15 +9,17 @@ package com.draeger.medical.sdccc.messages;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -104,6 +106,9 @@ public class TestMessageStorage {
                     + "</msg:MetricState>"
                     + "</msg:ReportPart>"
                     + "</msg:EpisodicMetricReport>";
+    private static final byte[] ACTION_ENVELOPE = String.format(
+                    BASE_MESSAGE_STRING, "action", String.format(SEQUENCE_ID_METRIC_BODY_STRING, "3", "1"))
+            .getBytes(StandardCharsets.UTF_8);
     private static final String SEQUENCE_ID_ALERT_BODY_STRING =
             "<msg:EpisodicAlertReport MdibVersion=\"%s\" SequenceId=\"urn:uuid:%s\">"
                     + "<msg:ReportPart>"
@@ -253,9 +258,7 @@ public class TestMessageStorage {
                     CommunicationLog.MessageType.REQUEST,
                     headerContext,
                     messageStorage)) {
-                message.write(String.format(
-                                BASE_MESSAGE_STRING, "action", String.format(SEQUENCE_ID_METRIC_BODY_STRING, "3", "1"))
-                        .getBytes(StandardCharsets.UTF_8));
+                message.write(ACTION_ENVELOPE);
             }
             messageStorage.flush();
 
@@ -1864,8 +1867,7 @@ public class TestMessageStorage {
 
             // then
             assertEquals(Charset.forName("ISO-8859-13"), actualCharset);
-            Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                    .invalidateTestRun(anyString());
+            verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
         }
     }
 
@@ -1985,7 +1987,7 @@ public class TestMessageStorage {
 
             // then
             assertEquals(StandardCharsets.UTF_8, actualCharset);
-            Mockito.verifyNoInteractions(this.testRunObserver);
+            verifyNoInteractions(this.testRunObserver);
         }
     }
 
@@ -2018,8 +2020,7 @@ public class TestMessageStorage {
             final Charset actualCharset = messageStorage.determineCharsetFromMessage(message);
             // then
             assertEquals(Charset.forName("ISO-8859-13"), actualCharset);
-            Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                    .invalidateTestRun(anyString());
+            verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
         }
     }
 
@@ -2054,8 +2055,7 @@ public class TestMessageStorage {
 
             // then
             assertEquals(Charset.forName("ISO-8859-13"), actualCharset);
-            Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                    .invalidateTestRun(anyString());
+            verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
         }
     }
 
@@ -2089,8 +2089,7 @@ public class TestMessageStorage {
 
             // then
             assertEquals(Charset.forName("ISO-8859-13"), actualCharset);
-            Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                    .invalidateTestRun(anyString());
+            verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
         }
     }
 
@@ -2124,8 +2123,7 @@ public class TestMessageStorage {
 
             // then
             assertEquals(Charset.forName("ISO-8859-13"), actualCharset);
-            Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                    .invalidateTestRun(anyString());
+            verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
         }
     }
 
@@ -2161,8 +2159,7 @@ public class TestMessageStorage {
 
             // then
             assertEquals(StandardCharsets.ISO_8859_1, actualCharset);
-            Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                    .invalidateTestRun(anyString());
+            verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
         }
     }
 
@@ -2199,8 +2196,7 @@ public class TestMessageStorage {
 
             // then
             assertEquals(Charset.forName("ebcdic-gb-285+euro"), actualCharset);
-            Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                    .invalidateTestRun(anyString());
+            verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
         }
     }
 
@@ -2238,8 +2234,7 @@ public class TestMessageStorage {
 
             // then
             assertEquals(StandardCharsets.ISO_8859_1, actualCharset);
-            Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                    .invalidateTestRun(anyString());
+            verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
         }
     }
 
@@ -2289,10 +2284,10 @@ public class TestMessageStorage {
             // then
             assertEquals(charset, actualCharset);
             if (expectFailure) {
-                Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
+                verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
                         .invalidateTestRun(anyString());
             } else {
-                Mockito.verifyNoInteractions(this.testRunObserver);
+                verifyNoInteractions(this.testRunObserver);
             }
         }
     }
@@ -2332,8 +2327,7 @@ public class TestMessageStorage {
 
             // then
             assertEquals(StandardCharsets.UTF_8, actualCharset);
-            Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                    .invalidateTestRun(anyString());
+            verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
         }
     }
 
@@ -2354,7 +2348,7 @@ public class TestMessageStorage {
                 "application/soap+xml");
         // then
         assertEquals(StandardCharsets.UTF_8, actualCharset);
-        Mockito.verifyNoInteractions(this.testRunObserver);
+        verifyNoInteractions(this.testRunObserver);
     }
 
     /**
@@ -2375,8 +2369,7 @@ public class TestMessageStorage {
                 "application/soap+xml");
         // then
         assertEquals(Charset.forName("CP1147"), actualCharset);
-        Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                .invalidateTestRun(anyString());
+        verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
     }
 
     /**
@@ -2397,8 +2390,7 @@ public class TestMessageStorage {
                 "application/soap+xml");
         // then
         assertEquals(StandardCharsets.ISO_8859_1, actualCharset);
-        Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                .invalidateTestRun(anyString());
+        verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
     }
 
     /**
@@ -2419,8 +2411,7 @@ public class TestMessageStorage {
                 "application/soap+xml");
         // then
         assertEquals(StandardCharsets.ISO_8859_1, actualCharset);
-        Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                .invalidateTestRun(anyString());
+        verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
     }
 
     /**
@@ -2440,8 +2431,7 @@ public class TestMessageStorage {
                 "application/soap+xml");
         // then
         assertEquals(StandardCharsets.UTF_8, actualCharset);
-        Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                .invalidateTestRun(anyString());
+        verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
     }
 
     /**
@@ -2462,8 +2452,7 @@ public class TestMessageStorage {
                 "application/soap+xml");
         // then
         assertEquals(StandardCharsets.UTF_8, actualCharset);
-        Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                .invalidateTestRun(anyString());
+        verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
     }
 
     /**
@@ -2484,8 +2473,7 @@ public class TestMessageStorage {
                 "application/soap+xml");
         // then
         assertEquals(StandardCharsets.UTF_8, actualCharset);
-        Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                .invalidateTestRun(anyString());
+        verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
     }
 
     /**
@@ -2505,8 +2493,7 @@ public class TestMessageStorage {
                 "text/xml");
         // then
         assertEquals(StandardCharsets.UTF_8, actualCharset);
-        Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                .invalidateTestRun(anyString());
+        verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
     }
 
     /**
@@ -2521,10 +2508,188 @@ public class TestMessageStorage {
                 dir, null, null, StandardCharsets.ISO_8859_1, StandardCharsets.UTF_8, "application/soap+xml");
         // then
         assertEquals(StandardCharsets.ISO_8859_1, actualCharset);
-        Mockito.verify(this.testRunObserver, VerificationModeFactory.atLeastOnce())
-                .invalidateTestRun(anyString());
+        verify(this.testRunObserver, VerificationModeFactory.atLeastOnce()).invalidateTestRun(anyString());
     }
 
+    /**
+     * Checks that convertMessageToMessageContent() works when it does not detect any decoding problems in the message.
+     * @param dir - a temporary directory.
+     * @throws IOException - when something goes wrong.
+     */
+    @Test
+    public void testConvertToMessageContent(@TempDir final File dir) throws IOException {
+
+        final Charset charsetInHttpHeader = StandardCharsets.UTF_8;
+        final Charset charsetInXMLDeclaration = StandardCharsets.UTF_8;
+        final Charset charsetInXMLDeclarationEncoding = StandardCharsets.UTF_8;
+        final String mimeType = "application/xml";
+
+        try (final MessageStorage messageStorage = new MessageStorage(
+                1, false, true, mock(MessageFactory.class), new HibernateConfigImpl(dir), this.testRunObserver)) {
+            // given
+            final ListMultimap<String, String> headers = ArrayListMultimap.create();
+            headers.put("Content-Type", String.format("%s;charset=%s", mimeType, charsetInHttpHeader));
+
+            final HttpApplicationInfo applicationInfo = new HttpApplicationInfo(headers, "transactionId", "requestURI");
+            final TransportInfo transportInfo =
+                    new TransportInfo("http", "localhost", 1234, "remotehost", 4567, List.of());
+            final CommunicationContext communicationContext = new CommunicationContext(applicationInfo, transportInfo);
+            final Message message = new Message(
+                    CommunicationLog.Direction.INBOUND,
+                    CommunicationLog.MessageType.REQUEST,
+                    communicationContext,
+                    messageStorage);
+            final String content = String.format(
+                    "<?xml version=\"1.0\" encoding=\"%s\"?>%n<sometag></sometag>", charsetInXMLDeclaration);
+            final byte[] encodedContent = content.getBytes(charsetInXMLDeclarationEncoding);
+            message.write(encodedContent, 0, encodedContent.length);
+            message.close();
+
+            // when
+            final var result = messageStorage.convertMessageToMessageContent(message);
+
+            // then
+            assertNotNull(result);
+            assertFalse(testRunObserver.isInvalid());
+        }
+    }
+
+    /**
+     * Checks that convertMessageToMessageContent() works when it does not detect any decoding problems in the message.
+     * @param dir - a temporary directory.
+     * @throws IOException - when something goes wrong.
+     */
+    @Test
+    public void testConvertToMessageContentFailOnEncodingProblem(@TempDir final File dir) throws IOException {
+
+        final Charset charsetInHttpHeader = StandardCharsets.US_ASCII;
+        final Charset charsetInXMLDeclaration = StandardCharsets.US_ASCII;
+        final String mimeType = "application/xml";
+
+        try (final MessageStorage messageStorage = new MessageStorage(
+                1, false, true, mock(MessageFactory.class), new HibernateConfigImpl(dir), this.testRunObserver)) {
+            // given
+            final ListMultimap<String, String> headers = ArrayListMultimap.create();
+            headers.put("Content-Type", String.format("%s;charset=%s", mimeType, charsetInHttpHeader));
+
+            final HttpApplicationInfo applicationInfo = new HttpApplicationInfo(headers, "transactionId", "requestURI");
+            final TransportInfo transportInfo =
+                    new TransportInfo("http", "localhost", 1234, "remotehost", 4567, List.of());
+            final CommunicationContext communicationContext = new CommunicationContext(applicationInfo, transportInfo);
+            final Message message = new Message(
+                    CommunicationLog.Direction.INBOUND,
+                    CommunicationLog.MessageType.REQUEST,
+                    communicationContext,
+                    messageStorage);
+            final String content = String.format(
+                    "<?xml version=\"1.0\" encoding=\"%s\"?>%n<sometag>üöä</sometag>", charsetInXMLDeclaration);
+            final byte[] encodedContent = content.getBytes(StandardCharsets.UTF_8);
+            message.write(encodedContent, 0, encodedContent.length);
+            message.close();
+
+            // when
+            final var result = messageStorage.convertMessageToMessageContent(message);
+            // then
+            assertNotNull(result);
+        }
+        verify(testRunObserver, times(4)).invalidateTestRun(anyString());
+    }
+
+    /**
+     * Checks that convertMessageToMessageContent() works when it does not detect any decoding problems in the message.
+     * @param dir - a temporary directory.
+     * @throws IOException - when something goes wrong.
+     */
+    @Test
+    public void testConvertToMessageContentFailOnEncodingProblem2(@TempDir final File dir) throws IOException {
+
+        final Charset charsetInHttpHeader = StandardCharsets.UTF_8;
+        final Charset charsetInXMLDeclaration = StandardCharsets.UTF_8;
+        final String mimeType = "application/xml";
+
+        try (final MessageStorage messageStorage = new MessageStorage(
+                1, false, true, mock(MessageFactory.class), new HibernateConfigImpl(dir), this.testRunObserver)) {
+            // given
+            final ListMultimap<String, String> headers = ArrayListMultimap.create();
+            headers.put("Content-Type", String.format("%s;charset=%s", mimeType, charsetInHttpHeader));
+
+            final HttpApplicationInfo applicationInfo = new HttpApplicationInfo(headers, "transactionId", "requestURI");
+            final TransportInfo transportInfo =
+                    new TransportInfo("http", "localhost", 1234, "remotehost", 4567, List.of());
+            final CommunicationContext communicationContext = new CommunicationContext(applicationInfo, transportInfo);
+            final Message message = new Message(
+                    CommunicationLog.Direction.INBOUND,
+                    CommunicationLog.MessageType.REQUEST,
+                    communicationContext,
+                    messageStorage);
+            final String content = String.format(
+                    "<?xml version=\"1.0\" encoding=\"%s\"?>%n<sometag>üöä</sometag>", charsetInXMLDeclaration);
+            final byte[] encodedContent = content.getBytes(StandardCharsets.UTF_16);
+
+            message.write(encodedContent, 0, encodedContent.length);
+            message.close();
+
+            // when
+            final var result = messageStorage.convertMessageToMessageContent(message);
+
+            // then
+            assertNotNull(result);
+        }
+        verify(testRunObserver, times(6)).invalidateTestRun(anyString());
+    }
+
+    /**
+     * Checks that convertMessageToMessageContent() works when it does not detect any decoding problems in the message.
+     * @param dir - a temporary directory.
+     * @throws IOException - when something goes wrong.
+     */
+    @Test
+    public void testConvertToMessageContentFailOnEncodingProblem3(@TempDir final File dir) throws IOException {
+
+        final Charset charsetInHttpHeader = StandardCharsets.UTF_8;
+        final Charset charsetInXMLDeclaration = StandardCharsets.UTF_8;
+        final String mimeType = "application/xml";
+
+        try (final MessageStorage messageStorage = new MessageStorage(
+                1, false, true, mock(MessageFactory.class), new HibernateConfigImpl(dir), this.testRunObserver)) {
+            // given
+            final ListMultimap<String, String> headers = ArrayListMultimap.create();
+            headers.put("Content-Type", String.format("%s;charset=%s", mimeType, charsetInHttpHeader));
+
+            final HttpApplicationInfo applicationInfo = new HttpApplicationInfo(headers, "transactionId", "requestURI");
+            final TransportInfo transportInfo =
+                    new TransportInfo("http", "localhost", 1234, "remotehost", 4567, List.of());
+            final CommunicationContext communicationContext = new CommunicationContext(applicationInfo, transportInfo);
+            final Message message = new Message(
+                    CommunicationLog.Direction.INBOUND,
+                    CommunicationLog.MessageType.REQUEST,
+                    communicationContext,
+                    messageStorage);
+            final String content = String.format(
+                    "<?xml version=\"1.0\" encoding=\"%s\"?>%n<sometag>üöä</sometag>", charsetInXMLDeclaration);
+            final byte[] encodedContent = content.getBytes(StandardCharsets.ISO_8859_1);
+
+            message.write(encodedContent, 0, encodedContent.length);
+            message.close();
+
+            // when
+            final var result = messageStorage.convertMessageToMessageContent(message);
+
+            // then
+            assertNotNull(result);
+        }
+        verify(testRunObserver, times(2)).invalidateTestRun(anyString());
+    }
+
+    /**
+     * Checks that determineCharsetFromMessage() works with the given Charsets.
+     * @param dir - a temporary directory.
+     * @param charsetInHttpHeader - the Charset contained in the HTTP Header.
+     * @param bom   - the ByteOrderMark in the message body.
+     * @param charsetInXMLDeclaration - the Charset declared in the XML Declaration.
+     * @param charsetInXMLDeclarationEncoding - the Charset in which the XML Declaration is encoded.
+     * @throws IOException - when something goes wrong.
+     */
     private Charset testDetermineCharsetFromMessageUsingCharsets(
             final File dir,
             @Nullable final Charset charsetInHttpHeader,

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
@@ -209,7 +209,9 @@ public class TestSuiteIT {
     public void testInvalid() throws IOException, PreconditionException {
 
         final var preconditionRegistryMock = mock(PreconditionRegistry.class);
-        doThrow(new NullPointerException()).when(preconditionRegistryMock).runPreconditions();
+        doThrow(new NullPointerException("intentional exception for testing purposes"))
+                .when(preconditionRegistryMock)
+                .runPreconditions();
 
         final var injector = getConsumerInjector(false, new AbstractModule() {
             /**


### PR DESCRIPTION
SDCcc currently accepts the encoding specified in a message and uses it to decode the message. When the encoding is specified incorrectly or the message contains characters that are not mappable using the specified encoding, then they are replaced by Charset-specific default characters, which may lead to False-positives or False-negatives in Test Cases that rely on messages stored in the database.

A much better approach would be to check the encoding while decoding the messages and to raise an Encoding Error when decoding a message with the specified encoding fails. As usual, these Encoding Errors can be managed using the EnableMessageEncodingCheck and SummarizeMessageEncodingErrors configuration options.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
