### PR TITLE
Adapt to changes of the sdc-ri package structure

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/mdpws/invariant/InvariantDynamicDiscoveryTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/mdpws/invariant/InvariantDynamicDiscoveryTest.java
@@ -28,7 +28,7 @@ import javax.xml.namespace.QName;
 import javax.xml.xpath.XPathExpressionException;
 import org.junit.jupiter.api.Test;
 import org.somda.sdc.dpws.DpwsConstants;
-import org.somda.sdc.mdpws.common.CommonConstants;
+import org.somda.sdc.glue.common.CommonConstants;
 import org.w3c.dom.Node;
 
 /**

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/util/Constants.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/util/Constants.java
@@ -71,7 +71,7 @@ public final class Constants {
             "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
 
     public static final String MDPWS_NAMESPACE_PREFIX = "mdpws";
-    public static final String MDPWS_NAMESPACE = org.somda.sdc.mdpws.common.CommonConstants.NAMESPACE;
+    public static final String MDPWS_NAMESPACE = org.somda.sdc.glue.common.CommonConstants.NAMESPACE_MDPWS;
 
     public static final QName WSDL_INPUT = new QName(WSDL_NAMESPACE, "input");
     public static final QName WSDL_OUTPUT = new QName(WSDL_NAMESPACE, "output");

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/mdpws/invariant/InvariantDynamicDiscoveryTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/mdpws/invariant/InvariantDynamicDiscoveryTestTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.somda.sdc.dpws.DpwsConstants;
-import org.somda.sdc.mdpws.common.CommonConstants;
+import org.somda.sdc.glue.common.CommonConstants;
 
 /**
  * Unit test for the MDPWS {@linkplain InvariantDynamicDiscoveryTest}.

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
@@ -79,7 +79,7 @@ import org.somda.sdc.dpws.soap.factory.RequestResponseClientFactory;
 import org.somda.sdc.dpws.soap.wseventing.WsEventingConstants;
 import org.somda.sdc.dpws.soap.wseventing.model.ObjectFactory;
 import org.somda.sdc.glue.GlueConstants;
-import org.somda.sdc.mdpws.common.CommonConstants;
+import org.somda.sdc.glue.common.CommonConstants;
 
 /**
  * SDCcc system test.


### PR DESCRIPTION
Sdc-ri removed the mdpws package and moved the mdpws constants.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
