### PR TITLE
Let DescriptionModificationUptPrecondition use the new TriggerAnyDescriptorUpdate manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDCri version 5.0.0-SNAPSHOT
 - the precondition of biceps:R0133 so that it is now easier to satisfy.
 - the precondition of biceps:R0034_0 so that it is now easier to satisfy.
+- the precondition of biceps:C5 and biceps:R5052 so that it can be satisfied by devices that do not support updating
+  MDS descriptors.
 
 ### Fixed
 - the occurrence of the sequence ']]>' in the content of CDATA sections in the result xmls

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ this case in order to minimize the risk of such an invalid application going unn
 | R0125           | CreateContextStateWithAssociation                                                           |
 | R0133           | CreateContextStateWithAssociation                                                           |
 | B-128           | SetSystemSignalActivation, SetAlertActivation                                               |
-| C-5             | TriggerDescriptorUpdate                                                                     |
+| C-5             | TriggerAnyDescriptorUpdate                                                                  |
 | C-7             | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor, TriggerDescriptorUpdate |
 | C-11            | TriggerReport                                                                               |
 | C-12            | TriggerReport                                                                               |
@@ -283,7 +283,7 @@ this case in order to minimize the risk of such an invalid application going unn
 | R5025_0         | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
 | R5046_0         | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
 | R5051           | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
-| R5052           | TriggerDescriptorUpdate                                                                     |
+| R5052           | TriggerAnyDescriptorUpdate                                                                  |
 | R5053           | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
 | 5-4-7_0_0       | SetComponentActivation, SetMetricStatus                                                     |
 | 5-4-7_1         | SetComponentActivation, SetMetricStatus                                                     |

--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>com.draeger.medical</groupId>
             <artifactId>t2iapi</artifactId>
-            <version>2.0.1-SHAPSHOT</version>
+            <version>3.0.0.226</version>
         </dependency>
 
         <dependency>

--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>com.draeger.medical</groupId>
             <artifactId>t2iapi</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1-SHAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
@@ -233,8 +233,7 @@ public class FallbackManipulations implements Manipulations {
 
     @Override
     public ResponseTypes.Result triggerAnyDescriptorUpdate() {
-        final var triggerReportString = "Trigger a descriptor update for some descriptor";
-        final var interactionMessage = triggerReportString;
+        final var interactionMessage = "Trigger a descriptor update for some descriptor";
         final var interactionResult = interactionFactory
                 .createUserInteraction(new FilterInputStream(System.in) {
                     @Override

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
@@ -232,6 +232,19 @@ public class FallbackManipulations implements Manipulations {
     }
 
     @Override
+    public ResponseTypes.Result triggerAnyDescriptorUpdate() {
+        final var triggerReportString = "Trigger a descriptor update for some descriptor";
+        final var interactionMessage = triggerReportString;
+        final var interactionResult = interactionFactory
+                .createUserInteraction(new FilterInputStream(System.in) {
+                    @Override
+                    public void close() {}
+                })
+                .displayYesNoUserInteraction(interactionMessage);
+        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+    }
+
+    @Override
     public ResponseTypes.Result triggerReport(final QName reportType) {
         final var triggerReportString = "Trigger a report for type %s";
         final var interactionMessage = String.format(triggerReportString, reportType);

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
@@ -302,6 +302,16 @@ public class GRpcManipulations implements Manipulations {
     }
 
     @Override
+    public ResponseTypes.Result triggerAnyDescriptorUpdate() {
+        return performCallWrapper(
+                v -> deviceStub.triggerAnyDescriptorUpdate(Empty.getDefaultInstance()),
+                v -> fallback.triggerAnyDescriptorUpdate(),
+                BasicResponses.BasicResponse::getResult,
+                BasicResponses.BasicResponse::getResult,
+                ManipulationParameterUtil.buildEmptyManipulationParameterData());
+    }
+
+    @Override
     public ResponseTypes.Result triggerReport(final QName report) {
         final var reportType = REPORT_TYPE_MAP.get(report);
         if (reportType == null) return ResponseTypes.Result.RESULT_FAIL;

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
@@ -136,6 +136,15 @@ public interface Manipulations {
     ResponseTypes.Result triggerDescriptorUpdate(String handle);
 
     /**
+     * Trigger a descriptor update for some descriptor handle.
+     * The handle is chosen by the device. It is expected that the manipulation
+     * succeeds as long as there is a handle than can be updated.
+     *
+     * @return the result of the manipulation
+     */
+    ResponseTypes.Result triggerAnyDescriptorUpdate();
+
+    /**
      * Trigger a report message of the provided type.
      *
      * @param reportType type of report a message should be triggered for.

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
@@ -136,9 +136,7 @@ public interface Manipulations {
     ResponseTypes.Result triggerDescriptorUpdate(String handle);
 
     /**
-     * Trigger a descriptor update for some descriptor handle.
-     * The handle is chosen by the device. It is expected that the manipulation
-     * succeeds as long as there is a handle than can be updated.
+     * Trigger a descriptor update for some descriptor (chosen by the device).
      *
      * @return the result of the manipulation
      */

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
@@ -178,24 +178,10 @@ public class ConditionalPreconditions {
                 && manipulationResults.contains(ResponseTypes.Result.RESULT_SUCCESS);
     }
 
-    private static boolean descriptionUpdateManipulation(final Injector injector, final Logger logger) {
+    private static boolean descriptionUpdateManipulation(final Injector injector) {
         final var manipulations = injector.getInstance(Manipulations.class);
-        final var testClient = injector.getInstance(TestClient.class);
 
-        final MdibAccess mdibAccess;
-        final SdcRemoteDevice remoteDevice;
-
-        remoteDevice = testClient.getSdcRemoteDevice();
-        if (remoteDevice == null) {
-            logger.error("remote device could not be accessed, likely due to a disconnect");
-            return false;
-        }
-        mdibAccess = remoteDevice.getMdibAccess();
-
-        final String handle =
-                mdibAccess.getRootEntities().get(0).getDescriptor().getHandle();
-
-        final ResponseTypes.Result manipulationResult = manipulations.triggerDescriptorUpdate(handle);
+        final ResponseTypes.Result manipulationResult = manipulations.triggerAnyDescriptorUpdate();
 
         return ResponseTypes.Result.RESULT_SUCCESS.equals(manipulationResult);
     }
@@ -317,7 +303,7 @@ public class ConditionalPreconditions {
          * @return true if successful, false otherwise
          */
         static boolean manipulation(final Injector injector) {
-            return descriptionUpdateManipulation(injector, LOG);
+            return descriptionUpdateManipulation(injector);
         }
     }
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
@@ -519,19 +519,14 @@ public class ConditionalPreconditionsTest {
     @Test
     @DisplayName("DescriptionModificationUptPrecondition correctly calls manipulation")
     public void testDescriptionModificationUptManipulation() {
-        final var descriptorHandle = "coolesHandle";
-
-        when(mockManipulations.triggerDescriptorUpdate(descriptorHandle))
+        when(mockManipulations.triggerAnyDescriptorUpdate())
                 .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-
-        when(mockDevice.getMdibAccess().getRootEntities().get(0).getDescriptor().getHandle())
-                .thenReturn(descriptorHandle);
 
         new ConditionalPreconditions.DescriptionModificationUptPrecondition();
 
         assertTrue(ConditionalPreconditions.DescriptionModificationUptPrecondition.manipulation(testInjector));
 
-        verify(mockManipulations, times(1)).triggerDescriptorUpdate(descriptorHandle);
+        verify(mockManipulations, times(1)).triggerAnyDescriptorUpdate();
     }
 
     /**

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
@@ -519,8 +519,7 @@ public class ConditionalPreconditionsTest {
     @Test
     @DisplayName("DescriptionModificationUptPrecondition correctly calls manipulation")
     public void testDescriptionModificationUptManipulation() {
-        when(mockManipulations.triggerAnyDescriptorUpdate())
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+        when(mockManipulations.triggerAnyDescriptorUpdate()).thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
 
         new ConditionalPreconditions.DescriptionModificationUptPrecondition();
 


### PR DESCRIPTION
The DescriptionModificationUptPrecondition previously had the problem that it did not work with Devices that did not support Updating MDS descriptors.
In order to remove this assumption, I adapted it to use the new TriggerAnyDescriptorUpdate manipulation, which allows the device to choose which descriptor it updates. It should hence succeed as long as the device has some descriptor that can be updated and the Precondition should hence now work with all devices whose T2IAPI-Server implements this new Manipulation.

NOTE: this code only compiles once the [PR#50](https://github.com/Draegerwerk/t2iapi/pull/50) in T2IAPI has been merged to master. I might have to adjust the version of T2IAPI in the pom.xml to use the correct version after that happened...

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
