### PR TITLE
Ensure that the exitCode is != 0 in case of Errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - setComponentActivation stores incorrect manipulation data in the database resulting in no test data being available for 5-4-7_* tests
 - that preconditions of the following requirements could not handle the T2IAPI manipulation result RESULT_NOT_SUPPORTED: biceps:R0029_0 biceps:R0116 biceps:5-4-7_0_0 biceps:5-4-7_1 biceps:5-4-7_2 biceps:5-4-7_3 biceps:5-4-7_4 biceps:5-4-7_5 biceps:5-4-7_6_0 biceps:5-4-7_7 biceps:5-4-7_8 biceps:5-4-7_9 biceps:5-4-7_10 biceps:5-4-7_11 biceps:5-4-7_12_0 biceps:5-4-7_13 biceps:5-4-7_14 biceps:5-4-7_15 biceps:5-4-7_16 biceps:5-4-7_17
 - biceps:R0034_0 does not track changes when reinserting descriptors.
-- report duplication issue in biceps:C11-C15, biceps:C5, biceps:R5046_0, biceps:B-284_0 as well as biceps:R5003. 
+- report duplication issue in biceps:C11-C15, biceps:C5, biceps:R5046_0, biceps:B-284_0 as well as biceps:R5003.
+- SDCcc previously terminated with exitCode 0 despite certain Errors.
 
 ## [7.0.1] - 2023-03-17
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,15 @@ this case in order to minimize the risk of such an invalid application going unn
 | R0056           | TriggerDescriptorUpdate |
 | R0078_0         | TriggerReport           |
 
+## Exit Codes
+
+SDCcc's exitCode should be interpreted as follows:
+
+| **ExitCode** | **Semantics**                                                                                                        |
+|--------------|----------------------------------------------------------------------------------------------------------------------|
+| 0            | Success - SDC-Compliance could be successfully measured and the Device Under Test satisfies all tested Requirements  |
+| 1            | Failure - SDC-Compliance could be successfully measured, but the Device Under Test violated Requirements             |
+| 2            | Error - SDC-Compliance could not be measured                                                                         |
 
 ## Notices
 SDCcc is not intended for use in medical products, clinical trials, clinical studies, or in clinical routine.

--- a/README.md
+++ b/README.md
@@ -324,9 +324,9 @@ SDCcc's exitCode should be interpreted as follows:
 
 | **ExitCode** | **Semantics**                                                                                                        |
 |--------------|----------------------------------------------------------------------------------------------------------------------|
-| 0            | Success - SDC-Compliance could be successfully measured and the Device Under Test satisfies all tested Requirements  |
-| 1            | Failure - SDC-Compliance could be successfully measured, but the Device Under Test violated Requirements             |
-| 2            | Error - SDC-Compliance could not be measured                                                                         |
+| 0            | Success - Test run execution was successful and the device under test satisfies all tested requirements  |
+| 1            | Failure - Test run execution was successful, but the device under test violated requirements             |
+| 2            | Error - Test run execution was not successful                                                                         |
 
 ## Notices
 SDCcc is not intended for use in medical products, clinical trials, clinical studies, or in clinical routine.

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -541,11 +541,10 @@ public class TestSuite {
             System.exit(2); // exitCode != 0 to indicate Error
         }
 
-        if (numberOfTestFailures > 0) {
-            System.exit(1); // exitCode != 0 to indicate Failure
-        }
         if (hadError || testRunObserver.isInvalid()) {
             System.exit(2); // exitCode != 0 to indicate Error
+        } else if (numberOfTestFailures > 0) {
+            System.exit(1); // exitCode != 0 to indicate Failure
         } else {
             System.exit(0); // exitCode == 0 to indicate Success
         }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -525,7 +525,8 @@ public class TestSuite {
         return createInjector(configurationModule, new TestRunConfig(testRunDir));
     }
 
-    private static void exit(final long numberOfTestFailures, boolean hadError, final Injector injector, final File testRunDir) {
+    private static void exit(
+            final long numberOfTestFailures, final boolean hadError, final Injector injector, final File testRunDir) {
 
         final TestRunObserver testRunObserver = injector.getInstance(TestRunObserver.class);
         try {
@@ -542,7 +543,8 @@ public class TestSuite {
 
         if (numberOfTestFailures > 0) {
             System.exit(1); // exitCode != 0 to indicate Failure
-        } if (hadError || testRunObserver.isInvalid()) {
+        }
+        if (hadError || testRunObserver.isInvalid()) {
             System.exit(2); // exitCode != 0 to indicate Error
         } else {
             System.exit(0); // exitCode == 0 to indicate Success


### PR DESCRIPTION
Previously, in case of Test Run Invalidations (which are Errors), SDCcc would still exit with exitCode 0 unless there were also test failures. Since an exitCode == 0 indicates success, it should be ensured that Errors cause an exitCode != 0.
This behaviour was hence corrected.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
