### PR TITLE
changed biceps:R0034_0 precondition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SDCcc.SummarizeMessageEncodingErrors.
 - checking for message encoding errors can be disabled using the configuration option SDCcc.EnableMessageEncodingCheck.
 - configuration option SDCcc.Network.MulticastTTL to configure the Time To Live of the Multicast Packets used for Discovery.
+- precondition for biceps:R5024 to trigger description modification reports for test data
 
 ### Changed
 - SDCri version 4.1.0-SNAPSHOT
 - the precondition of biceps:R0133 so that it is now easier to satisfy.
+- the precondition of biceps:R0034_0 so that it is now easier to satisfy.
 
 ### Fixed
 - the occurrence of the sequence ']]>' in the content of CDATA sections in the result xmls

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ this case in order to minimize the risk of such an invalid application going unn
 | R0025_0         | SetComponentActivation                                                                      |
 | R0029_0         | SetAlertActivation, SetAlertConditionPresence                                               |
 | R0033           | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
-| R0034_0         | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
+| R0034_0         | TriggerReport                                                                               |
 | R0038_0         | TriggerReport                                                                               |
 | R0055_0         | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
 | R0097           | CreateContextStateWithAssociation                                                           |

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ this case in order to minimize the risk of such an invalid application going unn
 | C-13            | TriggerReport                                                                               |
 | C-14            | TriggerReport                                                                               |
 | C-15            | TriggerReport                                                                               |
+| R5024           | TriggerReport                                                                               |
 | R5025_0         | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
 | R5046_0         | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
 | R5051           | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
@@ -200,12 +200,14 @@ public class ConditionalPreconditions {
         return ResponseTypes.Result.RESULT_SUCCESS.equals(manipulationResult);
     }
 
-    private static boolean triggerReportPreconditionCheck(final Injector injector, final QName... reportType)
-            throws PreconditionException {
+    private static boolean triggerReportPreconditionCheck(
+            final Injector injector, final Logger log, final QName... reportType) throws PreconditionException {
         final var messageStorage = injector.getInstance(MessageStorage.class);
         try (final var messages = messageStorage.getInboundMessagesByBodyType(reportType)) {
             // determine if there were any reports with the specified type
-            return messages.areObjectsPresent();
+            final var areReportsPresent = messages.areObjectsPresent();
+            log.info("Reports of types {} are present: {}", reportType, areReportsPresent);
+            return areReportsPresent;
         } catch (IOException e) {
             throw new PreconditionException(
                     String.format(
@@ -641,6 +643,7 @@ public class ConditionalPreconditions {
         static boolean preconditionCheck(final Injector injector) throws PreconditionException {
             return triggerReportPreconditionCheck(
                     injector,
+                    LOG,
                     Constants.MSG_EPISODIC_ALERT_REPORT,
                     Constants.MSG_EPISODIC_COMPONENT_REPORT,
                     Constants.MSG_EPISODIC_METRIC_REPORT,
@@ -967,7 +970,7 @@ public class ConditionalPreconditions {
         }
 
         static boolean preconditionCheck(final Injector injector) throws PreconditionException {
-            return triggerReportPreconditionCheck(injector, Constants.MSG_EPISODIC_ALERT_REPORT);
+            return triggerReportPreconditionCheck(injector, LOG, Constants.MSG_EPISODIC_ALERT_REPORT);
         }
 
         /**
@@ -999,7 +1002,7 @@ public class ConditionalPreconditions {
         }
 
         static boolean preconditionCheck(final Injector injector) throws PreconditionException {
-            return triggerReportPreconditionCheck(injector, Constants.MSG_EPISODIC_COMPONENT_REPORT);
+            return triggerReportPreconditionCheck(injector, LOG, Constants.MSG_EPISODIC_COMPONENT_REPORT);
         }
 
         /**
@@ -1031,7 +1034,7 @@ public class ConditionalPreconditions {
         }
 
         static boolean preconditionCheck(final Injector injector) throws PreconditionException {
-            return triggerReportPreconditionCheck(injector, Constants.MSG_EPISODIC_CONTEXT_REPORT);
+            return triggerReportPreconditionCheck(injector, LOG, Constants.MSG_EPISODIC_CONTEXT_REPORT);
         }
 
         /**
@@ -1063,7 +1066,7 @@ public class ConditionalPreconditions {
         }
 
         static boolean preconditionCheck(final Injector injector) throws PreconditionException {
-            return triggerReportPreconditionCheck(injector, Constants.MSG_EPISODIC_METRIC_REPORT);
+            return triggerReportPreconditionCheck(injector, LOG, Constants.MSG_EPISODIC_METRIC_REPORT);
         }
 
         /**
@@ -1095,7 +1098,7 @@ public class ConditionalPreconditions {
         }
 
         static boolean preconditionCheck(final Injector injector) throws PreconditionException {
-            return triggerReportPreconditionCheck(injector, Constants.MSG_EPISODIC_OPERATIONAL_STATE_REPORT);
+            return triggerReportPreconditionCheck(injector, LOG, Constants.MSG_EPISODIC_OPERATIONAL_STATE_REPORT);
         }
 
         /**
@@ -1126,7 +1129,7 @@ public class ConditionalPreconditions {
         }
 
         static boolean preconditionCheck(final Injector injector) throws PreconditionException {
-            return triggerReportPreconditionCheck(injector, Constants.MSG_OPERATION_INVOKED_REPORT);
+            return triggerReportPreconditionCheck(injector, LOG, Constants.MSG_OPERATION_INVOKED_REPORT);
         }
 
         /**
@@ -1137,6 +1140,37 @@ public class ConditionalPreconditions {
          */
         static boolean manipulation(final Injector injector) {
             return triggerReportManipulation(injector, LOG, Constants.MSG_OPERATION_INVOKED_REPORT);
+        }
+    }
+
+    /**
+     * Precondition which checks whether DescriptionModification messages have been received, and trigger such a
+     * message otherwise.
+     */
+    public static class TriggerDescriptionModificationReportPrecondition extends SimplePrecondition {
+        private static final Logger LOG = LogManager.getLogger(TriggerDescriptionModificationReportPrecondition.class);
+
+        /**
+         * Creates a trigger description modification report message precondition check.
+         */
+        public TriggerDescriptionModificationReportPrecondition() {
+            super(
+                    TriggerDescriptionModificationReportPrecondition::preconditionCheck,
+                    TriggerDescriptionModificationReportPrecondition::manipulation);
+        }
+
+        static boolean preconditionCheck(final Injector injector) throws PreconditionException {
+            return triggerReportPreconditionCheck(injector, LOG, Constants.MSG_DESCRIPTION_MODIFICATION_REPORT);
+        }
+
+        /**
+         * Performs the manipulation to trigger description modification reports.
+         *
+         * @param injector to analyze mdib on
+         * @return  true if successful, false otherwise
+         */
+        static boolean manipulation(final Injector injector) {
+            return triggerReportManipulation(injector, LOG, Constants.MSG_DESCRIPTION_MODIFICATION_REPORT);
         }
     }
 }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
@@ -1144,7 +1144,7 @@ public class ConditionalPreconditions {
     }
 
     /**
-     * Precondition which checks whether DescriptionModification messages have been received, and trigger such a
+     * Precondition which checks whether DescriptionModificationReport messages have been received, and trigger such a
      * message otherwise.
      */
     public static class TriggerDescriptionModificationReportPrecondition extends SimplePrecondition {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -293,7 +293,8 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @TestIdentifier(EnabledTestConfig.BICEPS_R5024)
     @TestDescription("Retrieves each report part from each description modification report seen during the test run and"
             + " checks that each descriptor does not contain nested descriptors.")
-    @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.class})
+    @RequirePrecondition(
+            simplePreconditions = {ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.class})
     void testRequirementR5024() throws NoTestData, IOException {
         try (final var messages =
                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -293,6 +293,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @TestIdentifier(EnabledTestConfig.BICEPS_R5024)
     @TestDescription("Retrieves each report part from each description modification report seen during the test run and"
             + " checks that each descriptor does not contain nested descriptors.")
+    @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.class})
     void testRequirementR5024() throws NoTestData, IOException {
         try (final var messages =
                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTest.java
@@ -153,9 +153,10 @@ public class InvariantParticipantModelVersioningTest extends InjectorTestBase {
             + " extends pm:AbstractDescriptor.")
     @TestIdentifier(EnabledTestConfig.BICEPS_R0034_0)
     @TestDescription("Starting from the initially retrieved mdib, applies every episodic report to the mdib and"
-            + " verifies that descriptor versions are incremented whenever the descriptors attributes or content changes,\n"
+            + " verifies that descriptor versions are incremented whenever the descriptors attributes or content changes,"
             + " except for changes to children of any Type that extends AbstractDescriptor.")
-    @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.DescriptionChangedPrecondition.class})
+    @RequirePrecondition(
+            simplePreconditions = {ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.class})
     void testRequirementR0034() throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
                 messageStorage, getInjector().getInstance(TestRunObserver.class));

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
@@ -2274,6 +2274,27 @@ public class ConditionalPreconditionsTest {
             // no messages
             assertFalse(ConditionalPreconditions.TriggerOperationInvokedReportPrecondition.preconditionCheck(injector));
         }
+        // TriggerDescriptionModificationReportPrecondition
+        {
+            when(mockGetter.areObjectsPresent()).thenReturn(true).thenReturn(false);
+
+            when(mockStorage.getInboundMessagesByBodyType(ArgumentMatchers.<QName>any()))
+                    .thenReturn(mockGetter);
+
+            final var injector = Guice.createInjector(new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(MessageStorage.class).toInstance(mockStorage);
+                }
+            });
+
+            assertTrue(ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.preconditionCheck(
+                    injector));
+
+            // no messages
+            assertFalse(ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.preconditionCheck(
+                    injector));
+        }
     }
 
     /**
@@ -2404,6 +2425,28 @@ public class ConditionalPreconditionsTest {
 
             // second call must return false
             assertFalse(ConditionalPreconditions.TriggerOperationInvokedReportPrecondition.manipulation(injector));
+        }
+        // TriggerDescriptionModificationReportPrecondition
+        {
+            when(manipulations.triggerReport(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT))
+                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
+                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+
+            final var injector = Guice.createInjector(new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(Manipulations.class).toInstance(manipulations);
+                }
+            });
+
+            assertTrue(
+                    ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.manipulation(injector));
+
+            verify(manipulations, times(1)).triggerReport(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT);
+
+            // second call must return false
+            assertFalse(
+                    ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.manipulation(injector));
         }
     }
 


### PR DESCRIPTION
precondition TriggerDescriptionModificationReportPrecondition to trigger description modification reports added.
Unit test for  TriggerDescriptionModificationReportPrecondition added. 
Test cases for biceps:R0034_0 and biceps:R5024 are now using the TriggerDescriptionModificationReportPrecondition.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
