### PR TITLE
Add missing unit tests for preconditions

### DIFF
--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -246,6 +246,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junitVersion}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <reporting>

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -1408,7 +1408,7 @@ public class ManipulationPreconditions {
 
     /**
      * Sets the activation state for every metric with category 'Set' to 'On' and then the status to 'setting
-     * not being performed and is de-initialized,' to trigger an activation state change to 'Off'.
+     * not being performed and is de-initialized' to trigger an activation state change to 'Off'.
      */
     public static class MetricStatusManipulationSETActivationStateOFF extends ManipulationPrecondition {
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2314,8 +2314,6 @@ public class ManipulationPreconditionsTest {
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
     }
 
-    //TODO
-
     @Test
     @DisplayName("testMetricStatusManipulationCLCActivationStateNOTRDY: Set calculations of metrics with category CLC"
             + " to currently initializing to trigger an ActivationState change to NotRdy.")
@@ -2361,6 +2359,96 @@ public class ManipulationPreconditionsTest {
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
     }
+
+    // TODO
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: Set metric with category SET to 'calculation"
+        + " initialized, but is not being performed' which results in activation state STND_BY.")
+    void testMetricStatusManipulationCLCActivationStateSTNDBYGood() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateSTNDBYAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateSTNDBYAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: setComponentActivation failed.")
+    void testMetricStatusManipulationCLCActivationStateSTNDBYBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: setMetricStatus failed.")
+    void testMetricStatusManipulationCLCActivationStateSTNDBYBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
+    }
+
+    //TODO
 
     @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: Set ActivationState of all SET-Metrics to FAIL.")

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2157,6 +2157,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateSHTDNAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.SHTDN);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateSHTDNAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.SHTDN);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateSHTDN: setComponentActivation failed.")
     void testMetricStatusManipulationSETActivationStateSHTDNBadFirstManipulationFailed() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
@@ -2554,6 +2597,49 @@ public class ManipulationPreconditionsTest {
                 "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateSHTDNAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateSHTDNNAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
     }
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2579,7 +2579,7 @@ public class ManipulationPreconditionsTest {
         "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2144,6 +2144,91 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateOFF: Setting a metric with category SET to `setting\n"
+        + " not being performed and is de-initialized` results in activation state OFF.")
+    void testMetricStatusManipulationSETActivationStateOFFGood() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateOFFAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateOFFAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateOFF: setComponentActivation failed.")
+    void testMetricStatusManipulationSETActivationStateOFFBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateOFF: setMetricStatus failed.")
+    void testMetricStatusManipulationSETActivationStateOFFBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationCLCActivationStateNOTRDY: Set calculations of metrics with category CLC"
             + " to currently initializing to trigger an ActivationState change to NotRdy.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYGood() {
@@ -2791,7 +2876,6 @@ public class ManipulationPreconditionsTest {
     }
 
     // TODO:
-    //  MetricStatusManipulationSETActivationStateSTNDBY
     //  MetricStatusManipulationSETActivationStateOFF
     //  MetricStatusManipulationCLCActivationStateON
     //  MetricStatusManipulationCLCActivationStateSTNDBY

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -54,6 +54,9 @@ import org.somda.sdc.biceps.model.participant.AbstractMetricState;
 import org.somda.sdc.biceps.model.participant.AlertActivation;
 import org.somda.sdc.biceps.model.participant.AlertConditionDescriptor;
 import org.somda.sdc.biceps.model.participant.AlertConditionState;
+import org.somda.sdc.biceps.model.participant.AlertSignalDescriptor;
+import org.somda.sdc.biceps.model.participant.AlertSignalManifestation;
+import org.somda.sdc.biceps.model.participant.AlertSignalState;
 import org.somda.sdc.biceps.model.participant.AlertSystemDescriptor;
 import org.somda.sdc.biceps.model.participant.AlertSystemState;
 import org.somda.sdc.biceps.model.participant.BatteryState;
@@ -67,6 +70,7 @@ import org.somda.sdc.biceps.model.participant.MetricCategory;
 import org.somda.sdc.biceps.model.participant.PatientContextDescriptor;
 import org.somda.sdc.biceps.model.participant.PatientContextState;
 import org.somda.sdc.biceps.model.participant.ScoState;
+import org.somda.sdc.biceps.model.participant.SystemSignalActivation;
 import org.somda.sdc.biceps.model.participant.VmdState;
 import org.somda.sdc.glue.consumer.SdcRemoteDevice;
 
@@ -85,6 +89,11 @@ public class ManipulationPreconditionsTest {
     private static final String ALERT_SYSTEM_CONTEXT_HANDLE2 = "alerthandle2";
     private static final String ALERT_CONDITION_HANDLE = "alertconditionhandle";
     private static final String ALERT_CONDITION_HANDLE2 = "alertconditionhandle2";
+    private static final String ALERT_SIGNAL_HANDLE = "alertSignalHandle";
+    private static final String AUD_ALERT_SIGNAL_HANDLE = "audAlertSignalHandle";
+    private static final String OTH_ALERT_SIGNAL_HANDLE = "othAlertSignalHandle";
+    private static final String TAN_ALERT_SIGNAL_HANDLE = "tanAlertSignalHandle";
+    private static final String VIS_ALERT_SIGNAL_HANDLE = "visAlertSignalHandle";
     private static final String METRIC_HANDLE = "someMetric";
     private static final String VMD_HANDLE = "vmdHandle";
     private static final String VMD_HANDLE2 = "vmdHandleButDifferent";
@@ -105,6 +114,14 @@ public class ManipulationPreconditionsTest {
     private AlertSystemState mockAlertSystemState2;
     private AlertConditionState mockAlertConditionState;
     private AlertConditionState mockAlertConditionState2;
+    private AlertSignalDescriptor mockAudAlertSignalDescriptor;
+    private AlertSignalState mockAudAlertSignalState;
+    private AlertSignalDescriptor mockOthAlertSignalDescriptor;
+    private AlertSignalState mockOthAlertSignalState;
+    private AlertSignalDescriptor mockTanAlertSignalDescriptor;
+    private AlertSignalState mockTanAlertSignalState;
+    private AlertSignalDescriptor mockVisAlertSignalDescriptor;
+    private AlertSignalState mockVisAlertSignalState;
     private AbstractMetricDescriptor mockMetricDescriptor;
     private AbstractMetricDescriptor mockMetricDescriptor2;
     private AbstractMetricState mockMetricState;
@@ -115,6 +132,10 @@ public class ManipulationPreconditionsTest {
     private ScoState mockScoState;
     private ClockState mockClockState;
     private BatteryState mockBatteryState;
+    private SystemSignalActivation mockSystemSignalActivationAud;
+    private SystemSignalActivation mockSystemSignalActivationOth;
+    private SystemSignalActivation mockSystemSignalActivationTan;
+    private SystemSignalActivation mockSystemSignalActivationVis;
     private TestRunObserver testRunObserver;
     private MdibEntity mockEntity;
     private MdibEntity mockEntity2;
@@ -134,6 +155,14 @@ public class ManipulationPreconditionsTest {
         mockAlertSystemState2 = mock(AlertSystemState.class);
         mockAlertConditionState = mock(AlertConditionState.class);
         mockAlertConditionState2 = mock(AlertConditionState.class);
+        mockAudAlertSignalDescriptor = mock(AlertSignalDescriptor.class);
+        mockAudAlertSignalState = mock(AlertSignalState.class);
+        mockOthAlertSignalDescriptor = mock(AlertSignalDescriptor.class);
+        mockOthAlertSignalState = mock(AlertSignalState.class);
+        mockTanAlertSignalDescriptor = mock(AlertSignalDescriptor.class);
+        mockTanAlertSignalState = mock(AlertSignalState.class);
+        mockVisAlertSignalDescriptor = mock(AlertSignalDescriptor.class);
+        mockVisAlertSignalState = mock(AlertSignalState.class);
         mockMetricDescriptor = mock(AbstractMetricDescriptor.class);
         mockMetricDescriptor2 = mock(AbstractMetricDescriptor.class);
         mockMetricState = mock(AbstractMetricState.class);
@@ -144,6 +173,10 @@ public class ManipulationPreconditionsTest {
         mockScoState = mock(ScoState.class);
         mockClockState = mock(ClockState.class);
         mockBatteryState = mock(BatteryState.class);
+        mockSystemSignalActivationAud = mock(SystemSignalActivation.class);
+        mockSystemSignalActivationOth = mock(SystemSignalActivation.class);
+        mockSystemSignalActivationTan = mock(SystemSignalActivation.class);
+        mockSystemSignalActivationVis = mock(SystemSignalActivation.class);
         mockEntity = mock(MdibEntity.class);
         mockEntity2 = mock(MdibEntity.class);
         mockMdibAccess = mock(MdibAccess.class);
@@ -2348,5 +2381,239 @@ public class ManipulationPreconditionsTest {
         verify(mockManipulations, times(2)).setComponentActivation(anyString(), any(ComponentActivation.class));
         verify(mockManipulations).setComponentActivation(SCO_HANDLE, ComponentActivation.OFF);
         verify(mockManipulations).setComponentActivation(CLOCK_HANDLE, ComponentActivation.OFF);
+    }
+
+    private void setUpSystemSignalActivation() {
+        // build system signal activations
+        buildSystemSignalActivation(mockSystemSignalActivationAud, AlertSignalManifestation.AUD);
+        buildSystemSignalActivation(mockSystemSignalActivationOth, AlertSignalManifestation.OTH);
+        buildSystemSignalActivation(mockSystemSignalActivationTan, AlertSignalManifestation.TAN);
+        buildSystemSignalActivation(mockSystemSignalActivationVis, AlertSignalManifestation.VIS);
+        when(mockAlertSystemState.getSystemSignalActivation())
+                .thenReturn(List.of(
+                        mockSystemSignalActivationAud,
+                        mockSystemSignalActivationOth,
+                        mockSystemSignalActivationTan,
+                        mockSystemSignalActivationVis));
+
+        // build alert signals
+        buildAlertSignal(
+                mockAudAlertSignalDescriptor,
+                mockAudAlertSignalState,
+                AUD_ALERT_SIGNAL_HANDLE,
+                AlertSignalManifestation.AUD);
+        buildAlertSignal(
+                mockOthAlertSignalDescriptor,
+                mockOthAlertSignalState,
+                OTH_ALERT_SIGNAL_HANDLE,
+                AlertSignalManifestation.OTH);
+        buildAlertSignal(
+                mockTanAlertSignalDescriptor,
+                mockTanAlertSignalState,
+                TAN_ALERT_SIGNAL_HANDLE,
+                AlertSignalManifestation.TAN);
+        buildAlertSignal(
+                mockVisAlertSignalDescriptor,
+                mockVisAlertSignalState,
+                VIS_ALERT_SIGNAL_HANDLE,
+                AlertSignalManifestation.VIS);
+
+        when(mockEntity.getHandle()).thenReturn(ALERT_SYSTEM_CONTEXT_HANDLE);
+        when(mockEntity.getChildren())
+                .thenReturn(List.of(
+                        AUD_ALERT_SIGNAL_HANDLE,
+                        VIS_ALERT_SIGNAL_HANDLE,
+                        TAN_ALERT_SIGNAL_HANDLE,
+                        OTH_ALERT_SIGNAL_HANDLE));
+        when(mockDevice.getMdibAccess().findEntitiesByType(AlertSystemDescriptor.class))
+                .thenReturn(List.of(mockEntity));
+        when(mockDevice.getMdibAccess().getState(anyString(), eq(AlertSystemState.class)))
+                .thenReturn(Optional.of(mockAlertSystemState));
+        when(mockManipulations.setSystemSignalActivation(
+                        anyString(), any(AlertSignalManifestation.class), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+        when(mockManipulations.setAlertActivation(anyString(), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+    }
+
+    private void buildSystemSignalActivation(
+            final SystemSignalActivation ssa, final AlertSignalManifestation manifestation) {
+        when(ssa.getManifestation()).thenReturn(manifestation);
+        when(ssa.getState())
+                .thenReturn(AlertActivation.ON)
+                .thenReturn(AlertActivation.PSD)
+                .thenReturn(AlertActivation.OFF);
+    }
+
+    private void buildAlertSignal(
+            final AlertSignalDescriptor descriptor,
+            final AlertSignalState state,
+            final String handle,
+            final AlertSignalManifestation manifestation) {
+        when(descriptor.getHandle()).thenReturn(handle);
+        when(descriptor.getManifestation()).thenReturn(manifestation);
+        when(state.getDescriptorHandle()).thenReturn(handle);
+        when(state.getActivationState())
+                .thenReturn(AlertActivation.ON)
+                .thenReturn(AlertActivation.PSD)
+                .thenReturn(AlertActivation.OFF)
+                .thenReturn(AlertActivation.ON)
+                .thenReturn(AlertActivation.PSD)
+                .thenReturn(AlertActivation.OFF)
+                .thenReturn(AlertActivation.ON)
+                .thenReturn(AlertActivation.PSD)
+                .thenReturn(AlertActivation.OFF)
+                .thenReturn(AlertActivation.ON)
+                .thenReturn(AlertActivation.PSD)
+                .thenReturn(AlertActivation.OFF);
+
+        when(mockDevice.getMdibAccess().getDescriptor(handle, AlertSignalDescriptor.class))
+                .thenReturn(Optional.of(descriptor));
+        when(mockDevice.getMdibAccess().getState(handle, AlertSignalState.class))
+                .thenReturn(Optional.of(state));
+    }
+
+    @Test
+    @DisplayName("SystemSignalActivation is successful the system signal activation can be set for every manifestation")
+    void testSystemSignalActivationSuccessful() {
+        setUpSystemSignalActivation();
+
+        assertTrue(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
+
+        // 12 for each manifestation (aud, oth, tan, vis) and every activation state (on, psd, off)
+        final var expectedSystemSignalActivationManipulations = 12;
+        verify(mockManipulations, times(expectedSystemSignalActivationManipulations))
+                .setSystemSignalActivation(
+                        anyString(), any(AlertSignalManifestation.class), any(AlertActivation.class));
+        verify(mockManipulations, times(3))
+                .setSystemSignalActivation(anyString(), eq(AlertSignalManifestation.AUD), any(AlertActivation.class));
+        verify(mockManipulations, times(3))
+                .setSystemSignalActivation(anyString(), eq(AlertSignalManifestation.OTH), any(AlertActivation.class));
+        verify(mockManipulations, times(3))
+                .setSystemSignalActivation(anyString(), eq(AlertSignalManifestation.TAN), any(AlertActivation.class));
+        verify(mockManipulations, times(3))
+                .setSystemSignalActivation(anyString(), eq(AlertSignalManifestation.VIS), any(AlertActivation.class));
+        verify(mockManipulations, times(4))
+                .setSystemSignalActivation(anyString(), any(AlertSignalManifestation.class), eq(AlertActivation.ON));
+        verify(mockManipulations, times(4))
+                .setSystemSignalActivation(anyString(), any(AlertSignalManifestation.class), eq(AlertActivation.PSD));
+        verify(mockManipulations, times(4))
+                .setSystemSignalActivation(anyString(), any(AlertSignalManifestation.class), eq(AlertActivation.OFF));
+
+        // 4 different alert signals (aud, oth, tan, vis) with 3 different activation states (on, psd, off)
+        final var expectedAlertActivationManipulations = 12;
+        verify(mockManipulations, times(expectedAlertActivationManipulations))
+                .setAlertActivation(anyString(), any(AlertActivation.class));
+        verify(mockManipulations, times(3)).setAlertActivation(eq(AUD_ALERT_SIGNAL_HANDLE), any(AlertActivation.class));
+        verify(mockManipulations, times(3)).setAlertActivation(eq(OTH_ALERT_SIGNAL_HANDLE), any(AlertActivation.class));
+        verify(mockManipulations, times(3)).setAlertActivation(eq(TAN_ALERT_SIGNAL_HANDLE), any(AlertActivation.class));
+        verify(mockManipulations, times(3)).setAlertActivation(eq(VIS_ALERT_SIGNAL_HANDLE), any(AlertActivation.class));
+    }
+
+    @Test
+    @DisplayName(
+            "SystemSignalActivation is unsuccessful because the manipulation to set the system signal activation is not supported")
+    void testSystemSignalActivationAllNotSupported() {
+        setUpSystemSignalActivation();
+        when(mockManipulations.setSystemSignalActivation(
+                        anyString(), any(AlertSignalManifestation.class), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
+    }
+
+    @Test
+    @DisplayName(
+            "SystemSignalActivation is successful because at least one manipulation to set the system signal activation is successful and the rest not supported")
+    void testSystemSignalActivationSomeNotSupported() {
+        setUpSystemSignalActivation();
+        when(mockManipulations.setSystemSignalActivation(
+                        anyString(), eq(AlertSignalManifestation.OTH), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        assertTrue(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
+    }
+
+    @Test
+    @DisplayName(
+            "SystemSignalActivation the setAlertActivation manipulation for the child alert signals is not supported")
+    void testSystemSignalActivationChildNotSupported() {
+        setUpSystemSignalActivation();
+        when(mockManipulations.setAlertActivation(anyString(), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        assertTrue(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
+    }
+
+    @Test
+    @DisplayName(
+            "SystemSignalActivation the setAlertActivation manipulation for the child alert signals is not implemented")
+    void testSystemSignalActivationChildNotImplemented() {
+        setUpSystemSignalActivation();
+        when(mockManipulations.setAlertActivation(anyString(), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED);
+
+        assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
+    }
+
+    @Test
+    @DisplayName("SystemSignalActivation the setAlertActivation manipulation for the child alert signals failed")
+    void testSystemSignalActivationChildFailed() {
+        setUpSystemSignalActivation();
+        when(mockManipulations.setAlertActivation(anyString(), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
+    }
+
+    @Test
+    @DisplayName(
+            "SystemSignalActivation is unsuccessful because the manipulation to set the system signal activation is not implemented")
+    void testSystemSignalActivationAllNotImplemented() {
+        setUpSystemSignalActivation();
+        when(mockManipulations.setSystemSignalActivation(
+                        anyString(), any(AlertSignalManifestation.class), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED);
+
+        assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
+    }
+
+    @Test
+    @DisplayName(
+            "SystemSignalActivation is unsuccessful when some manipulations to set the system signal activation are not implemented, but others are successful")
+    void testSystemSignalActivationSomeNotImplemented() {
+        setUpSystemSignalActivation();
+        when(mockManipulations.setSystemSignalActivation(
+                        anyString(), eq(AlertSignalManifestation.AUD), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED);
+
+        assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
+    }
+
+    @Test
+    @DisplayName(
+            "SystemSignalActivation is unsuccessful because the manipulation to set the system signal activation failed")
+    void testSystemSignalActivationAllFail() {
+        setUpSystemSignalActivation();
+        when(mockManipulations.setSystemSignalActivation(
+                        anyString(), any(AlertSignalManifestation.class), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
+        verify(mockManipulations, times(3))
+                .setSystemSignalActivation(
+                        anyString(), any(AlertSignalManifestation.class), any(AlertActivation.class));
+    }
+
+    @Test
+    @DisplayName(
+            "SystemSignalActivation is unsuccessful when some manipulations to set the system signal activation failed, but others are successful")
+    void testSystemSignalActivationSomeFail() {
+        setUpSystemSignalActivation();
+        when(mockManipulations.setSystemSignalActivation(
+                        anyString(), eq(AlertSignalManifestation.TAN), any(AlertActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
 }

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2144,7 +2144,7 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
-    @DisplayName("MetricStatusManipulationSETActivationStateOFF: Setting a metric with category SET to `setting\n"
+    @DisplayName("MetricStatusManipulationSETActivationStateOFF: Setting a metric with category SET to `setting"
         + " not being performed and is de-initialized` results in activation state OFF.")
     void testMetricStatusManipulationSETActivationStateOFFGood() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
@@ -2226,6 +2226,57 @@ public class ManipulationPreconditionsTest {
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: Set ActivationState of all SET-Metrics to FAIL.")
+    void testMetricStatusManipulationSETActivationStateFAILGood() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        assertTrue(
+            ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
+            "The manipulation should have been successful.");
+
+        assertFalse(
+            testRunObserver.isInvalid(),
+            "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
+    }
+
+    @Test
+    @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: setComponentActivation failed.")
+    void testMetricStatusManipulationSETActivationStateFAILBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
+            "The manipulation should not have been successful.");
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: setMetricStatus failed.")
+    void testMetricStatusManipulationSETActivationStateFAILBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
+            "The manipulation should not have been successful.");
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
     }
 
     @Test
@@ -2448,59 +2499,6 @@ public class ManipulationPreconditionsTest {
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
     }
 
-    //TODO
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: Set ActivationState of all SET-Metrics to FAIL.")
-    void testMetricStatusManipulationSETActivationStateFAILGood() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        assertTrue(
-                ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
-                "The manipulation should have been successful.");
-
-        assertFalse(
-                testRunObserver.isInvalid(),
-                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: setComponentActivation failed.")
-    void testMetricStatusManipulationSETActivationStateFAILBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(
-                ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
-                "The manipulation should not have been successful.");
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: setMetricStatus failed.")
-    void testMetricStatusManipulationSETActivationStateFAILBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(
-                ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
-                "The manipulation should not have been successful.");
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
-    }
-
     @Test
     @DisplayName("MetricStatusManipulationCLCActivationStateSHTDN: Set CLC metrics to a state where the calculation"
             + " is currently de-initializing to trigger an activation state change to SHTDN.")
@@ -2545,6 +2543,91 @@ public class ManipulationPreconditionsTest {
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateOFF: Setting a metric with category SET to `calculation"
+        + " not being performed and is de-initialized` results in activation state OFF.")
+    void testMetricStatusManipulationCLCActivationStateOFFGood() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateOFFAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateOFFAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateOFF: setComponentActivation failed.")
+    void testMetricStatusManipulationCLCActivationStateOFFBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateOFF: setMetricStatus failed.")
+    void testMetricStatusManipulationCLCActivationStateOFFBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
     }
 
     @Test
@@ -3050,9 +3133,4 @@ public class ManipulationPreconditionsTest {
 
         assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
-
-    // TODO:
-    //  MetricStatusManipulationCLCActivationStateON
-    //  MetricStatusManipulationCLCActivationStateSTNDBY
-    //  MetricStatusManipulationCLCActivationStateOFF
 }

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2229,6 +2229,94 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateON: Setting a metric with category CLC to `calculation is"
+            + " being performed` results in activation state ON.")
+    void testMetricStatusManipulationCLCActivationStateONGood() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateONAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateONAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateON: setComponentActivation failed.")
+    void testMetricStatusManipulationCLCActivationStateONBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationCLCActivationStateON: setMetricStatus failed.")
+    void testMetricStatusManipulationCLCActivationStateONBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
+    }
+
+    //TODO
+
+    @Test
     @DisplayName("testMetricStatusManipulationCLCActivationStateNOTRDY: Set calculations of metrics with category CLC"
             + " to currently initializing to trigger an ActivationState change to NotRdy.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYGood() {
@@ -2876,7 +2964,6 @@ public class ManipulationPreconditionsTest {
     }
 
     // TODO:
-    //  MetricStatusManipulationSETActivationStateOFF
     //  MetricStatusManipulationCLCActivationStateON
     //  MetricStatusManipulationCLCActivationStateSTNDBY
     //  MetricStatusManipulationCLCActivationStateOFF

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -35,9 +35,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -1438,25 +1443,161 @@ public class ManipulationPreconditionsTest {
                 .thenReturn(List.of(mockEntity));
     }
 
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateON: Setting a metric with category MSRMT to `measurement is"
-                    + " being performed` results in activation state ON.")
-    void testMetricStatusManipulationMSRMTActivationStateONGood() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.ON);
+    // the argument source for the setMetricStatus preconditions
+    // 1. the specific method of the precondition to be tested
+    // 2. the metric category
+    // 3. the component activation of the metric before the setMetricStatus manipulation
+    // 4. the expected component activation after the setMetricStatus manipulation finished successfully
+    private static Stream<Arguments> metricStatusManipulationXActivationStateXArguments() {
+        return Stream.of(
+                // arguments for MetricStatusManipulationXActivationStateON preconditions
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON::manipulation,
+                        MetricCategory.MSRMT,
+                        ComponentActivation.OFF,
+                        ComponentActivation.ON),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON::manipulation,
+                        MetricCategory.CLC,
+                        ComponentActivation.OFF,
+                        ComponentActivation.ON),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationSETActivationStateON::manipulation,
+                        MetricCategory.SET,
+                        ComponentActivation.OFF,
+                        ComponentActivation.ON),
+                // arguments for MetricStatusManipulationXActivationStateNOTRDY preconditions
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateNOTRDY
+                                        ::manipulation,
+                        MetricCategory.MSRMT,
+                        ComponentActivation.OFF,
+                        ComponentActivation.NOT_RDY),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY
+                                        ::manipulation,
+                        MetricCategory.CLC,
+                        ComponentActivation.OFF,
+                        ComponentActivation.NOT_RDY),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY
+                                        ::manipulation,
+                        MetricCategory.SET,
+                        ComponentActivation.OFF,
+                        ComponentActivation.NOT_RDY),
+                // arguments for MetricStatusManipulationXActivationStateSTNDBY preconditions
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY
+                                        ::manipulation,
+                        MetricCategory.MSRMT,
+                        ComponentActivation.ON,
+                        ComponentActivation.STND_BY),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY
+                                        ::manipulation,
+                        MetricCategory.CLC,
+                        ComponentActivation.ON,
+                        ComponentActivation.STND_BY),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY
+                                        ::manipulation,
+                        MetricCategory.SET,
+                        ComponentActivation.ON,
+                        ComponentActivation.STND_BY),
+                // arguments for MetricStatusManipulationXActivationStateSHTDN preconditions
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN
+                                        ::manipulation,
+                        MetricCategory.MSRMT,
+                        ComponentActivation.ON,
+                        ComponentActivation.SHTDN),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN::manipulation,
+                        MetricCategory.CLC,
+                        ComponentActivation.ON,
+                        ComponentActivation.SHTDN),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN::manipulation,
+                        MetricCategory.SET,
+                        ComponentActivation.ON,
+                        ComponentActivation.SHTDN),
+                // arguments for MetricStatusManipulationXActivationStateOFF preconditions
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF::manipulation,
+                        MetricCategory.MSRMT,
+                        ComponentActivation.ON,
+                        ComponentActivation.OFF),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF::manipulation,
+                        MetricCategory.CLC,
+                        ComponentActivation.ON,
+                        ComponentActivation.OFF),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF::manipulation,
+                        MetricCategory.SET,
+                        ComponentActivation.ON,
+                        ComponentActivation.OFF),
+                // arguments for MetricStatusManipulationXActivationStateFAIL preconditions
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL
+                                        ::manipulation,
+                        MetricCategory.MSRMT,
+                        ComponentActivation.ON,
+                        ComponentActivation.FAIL),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL::manipulation,
+                        MetricCategory.CLC,
+                        ComponentActivation.ON,
+                        ComponentActivation.FAIL),
+                Arguments.of(
+                        (Function<Injector, Boolean>)
+                                ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL::manipulation,
+                        MetricCategory.SET,
+                        ComponentActivation.ON,
+                        ComponentActivation.FAIL));
     }
 
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateONAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+    @DisplayName("The precondition is successful when setComponentActivation and setMetricStatus work as intended")
+    @ParameterizedTest
+    @MethodSource("metricStatusManipulationXActivationStateXArguments")
+    void testMetricStatusManipulationXActivationStateXGood(
+            final Function<Injector, Boolean> manipulation,
+            final MetricCategory category,
+            final ComponentActivation startActivation,
+            final ComponentActivation expectedActivation) {
+        setMetricStatusSetup(category, METRIC_HANDLE, startActivation, expectedActivation);
+        assertTrue(manipulation.apply(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, startActivation);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, category, expectedActivation);
+    }
+
+    @DisplayName("The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    @ParameterizedTest
+    @MethodSource("metricStatusManipulationXActivationStateXArguments")
+    void testMetricStatusManipulationXActivationStateXAllowNotSupported1(
+            final Function<Injector, Boolean> manipulation,
+            final MetricCategory category,
+            final ComponentActivation startActivation,
+            final ComponentActivation expectedActivation) {
+        metricMockSetup(category, METRIC_HANDLE, SOME_HANDLE, startActivation, expectedActivation);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
@@ -1465,19 +1606,22 @@ public class ManipulationPreconditionsTest {
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
                 .thenReturn(List.of(mockEntity2, mockEntity));
 
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+        assertTrue(manipulation.apply(injector));
 
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, startActivation);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, startActivation);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, category, expectedActivation);
     }
 
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateONAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+    @DisplayName("The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    @ParameterizedTest
+    @MethodSource("metricStatusManipulationXActivationStateXArguments")
+    void testMetricStatusManipulationXActivationStateXAllowNotSupported2(
+            final Function<Injector, Boolean> manipulation,
+            final MetricCategory category,
+            final ComponentActivation startActivation,
+            final ComponentActivation expectedActivation) {
+        metricMockSetup(category, METRIC_HANDLE, SOME_HANDLE, startActivation, expectedActivation);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
@@ -1487,1492 +1631,51 @@ public class ManipulationPreconditionsTest {
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
                 .thenReturn(List.of(mockEntity2, mockEntity));
 
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+        assertTrue(manipulation.apply(injector));
 
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, startActivation);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, startActivation);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, category, expectedActivation);
     }
 
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateON: setComponentActivation failed.")
-    void testMetricStatusManipulationMSRMTActivationStateONBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+    @DisplayName("The precondition fails when setComponentActivation failed.")
+    @ParameterizedTest
+    @MethodSource("metricStatusManipulationXActivationStateXArguments")
+    void testMetricStatusManipulationXActivationStateXBadFirstManipulationFailed(
+            final Function<Injector, Boolean> manipulation,
+            final MetricCategory category,
+            final ComponentActivation startActivation,
+            final ComponentActivation expectedActivation) {
+        setMetricStatusSetup(category, METRIC_HANDLE, startActivation, expectedActivation);
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
                 .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+        assertFalse(manipulation.apply(injector));
 
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, startActivation);
     }
 
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateON: setMetricStatus failed.")
-    void testMetricStatusManipulationMSRMTActivationStateONBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+    @DisplayName("The precondition fails when setMetricStatus failed.")
+    @ParameterizedTest
+    @MethodSource("metricStatusManipulationXActivationStateXArguments")
+    void testMetricStatusManipulationXActivationStateXBadSecondManipulationFailed(
+            final Function<Injector, Boolean> manipulation,
+            final MetricCategory category,
+            final ComponentActivation startActivation,
+            final ComponentActivation expectedActivation) {
+        setMetricStatusSetup(category, METRIC_HANDLE, startActivation, expectedActivation);
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
                         any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
                 .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON.manipulation(injector));
+        assertFalse(manipulation.apply(injector));
 
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateNOTRDY: Set metric with category MSRMT to currently"
-            + " initializing which results in activation state NOT_RDY.")
-    void testMetricStatusManipulationMSRMTActivationStateNOTRDYGood() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateNOTRDY.manipulation(injector));
-
-        assertFalse(
-                testRunObserver.isInvalid(),
-                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.NOT_RDY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateNOTRDYAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateNOTRDY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.NOT_RDY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateNOTRDYAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateNOTRDY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.NOT_RDY);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateNOTRDY: setComponentActivation failed.")
-    void testMetricStatusManipulationMSRMTActivationStateNOTRDYBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(
-                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateNOTRDY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateNOTRDY: setMetricStatus failed.")
-    void testMetricStatusManipulationMSRMTActivationStateNOTRDYBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(
-                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateNOTRDY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.NOT_RDY);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateSTNDBY: Set metric with category MSRMT to 'measurement"
-            + " initialized, but is not being performed' which results in activation state STND_BY.")
-    void testMetricStatusManipulationMSRMTActivationStateSTNDBYGood() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateSTNDBYAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateSTNDBYAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateSTNDBY: setComponentActivation failed.")
-    void testMetricStatusManipulationMSRMTActivationStateSTNDBYBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(
-                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateSTNDBY: setMetricStatus failed.")
-    void testMetricStatusManipulationMSRMTActivationStateSTNDBYBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(
-                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateOFF: Setting a metric with category MSRMT to `measurement"
-            + " not being performed and is de-initialized` results in activation state OFF.")
-    void testMetricStatusManipulationMSRMTActivationStateOFFGood() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateOFFAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateOFFAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateOFF: setComponentActivation failed.")
-    void testMetricStatusManipulationMSRMTActivationStateOFFBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationMSRMTActivationStateOFF: setMetricStatus failed.")
-    void testMetricStatusManipulationMSRMTActivationStateOFFBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationMSRMTActivationStateFAIL: Set ActivationState "
-            + "of all MSRMT-Metrics to FAIL.")
-    void testMetricStatusManipulationMSRMTActivationStateFAILGood() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
-
-        assertFalse(
-                testRunObserver.isInvalid(),
-                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateFAILAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateFAILAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationMSRMTActivationStateFAIL: setComponentActivation failed.")
-    void testMetricStatusManipulationMSRMTActivationStateFAILBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationMSRMTActivationStateFAIL: setMetricStatus failed.")
-    void testMetricStatusManipulationMSRMTActivationStateFAILBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationSETActivationStateON: Setting a metric with category SET to `setting is"
-            + " currently being applied` results in activation state ON.")
-    void testMetricStatusManipulationSETActivationStateONGood() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateONAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateONAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationSETActivationStateON: setComponentActivation failed.")
-    void testMetricStatusManipulationSETActivationStateONBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationSETActivationStateON: setMetricStatus failed.")
-    void testMetricStatusManipulationSETActivationStateONBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateNOTRDYGood: Set ActivationState "
-            + "of all SET-Metrics to NOTRDY.")
-    void testMetricStatusManipulationSETActivationStateNOTRDYGood() {
-
-        // given
-
-        final ComponentActivation startActivationState = ComponentActivation.OFF;
-        final MetricCategory metricCategory = MetricCategory.SET;
-        final ComponentActivation activationState = ComponentActivation.NOT_RDY;
-        final String metricStateHandle = "metricStateHandle";
-
-        setupMetricStatusManipulation(metricCategory, metricStateHandle);
-
-        when(mockManipulations.setComponentActivation(metricStateHandle, startActivationState))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-        when(mockManipulations.setMetricStatus(metricStateHandle, metricCategory, activationState))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-
-        // when
-
-        final boolean result =
-                ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector);
-
-        // then
-
-        assertTrue(result);
-        assertFalse(
-                testRunObserver.isInvalid(),
-                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
-        verify(mockManipulations).setComponentActivation(metricStateHandle, startActivationState);
-        verify(mockManipulations).setMetricStatus(metricStateHandle, metricCategory, activationState);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateNOTRDYAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.NOT_RDY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateNOTRDYAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.NOT_RDY);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateNOTRDYBad: First Manipulation failed.")
-    void testMetricStatusManipulationSETActivationStateNOTRDYBadFirstManipulationFailed() {
-
-        // given
-
-        final ComponentActivation startActivationState = ComponentActivation.OFF;
-        final MetricCategory metricCategory = MetricCategory.SET;
-        final ComponentActivation activationState = ComponentActivation.NOT_RDY;
-        final String metricStateHandle = "metricStateHandle";
-
-        setupMetricStatusManipulation(metricCategory, metricStateHandle);
-
-        when(mockManipulations.setComponentActivation(metricStateHandle, startActivationState))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-        when(mockManipulations.setMetricStatus(metricStateHandle, metricCategory, activationState))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-
-        // when
-
-        assertFalse(testRunObserver.isInvalid());
-        final boolean result =
-                ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector);
-
-        // then
-        assertFalse(result);
-        verify(mockManipulations).setComponentActivation(metricStateHandle, startActivationState);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateNOTRDYBad: Second Manipulation Failed.")
-    void testMetricStatusManipulationSETActivationStateNOTRDYBadSecondManipulationFailed() {
-
-        // given
-        final ComponentActivation startActivationState = ComponentActivation.OFF;
-        final MetricCategory metricCategory = MetricCategory.SET;
-        final ComponentActivation activationState = ComponentActivation.NOT_RDY;
-        final String metricStateHandle = "metricStateHandle";
-
-        setupMetricStatusManipulation(metricCategory, metricStateHandle);
-
-        when(mockManipulations.setComponentActivation(metricStateHandle, startActivationState))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-        when(mockManipulations.setMetricStatus(metricStateHandle, metricCategory, activationState))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        // when
-        assertFalse(testRunObserver.isInvalid());
-        final boolean result =
-                ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector);
-
-        // then
-        assertFalse(result);
-        verify(mockManipulations).setComponentActivation(metricStateHandle, startActivationState);
-        verify(mockManipulations).setMetricStatus(metricStateHandle, metricCategory, activationState);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: Set metric with category SET to 'setting"
-            + " initialized, but is not being performed' which results in activation state STND_BY.")
-    void testMetricStatusManipulationSETActivationStateSTNDBYGood() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateSTNDBYAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateSTNDBYAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: setComponentActivation failed.")
-    void testMetricStatusManipulationSETActivationStateSTNDBYBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: setMetricStatus failed.")
-    void testMetricStatusManipulationSETActivationStateSTNDBYBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateSHTDN: Set SET metrics to a state where the setting is"
-            + " currently de-initializing to trigger the setting of the activation state to SHTDN")
-    void testMetricStatusManipulationSETActivationStateSHTDNGood() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
-
-        assertFalse(
-                testRunObserver.isInvalid(),
-                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.SHTDN);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateSHTDNAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.SHTDN);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateSHTDNAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.SHTDN);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateSHTDN: setComponentActivation failed.")
-    void testMetricStatusManipulationSETActivationStateSHTDNBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateSHTDN: setMetricStatus failed.")
-    void testMetricStatusManipulationSETActivationStateSHTDNGoodSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.SHTDN);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationSETActivationStateOFF: Setting a metric with category SET to `setting"
-            + " not being performed and is de-initialized` results in activation state OFF.")
-    void testMetricStatusManipulationSETActivationStateOFFGood() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateOFFAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateOFFAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationSETActivationStateOFF: setComponentActivation failed.")
-    void testMetricStatusManipulationSETActivationStateOFFBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationSETActivationStateOFF: setMetricStatus failed.")
-    void testMetricStatusManipulationSETActivationStateOFFBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: Set ActivationState of all SET-Metrics to FAIL.")
-    void testMetricStatusManipulationSETActivationStateFAILGood() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        assertTrue(
-                ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
-                "The manipulation should have been successful.");
-
-        assertFalse(
-                testRunObserver.isInvalid(),
-                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateFAILAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationSETActivationStateFAILAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: setComponentActivation failed.")
-    void testMetricStatusManipulationSETActivationStateFAILBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(
-                ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
-                "The manipulation should not have been successful.");
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: setMetricStatus failed.")
-    void testMetricStatusManipulationSETActivationStateFAILBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(
-                ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
-                "The manipulation should not have been successful.");
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateON: Setting a metric with category CLC to `calculation is"
-            + " being performed` results in activation state ON.")
-    void testMetricStatusManipulationCLCActivationStateONGood() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateONAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateONAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateON: setComponentActivation failed.")
-    void testMetricStatusManipulationCLCActivationStateONBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateON: setMetricStatus failed.")
-    void testMetricStatusManipulationCLCActivationStateONBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationCLCActivationStateNOTRDY: Set calculations of metrics with category CLC"
-            + " to currently initializing to trigger an ActivationState change to NotRdy.")
-    void testMetricStatusManipulationCLCActivationStateNOTRDYGood() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
-
-        assertFalse(
-                testRunObserver.isInvalid(),
-                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationCLCActivationStateNOTRDY: setComponentActivation failed.")
-    void testMetricStatusManipulationCLCActivationStateNOTRDYBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationCLCActivationStateNOTRDY: setMetricStatus failed.")
-    void testMetricStatusManipulationCLCActivationStateNOTRDYBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: Set metric with category SET to 'calculation"
-            + " initialized, but is not being performed' which results in activation state STND_BY.")
-    void testMetricStatusManipulationCLCActivationStateSTNDBYGood() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateSTNDBYAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateSTNDBYAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: setComponentActivation failed.")
-    void testMetricStatusManipulationCLCActivationStateSTNDBYBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: setMetricStatus failed.")
-    void testMetricStatusManipulationCLCActivationStateSTNDBYBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateSHTDN: Set CLC metrics to a state where the calculation"
-            + " is currently de-initializing to trigger an activation state change to SHTDN.")
-    void testMetricStatusManipulationCLCActivationStateSHTDNGood() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
-
-        assertFalse(
-                testRunObserver.isInvalid(),
-                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateSHTDNAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateSHTDNNAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateSHTDN: setComponentActivation failed.")
-    void testMetricStatusManipulationCLCActivationStateSHTDNBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateSHTDN: setMetricStatus failed.")
-    void testMetricStatusManipulationCLCActivationStateSHTDNBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.SHTDN);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateOFF: Setting a metric with category SET to `calculation"
-            + " not being performed and is de-initialized` results in activation state OFF.")
-    void testMetricStatusManipulationCLCActivationStateOFFGood() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateOFFAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateOFFAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateOFF: setComponentActivation failed.")
-    void testMetricStatusManipulationCLCActivationStateOFFBadFirstManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("MetricStatusManipulationCLCActivationStateOFF: setMetricStatus failed.")
-    void testMetricStatusManipulationCLCActivationStateOFFBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.OFF);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationCLCActivationStateFAIL: Set ActivationState of all CLC-Metrics to FAIL.")
-    void testMetricStatusManipulationCLCActivationStateFAILGood() {
-        // given
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // when
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
-
-        // then
-        assertFalse(
-                testRunObserver.isInvalid(),
-                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateFAILAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationCLCActivationStateFAILAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.FAIL);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationCLCActivationStateFAIL: setComponentActivation failed.")
-    void testMetricStatusManipulationCLCActivationStateFAILBadFirstManipulationFailed() {
-        // given
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        // when
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
-
-        // then
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationCLCActivationStateFAIL: setMetricStatus failed.")
-    void testMetricStatusManipulationCLCActivationStateFAILBadSecondManipulationFailed() {
-        setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
-
-        // let setMetricStatus fail
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.FAIL);
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, startActivation);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, category, expectedActivation);
     }
 
     @Test

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2011,6 +2011,93 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: Set metric with category SET to 'setting"
+        + " initialized, but is not being performed' which results in activation state STND_BY.")
+    void testMetricStatusManipulationSETActivationStateSTNDBYGood() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateSTNDBYAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateSTNDBYAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: setComponentActivation failed.")
+    void testMetricStatusManipulationSETActivationStateSTNDBYBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: setMetricStatus failed.")
+    void testMetricStatusManipulationSETActivationStateSTNDBYBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(
+            ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateSHTDN: Set SET metrics to a state where the setting is"
             + " currently de-initializing to trigger the setting of the activation state to SHTDN")
     void testMetricStatusManipulationSETActivationStateSHTDNGood() {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1804,6 +1804,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateFAILAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.FAIL);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationMSRMTActivationStateFAILAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.FAIL);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationMSRMTActivationStateFAIL: setComponentActivation failed.")
     void testMetricStatusManipulationMSRMTActivationStateFAILBadFirstManipulationFailed() {
         setMetricStatusSetup(MetricCategory.MSRMT, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
@@ -2332,6 +2375,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateFAILAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateFAILAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateFAIL: setComponentActivation failed.")
     void testMetricStatusManipulationSETActivationStateFAILBadFirstManipulationFailed() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
@@ -2773,6 +2859,49 @@ public class ManipulationPreconditionsTest {
                 "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.FAIL);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateFAILAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.FAIL);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateFAILAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.FAIL);
     }
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1805,17 +1805,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateFAILAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
 
@@ -1826,18 +1826,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationMSRMTActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationMSRMTActivationStateFAILAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL.manipulation(injector));
 
@@ -1877,8 +1877,7 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
-    @DisplayName(
-        "MetricStatusManipulationSETActivationStateON: Setting a metric with category SET to `setting is"
+    @DisplayName("MetricStatusManipulationSETActivationStateON: Setting a metric with category SET to `setting is"
             + " currently being applied` results in activation state ON.")
     void testMetricStatusManipulationSETActivationStateONGood() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
@@ -1891,17 +1890,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateONAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
 
@@ -1912,18 +1911,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateONAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
 
@@ -1939,7 +1938,7 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
 
@@ -1953,8 +1952,8 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
 
@@ -1998,17 +1997,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateNOTRDYAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector));
 
@@ -2019,18 +2018,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateNOTRDYAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector));
 
@@ -2098,7 +2097,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationSETActivationStateSTNDBY: Set metric with category SET to 'setting"
-        + " initialized, but is not being performed' which results in activation state STND_BY.")
+            + " initialized, but is not being performed' which results in activation state STND_BY.")
     void testMetricStatusManipulationSETActivationStateSTNDBYGood() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
@@ -2110,17 +2109,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateSTNDBYAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
 
@@ -2131,18 +2130,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateSTNDBYAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
 
@@ -2158,10 +2157,9 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
@@ -2173,11 +2171,10 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.STND_BY);
@@ -2201,17 +2198,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateSHTDNAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
 
@@ -2222,18 +2219,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateSHTDNAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN.manipulation(injector));
 
@@ -2274,7 +2271,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationSETActivationStateOFF: Setting a metric with category SET to `setting"
-        + " not being performed and is de-initialized` results in activation state OFF.")
+            + " not being performed and is de-initialized` results in activation state OFF.")
     void testMetricStatusManipulationSETActivationStateOFFGood() {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
@@ -2286,17 +2283,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateOFFAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
 
@@ -2307,18 +2304,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateOFFAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
 
@@ -2334,7 +2331,7 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
 
@@ -2348,8 +2345,8 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF.manipulation(injector));
 
@@ -2363,12 +2360,12 @@ public class ManipulationPreconditionsTest {
         setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         assertTrue(
-            ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
-            "The manipulation should have been successful.");
+                ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
+                "The manipulation should have been successful.");
 
         assertFalse(
-            testRunObserver.isInvalid(),
-            "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
+                testRunObserver.isInvalid(),
+                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
@@ -2376,17 +2373,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateFAILAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector));
 
@@ -2397,18 +2394,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationSETActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationSETActivationStateFAILAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector));
 
@@ -2424,11 +2421,11 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
-            "The manipulation should not have been successful.");
+                ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
+                "The manipulation should not have been successful.");
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
@@ -2440,20 +2437,19 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
-            "The manipulation should not have been successful.");
+                ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL.manipulation(injector),
+                "The manipulation should not have been successful.");
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.FAIL);
     }
 
     @Test
-    @DisplayName(
-        "MetricStatusManipulationCLCActivationStateON: Setting a metric with category CLC to `calculation is"
+    @DisplayName("MetricStatusManipulationCLCActivationStateON: Setting a metric with category CLC to `calculation is"
             + " being performed` results in activation state ON.")
     void testMetricStatusManipulationCLCActivationStateONGood() {
         setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
@@ -2466,17 +2462,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateONAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
 
@@ -2487,18 +2483,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateONAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
 
@@ -2514,7 +2510,7 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
 
@@ -2528,8 +2524,8 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON.manipulation(injector));
 
@@ -2555,17 +2551,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
 
@@ -2576,18 +2572,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
 
@@ -2628,7 +2624,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: Set metric with category SET to 'calculation"
-        + " initialized, but is not being performed' which results in activation state STND_BY.")
+            + " initialized, but is not being performed' which results in activation state STND_BY.")
     void testMetricStatusManipulationCLCActivationStateSTNDBYGood() {
         setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
@@ -2640,17 +2636,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateSTNDBYAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
 
@@ -2661,18 +2657,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateSTNDBY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateSTNDBYAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.STND_BY);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
 
@@ -2688,10 +2684,9 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
     }
@@ -2703,11 +2698,10 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
-        assertFalse(
-            ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY.manipulation(injector));
 
         verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.STND_BY);
@@ -2731,17 +2725,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateSHTDNAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
 
@@ -2752,18 +2746,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateSHTDNNAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN.manipulation(injector));
 
@@ -2804,7 +2798,7 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName("MetricStatusManipulationCLCActivationStateOFF: Setting a metric with category SET to `calculation"
-        + " not being performed and is de-initialized` results in activation state OFF.")
+            + " not being performed and is de-initialized` results in activation state OFF.")
     void testMetricStatusManipulationCLCActivationStateOFFGood() {
         setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
@@ -2816,17 +2810,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateOFFAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
 
@@ -2837,18 +2831,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateOFF: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateOFFAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.OFF);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
 
@@ -2864,7 +2858,7 @@ public class ManipulationPreconditionsTest {
 
         // let setComponentActivation fail
         when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
 
@@ -2878,8 +2872,8 @@ public class ManipulationPreconditionsTest {
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF.manipulation(injector));
 
@@ -2907,17 +2901,17 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setComponentActivation is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateFAILAllowNotSupported1() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setComponentActivation manipulation
         when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
 
@@ -2928,18 +2922,18 @@ public class ManipulationPreconditionsTest {
 
     @Test
     @DisplayName(
-        "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+            "MetricStatusManipulationCLCActivationStateFAIL: The precondition does not fail if setMetricStatus is not supported by all metrics.")
     void testMetricStatusManipulationCLCActivationStateFAILAllowNotSupported2() {
         metricMockSetup(
-            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
+                MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.FAIL);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
 
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-            .thenReturn(List.of(mockEntity2, mockEntity));
+                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL.manipulation(injector));
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -2554,6 +2554,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.CLC, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationCLCActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationCLCActivationStateNOTRDYAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationCLCActivationStateNOTRDY: setComponentActivation failed.")
     void testMetricStatusManipulationCLCActivationStateNOTRDYBadFirstManipulationFailed() {
         setMetricStatusSetup(MetricCategory.CLC, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1954,6 +1954,49 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateNOTRDYAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.NOT_RDY);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateNOTRDY: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateNOTRDYAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.NOT_RDY);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.NOT_RDY);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateNOTRDYBad: First Manipulation failed.")
     void testMetricStatusManipulationSETActivationStateNOTRDYBadFirstManipulationFailed() {
 
@@ -2411,7 +2454,6 @@ public class ManipulationPreconditionsTest {
         verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.CLC, ComponentActivation.NOT_RDY);
     }
 
-    // TODO
     @Test
     @DisplayName("MetricStatusManipulationCLCActivationStateSTNDBY: Set metric with category SET to 'calculation"
         + " initialized, but is not being performed' which results in activation state STND_BY.")

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1834,6 +1834,92 @@ public class ManipulationPreconditionsTest {
     }
 
     @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateON: Setting a metric with category SET to `setting is"
+            + " currently being applied` results in activation state ON.")
+    void testMetricStatusManipulationSETActivationStateONGood() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setComponentActivation is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateONAllowNotSupported1() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let one metric not support setComponentActivation manipulation
+        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName(
+        "MetricStatusManipulationSETActivationStateON: The precondition does not fail if setMetricStatus is not supported by all metrics.")
+    void testMetricStatusManipulationSETActivationStateONAllowNotSupported2() {
+        metricMockSetup(
+            MetricCategory.SET, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let one metric not support setMetricStatus manipulation
+        when(mockManipulations.setMetricStatus(
+            eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+
+        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
+            .thenReturn(List.of(mockEntity2, mockEntity));
+
+        assertTrue(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateON: setComponentActivation failed.")
+    void testMetricStatusManipulationSETActivationStateONBadFirstManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let setComponentActivation fail
+        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+    }
+
+    @Test
+    @DisplayName("MetricStatusManipulationSETActivationStateON: setMetricStatus failed.")
+    void testMetricStatusManipulationSETActivationStateONBadSecondManipulationFailed() {
+        setMetricStatusSetup(MetricCategory.SET, METRIC_HANDLE, ComponentActivation.OFF, ComponentActivation.ON);
+
+        // let setMetricStatus fail
+        when(mockManipulations.setMetricStatus(
+            any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+            .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+        assertFalse(ManipulationPreconditions.MetricStatusManipulationSETActivationStateON.manipulation(injector));
+
+        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.OFF);
+        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.SET, ComponentActivation.ON);
+    }
+
+    @Test
     @DisplayName("testMetricStatusManipulationSETActivationStateNOTRDYGood: Set ActivationState "
             + "of all SET-Metrics to NOTRDY.")
     void testMetricStatusManipulationSETActivationStateNOTRDYGood() {
@@ -2616,4 +2702,11 @@ public class ManipulationPreconditionsTest {
 
         assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
+
+    // TODO:
+    //  MetricStatusManipulationSETActivationStateSTNDBY
+    //  MetricStatusManipulationSETActivationStateOFF
+    //  MetricStatusManipulationCLCActivationStateON
+    //  MetricStatusManipulationCLCActivationStateSTNDBY
+    //  MetricStatusManipulationCLCActivationStateOFF
 }


### PR DESCRIPTION
Added missing unit tests for 

- AbstractDeviceComponentStateOFFManipulation
- AlertConditionPresenceManipulation
- SystemSignalActivationManipulation
- MetricStatusManipulation*ActivationState*

Reworked SystemSignalActivationManipulation to handle manipulation result NOT_SUPPORTED.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
