### PR TITLE
Remove broken echo commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Retrieve current version from pom
         run: |
           echo RELEASE_VERSION=$(cat pom.xml | grep -o -P '(?<=revision\>).*(?=\<\/revision)') >> $GITHUB_ENV
-          echo "Release version is $RELEASE_VERSION"
           echo GIT_HASH_SHORT=$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_ENV
-          echo "Git revision is is $GIT_HASH_SHORT"
 
       - name: Remove SNAPSHOT suffix for release
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Remove echo commands for the release version and for the git hash, because they do not work. A replacement in the build.yml is not needed due to the GitHub interface displaying those values in later steps anyways.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
