### PR TITLE
Reworked biceps:5-4-7 tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - setComponentActivation stores incorrect manipulation data in the database resulting in no test data being available for 5-4-7_* tests
 - that preconditions of the following requirements could not handle the T2IAPI manipulation result RESULT_NOT_SUPPORTED: biceps:R0029_0 biceps:R0116 biceps:5-4-7_0_0 biceps:5-4-7_1 biceps:5-4-7_2 biceps:5-4-7_3 biceps:5-4-7_4 biceps:5-4-7_5 biceps:5-4-7_6_0 biceps:5-4-7_7 biceps:5-4-7_8 biceps:5-4-7_9 biceps:5-4-7_10 biceps:5-4-7_11 biceps:5-4-7_12_0 biceps:5-4-7_13 biceps:5-4-7_14 biceps:5-4-7_15 biceps:5-4-7_16 biceps:5-4-7_17
 - biceps:R0034_0 does not track changes when reinserting descriptors.
-- report duplication issue in biceps:C11-C15, biceps:C5, biceps:R5046_0, biceps:B-284_0 as well as biceps:R5003. 
+- report duplication issue in biceps:C11-C15, biceps:C5, biceps:R5046_0, biceps:B-284_0 as well as biceps:R5003.
+- biceps:5-4-7 tests confusing changes made by SetComponentActivation manipulations with changes made by SetMetricStatus (#118)
 
 ## [7.0.1] - 2023-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - that preconditions of the following requirements could not handle the T2IAPI manipulation result RESULT_NOT_SUPPORTED: biceps:R0029_0 biceps:R0116 biceps:5-4-7_0_0 biceps:5-4-7_1 biceps:5-4-7_2 biceps:5-4-7_3 biceps:5-4-7_4 biceps:5-4-7_5 biceps:5-4-7_6_0 biceps:5-4-7_7 biceps:5-4-7_8 biceps:5-4-7_9 biceps:5-4-7_10 biceps:5-4-7_11 biceps:5-4-7_12_0 biceps:5-4-7_13 biceps:5-4-7_14 biceps:5-4-7_15 biceps:5-4-7_16 biceps:5-4-7_17
 - biceps:R0034_0 does not track changes when reinserting descriptors.
 - report duplication issue in biceps:C11-C15, biceps:C5, biceps:R5046_0, biceps:B-284_0 as well as biceps:R5003.
-- biceps:5-4-7 tests confusing changes made by SetComponentActivation manipulations with changes made by SetMetricStatus (#118)
+- biceps:5-4-7 tests confusing changes made by SetComponentActivation manipulations with changes made by SetMetricStatus.
 
 ## [7.0.1] - 2023-03-17
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ in high numbers. When this option is set to true, then the errors will not be di
 at the end. When the option is set to false, then the individual errors are displayed, which is useful for fixing
 these problems.
 
+```
+[SDCcc.TestParameter]
+Biceps547TimeInterval=5
+```
+When running biceps:5-4-7 tests the Biceps547TimeInterval parameter is used to pause between the SetMetricStatus 
+manipulation calls with a default of 5 seconds. The report that follows a SetMetricStatus manipulation is expected 
+within the specified seconds.
+
 ## Running SDCcc
 The following command line options are supported by the test tool, the first two need to be provided.
 

--- a/README.md
+++ b/README.md
@@ -293,24 +293,24 @@ this case in order to minimize the risk of such an invalid application going unn
 | R5051           | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
 | R5052           | TriggerAnyDescriptorUpdate                                                                  |
 | R5053           | GetRemovableDescriptorsOfClass, RemoveDescriptor, InsertDescriptor                          |
-| 5-4-7_0_0       | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_1         | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_2         | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_3         | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_4         | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_5         | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_6_0       | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_7         | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_8         | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_9         | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_10        | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_11        | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_12_0      | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_13        | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_14        | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_15        | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_16        | SetComponentActivation, SetMetricStatus                                                     |
-| 5-4-7_17        | SetComponentActivation, SetMetricStatus                                                     |
+| 5-4-7_0_0       | SetMetricStatus                                                                             |
+| 5-4-7_1         | SetMetricStatus                                                                             |
+| 5-4-7_2         | SetMetricStatus                                                                             |
+| 5-4-7_3         | SetMetricStatus                                                                             |
+| 5-4-7_4         | SetMetricStatus                                                                             |
+| 5-4-7_5         | SetMetricStatus                                                                             |
+| 5-4-7_6_0       | SetMetricStatus                                                                             |
+| 5-4-7_7         | SetMetricStatus                                                                             |
+| 5-4-7_8         | SetMetricStatus                                                                             |
+| 5-4-7_9         | SetMetricStatus                                                                             |
+| 5-4-7_10        | SetMetricStatus                                                                             |
+| 5-4-7_11        | SetMetricStatus                                                                             |
+| 5-4-7_12_0      | SetMetricStatus                                                                             |
+| 5-4-7_13        | SetMetricStatus                                                                             |
+| 5-4-7_14        | SetMetricStatus                                                                             |
+| 5-4-7_15        | SetMetricStatus                                                                             |
+| 5-4-7_16        | SetMetricStatus                                                                             |
+| 5-4-7_17        | SetMetricStatus                                                                             |
 
 [MDPWS]
 

--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -31,4 +31,4 @@ Enable=false
 ServerAddress="localhost:50051"
 
 [SDCcc.TestParameter]
-Biceps547TimeInterval=1
+Biceps547TimeInterval=5

--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -29,3 +29,6 @@ Enable=false
 
 [SDCcc.gRPC]
 ServerAddress="localhost:50051"
+
+[SDCcc.TestParameter]
+Biceps547TimeInterval=1

--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>com.draeger.medical</groupId>
             <artifactId>t2iapi</artifactId>
-            <version>3.0.0.226</version>
+            <version>3.0.0.262</version>
         </dependency>
 
         <dependency>

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
@@ -25,6 +25,7 @@ public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
         configureNetwork();
         configureProvider();
         configureGRpc();
+        configureTestParameter();
         configureInternalSettings();
         configureCommlogSettings();
     }
@@ -60,6 +61,10 @@ public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
 
     void configureGRpc() {
         bind(TestSuiteConfig.GRPC_SERVER_ADDRESS, String.class, "localhost:50051");
+    }
+
+    void configureTestParameter() {
+        bind(TestSuiteConfig.TEST_BICEPS_547_TIME_INTERVAL, long.class, 5000L);
     }
 
     void configureInternalSettings() {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
@@ -64,7 +64,7 @@ public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
     }
 
     void configureTestParameter() {
-        bind(TestSuiteConfig.TEST_BICEPS_547_TIME_INTERVAL, long.class, 5000L);
+        bind(TestSuiteConfig.TEST_BICEPS_547_TIME_INTERVAL, long.class, 5L);
     }
 
     void configureInternalSettings() {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
@@ -71,6 +71,12 @@ public final class TestSuiteConfig {
     public static final String GRPC_SERVER_ADDRESS = SDCCC + GRPC + "ServerAddress";
 
     /*
+     * Test parameter configuration
+     */
+    private static final String TEST_PARAMETER = "TestParameter.";
+    public static final String TEST_BICEPS_547_TIME_INTERVAL = SDCCC + TEST_PARAMETER + "Biceps547TimeInterval";
+
+    /*
      * Commlog configuration
      */
     private static final String COMMLOG = "Commlog.";

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
@@ -203,7 +203,10 @@ public class FallbackManipulations implements Manipulations {
 
     @Override
     public ResponseTypes.Result setMetricStatus(
-            final String handle, final MetricCategory category, final ComponentActivation activation) {
+            final String sequenceId,
+            final String handle,
+            final MetricCategory category,
+            final ComponentActivation activation) {
 
         final var metricStatusString = getMetricStatus(activation);
         if (metricStatusString.isEmpty()) return ResponseTypes.Result.RESULT_FAIL;

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
@@ -272,7 +272,10 @@ public class GRpcManipulations implements Manipulations {
 
     @Override
     public ResponseTypes.Result setMetricStatus(
-            final String handle, final MetricCategory category, final ComponentActivation activation) {
+            final String sequenceId,
+            final String handle,
+            final MetricCategory category,
+            final ComponentActivation activation) {
         final var metricStatus = getMetricStatus(activation);
         if (metricStatus.isEmpty()) return ResponseTypes.Result.RESULT_FAIL;
         final var message = MetricRequests.SetMetricStatusRequest.newBuilder()
@@ -282,10 +285,11 @@ public class GRpcManipulations implements Manipulations {
 
         return performCallWrapper(
                 v -> metricStub.setMetricStatus(message),
-                v -> fallback.setMetricStatus(handle, category, activation),
+                v -> fallback.setMetricStatus(sequenceId, handle, category, activation),
                 BasicResponses.BasicResponse::getResult,
                 BasicResponses.BasicResponse::getResult,
-                ManipulationParameterUtil.buildMetricStatusManipulationParameterData(handle, category, activation));
+                ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                        sequenceId, handle, category, activation));
     }
 
     @Override

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
@@ -120,12 +120,14 @@ public interface Manipulations {
     /**
      * Set the metric to a specific state to trigger the setting of the ActivationState.
      *
+     * @param sequenceId during which the manipulation was performed
      * @param handle state handle to set the status of the metric for
      * @param category of the metric to set the status for
      * @param activation the activation state the metric should have, after manipulation
      * @return the result of the manipulation
      */
-    ResponseTypes.Result setMetricStatus(String handle, MetricCategory category, ComponentActivation activation);
+    ResponseTypes.Result setMetricStatus(
+            String sequenceId, String handle, MetricCategory category, ComponentActivation activation);
 
     /**
      * Trigger a descriptor update for the provided descriptor handle.

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -86,7 +86,13 @@ public class ManipulationPreconditions {
                 final var metricState =
                         entity.getStates(AbstractMetricState.class).get(0);
                 final var handle = metricState.getDescriptorHandle();
-                final var manipulationResult = manipulations.setMetricStatus(handle, category, activationState);
+                final var sequenceId = testClient
+                        .getSdcRemoteDevice()
+                        .getMdibAccess()
+                        .getMdibVersion()
+                        .getSequenceId();
+                final var manipulationResult =
+                        manipulations.setMetricStatus(sequenceId, handle, category, activationState);
                 log.debug(
                         "Manipulation setMetricStatus was {} for metric state with handle {}",
                         manipulationResult,

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -1154,7 +1154,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.MSRMT;
             final var activationState = ComponentActivation.ON;
-            final var startingActivationState = ComponentActivation.OFF;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1181,7 +1180,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.MSRMT;
             final var activationState = ComponentActivation.NOT_RDY;
-            final var startingActivationState = ComponentActivation.OFF;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1208,7 +1206,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.MSRMT;
             final var activationState = ComponentActivation.STND_BY;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1234,7 +1231,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.MSRMT;
             final var activationState = ComponentActivation.SHTDN;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1260,7 +1256,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.MSRMT;
             final var activationState = ComponentActivation.OFF;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1286,7 +1281,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.MSRMT;
             final var activationState = ComponentActivation.FAIL;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1312,7 +1306,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.SET;
             final var activationState = ComponentActivation.ON;
-            final var startingActivationState = ComponentActivation.OFF;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1338,7 +1331,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.SET;
             final var activationState = ComponentActivation.NOT_RDY;
-            final var startingActivationState = ComponentActivation.OFF;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1364,7 +1356,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.SET;
             final var activationState = ComponentActivation.STND_BY;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1390,7 +1381,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.SET;
             final var activationState = ComponentActivation.SHTDN;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1416,7 +1406,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.SET;
             final var activationState = ComponentActivation.OFF;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1442,7 +1431,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.SET;
             final var activationState = ComponentActivation.FAIL;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1468,7 +1456,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.CLC;
             final var activationState = ComponentActivation.ON;
-            final var startingActivationState = ComponentActivation.OFF;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1494,7 +1481,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.CLC;
             final var activationState = ComponentActivation.NOT_RDY;
-            final var startingActivationState = ComponentActivation.OFF;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1520,7 +1506,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.CLC;
             final var activationState = ComponentActivation.STND_BY;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1546,7 +1531,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.CLC;
             final var activationState = ComponentActivation.SHTDN;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1572,7 +1556,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.CLC;
             final var activationState = ComponentActivation.OFF;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }
@@ -1598,7 +1581,6 @@ public class ManipulationPreconditions {
         static boolean manipulation(final Injector injector) {
             final var metricCategory = MetricCategory.CLC;
             final var activationState = ComponentActivation.FAIL;
-            final var startingActivationState = ComponentActivation.ON;
             return manipulateMetricStatus(injector, LOG, metricCategory, activationState);
         }
     }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
@@ -131,7 +131,6 @@ public class MessageStorage implements AutoCloseable {
             "getInboundMessagesByBodyType called on closed storage";
     private static final String GET_INBOUND_MESSAGE_BY_TIME_INTERVAL_CALLED_ON_CLOSED_STORAGE =
             "getInboundMessagesByTimeInterval called on closed storage";
-    // getInboundMessagesByTimestampAndBodyType
     private static final String GET_INBOUND_MESSAGE_BY_TIMESTAMP_CALLED_ON_CLOSED_STORAGE =
             "getInboundMessagesByTimestampAndBodyType called on closed storage";
     private static final String GET_MANIPULATION_DATA_BY_MANIPULATION =

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
@@ -26,16 +26,14 @@ import com.draeger.medical.sdccc.tests.util.ManipulationParameterUtil;
 import com.draeger.medical.sdccc.tests.util.NoTestData;
 import com.draeger.medical.sdccc.util.Constants;
 import com.draeger.medical.t2iapi.ResponseTypes;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import com.google.inject.Key;
-import com.google.inject.name.Names;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -76,7 +74,8 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
         final var riInjector = getInjector().getInstance(TestClient.class).getInjector();
         this.marshalling = riInjector.getInstance(MarshallingService.class);
         this.soapUtil = riInjector.getInstance(SoapUtil.class);
-        final var timeBufferInSeconds = getInjector().getInstance(Key.get(long.class, Names.named(TestSuiteConfig.TEST_BICEPS_547_TIME_INTERVAL)));
+        final var timeBufferInSeconds = getInjector()
+                .getInstance(Key.get(long.class, Names.named(TestSuiteConfig.TEST_BICEPS_547_TIME_INTERVAL)));
         BUFFER = TimeUnit.NANOSECONDS.convert(timeBufferInSeconds, TimeUnit.SECONDS);
     }
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.draeger.medical.sdccc.configuration.EnabledTestConfig;
+import com.draeger.medical.sdccc.configuration.TestSuiteConfig;
 import com.draeger.medical.sdccc.manipulation.precondition.impl.ManipulationPreconditions;
 import com.draeger.medical.sdccc.messages.MessageStorage;
 import com.draeger.medical.sdccc.messages.mapping.ManipulationData;
@@ -30,7 +31,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,7 +65,7 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
                     + " %s found, test failed.";
     public static final String WRONG_ACTIVATION_STATE =
             "The manipulated activation state for metric %s should be %s but is %s";
-    private static final long BUFFER = TimeUnit.NANOSECONDS.convert(5, TimeUnit.SECONDS);
+    private long BUFFER;
     private MessageStorage messageStorage;
     private MarshallingService marshalling;
     private SoapUtil soapUtil;
@@ -71,6 +76,8 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
         final var riInjector = getInjector().getInstance(TestClient.class).getInjector();
         this.marshalling = riInjector.getInstance(MarshallingService.class);
         this.soapUtil = riInjector.getInstance(SoapUtil.class);
+        final var timeBufferInSeconds = getInjector().getInstance(Key.get(long.class, Names.named(TestSuiteConfig.TEST_BICEPS_547_TIME_INTERVAL)));
+        BUFFER = TimeUnit.NANOSECONDS.convert(timeBufferInSeconds, TimeUnit.SECONDS);
     }
 
     @Test

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
@@ -7,6 +7,7 @@
 
 package com.draeger.medical.sdccc.tests.biceps.invariant;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -24,27 +25,25 @@ import com.draeger.medical.sdccc.tests.annotations.TestIdentifier;
 import com.draeger.medical.sdccc.tests.util.ImpliedValueUtil;
 import com.draeger.medical.sdccc.tests.util.ManipulationParameterUtil;
 import com.draeger.medical.sdccc.tests.util.NoTestData;
+import com.draeger.medical.sdccc.tests.util.guice.MdibHistorianFactory;
 import com.draeger.medical.sdccc.util.Constants;
+import com.draeger.medical.sdccc.util.TestRunObserver;
 import com.draeger.medical.t2iapi.ResponseTypes;
 import com.google.inject.Key;
 import com.google.inject.name.Names;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.somda.sdc.biceps.model.message.AbstractMetricReport;
-import org.somda.sdc.biceps.model.message.AbstractReport;
-import org.somda.sdc.biceps.model.message.WaveformStream;
+import org.somda.sdc.biceps.common.storage.PreprocessingException;
+import org.somda.sdc.biceps.consumer.access.RemoteMdibAccess;
+import org.somda.sdc.biceps.model.participant.AbstractMetricState;
 import org.somda.sdc.biceps.model.participant.ComponentActivation;
 import org.somda.sdc.biceps.model.participant.MetricCategory;
-import org.somda.sdc.dpws.soap.MarshallingService;
-import org.somda.sdc.dpws.soap.SoapUtil;
-import org.somda.sdc.dpws.soap.exception.MarshallingException;
+import org.somda.sdc.glue.consumer.report.ReportProcessingException;
 
 /**
  * BICEPS participant model state part tests (ch. 5.4).
@@ -54,29 +53,22 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
             "No setMetricStatus manipulation for metrics with category %s performed, test failed.";
     public static final String NO_SUCCESSFUL_MANIPULATION =
             "No successful setMetricStatus manipulation seen, test failed.";
-    public static final String NO_REPORT_IN_TIME_INTERVAL =
-            "No metric reports or waveform streams for %s manipulation found between %s and %s, test failed.";
-    public static final String NO_REPORT_WITH_EXPECTED_HANDLE =
-            "No metric reports or waveform streams with metric handle %s found, test failed.";
-    public static final String NO_REPORT_WITH_EXPECTED_ACTIVATION_STATE =
-            "No metric reports or waveform streams containing the metric handle %s with the expected activation state"
-                    + " %s found, test failed.";
+    public static final String NO_REPORT_IN_TIME = "No reports until timestamp %s found, test failed.";
+    public static final String NO_METRIC_WITH_EXPECTED_HANDLE = "No metric with handle %s found, test failed.";
     public static final String WRONG_ACTIVATION_STATE =
             "The manipulated activation state for metric %s should be %s but is %s";
     private long buffer;
     private MessageStorage messageStorage;
-    private MarshallingService marshalling;
-    private SoapUtil soapUtil;
+    private MdibHistorianFactory mdibHistorianFactory;
 
     @BeforeEach
     void setUp() {
         this.messageStorage = getInjector().getInstance(MessageStorage.class);
         final var riInjector = getInjector().getInstance(TestClient.class).getInjector();
-        this.marshalling = riInjector.getInstance(MarshallingService.class);
-        this.soapUtil = riInjector.getInstance(SoapUtil.class);
         final var timeBufferInSeconds = getInjector()
                 .getInstance(Key.get(long.class, Names.named(TestSuiteConfig.TEST_BICEPS_547_TIME_INTERVAL)));
         buffer = TimeUnit.NANOSECONDS.convert(timeBufferInSeconds, TimeUnit.SECONDS);
+        this.mdibHistorianFactory = riInjector.getInstance(MdibHistorianFactory.class);
     }
 
     @Test
@@ -366,7 +358,7 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
 
     private void testRequirement547(final MetricCategory category, final ComponentActivation activation)
             throws NoTestData {
-        final var successfulReportsSeen = new AtomicBoolean(false);
+        final var successfulManipulationSeen = new AtomicBoolean(false);
         try (final var manipulations = messageStorage.getManipulationDataByParametersAndManipulation(
                 ManipulationParameterUtil.buildMetricStatusManipulationParameterDataWithoutHandle(category, activation),
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS)) {
@@ -376,18 +368,18 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
                     .getStream()
                     .filter(it -> it.getResult().equals(ResponseTypes.Result.RESULT_SUCCESS))
                     .forEachOrdered(it -> {
-                        successfulReportsSeen.getAndSet(true);
-                        checkAssociatedReport(it, activation);
+                        successfulManipulationSeen.getAndSet(true);
+                        checkAssociatedMetric(it, activation);
                     });
         } catch (IOException e) {
             fail(e);
             // unreachable
             throw new RuntimeException(e);
         }
-        assertTestData(successfulReportsSeen.get(), NO_SUCCESSFUL_MANIPULATION);
+        assertTestData(successfulManipulationSeen.get(), NO_SUCCESSFUL_MANIPULATION);
     }
 
-    private void checkAssociatedReport(
+    private void checkAssociatedMetric(
             final ManipulationData manipulationData, final ComponentActivation expectedActivationState) {
         final var manipulationParameter = manipulationData.getParameters();
         final var manipulatedHandle = manipulationParameter.stream()
@@ -395,112 +387,47 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
                 .map(ManipulationParameter::getParameterValue)
                 .findFirst()
                 .orElseThrow();
-        try (final var relevantReports = messageStorage.getInboundMessagesByTimeIntervalAndBodyType(
-                manipulationData.getStartTimestamp(),
-                manipulationData.getFinishTimestamp() + buffer,
-                Constants.MSG_EPISODIC_METRIC_REPORT,
-                Constants.MSG_WAVEFORM_STREAM)) {
-            assertTestData(
-                    relevantReports.areObjectsPresent(),
-                    String.format(
-                            NO_REPORT_IN_TIME_INTERVAL,
-                            manipulationData.getMethodName(),
-                            manipulationData.getStartTimestamp(),
-                            manipulationData.getFinishTimestamp()));
+        final var sequenceId = manipulationParameter.stream()
+                .filter(it -> it.getParameterName().equals(Constants.MANIPULATION_PARAMETER_SEQUENCE_ID))
+                .map(ManipulationParameter::getParameterValue)
+                .findFirst()
+                .orElseThrow();
 
-            final var relevantReport = relevantReports
-                    .getStream()
-                    .map(it -> {
-                        try {
-                            final var message = marshalling.unmarshal(
-                                    new ByteArrayInputStream(it.getBody().getBytes(StandardCharsets.UTF_8)));
-                            final var metricReportOpt = soapUtil.getBody(message, AbstractMetricReport.class);
-                            if (metricReportOpt.isEmpty()) {
-                                final var waveformOpt = soapUtil.getBody(message, WaveformStream.class);
-                                return waveformOpt.orElseThrow();
-                            } else {
-                                return metricReportOpt.orElseThrow();
-                            }
-                        } catch (MarshallingException e) {
-                            fail("Error unmarshalling MessageContent " + e);
-                            // unreachable
-                            throw new RuntimeException(e);
-                        }
-                    })
-                    .filter(it -> isReportRelevant(it, manipulatedHandle))
-                    .findFirst();
+        final var historian = mdibHistorianFactory.createMdibHistorian(
+                messageStorage, getInjector().getInstance(TestRunObserver.class));
 
-            assertTrue(relevantReport.isPresent(), String.format(NO_REPORT_WITH_EXPECTED_HANDLE, manipulatedHandle));
+        final var endTimestamp = manipulationData.getFinishTimestamp() + buffer;
+        try (final var history = historian.uniqueEpisodicReportBasedHistoryUntilTimestamp(sequenceId, endTimestamp)) {
+            try (final var historyNext =
+                    historian.uniqueEpisodicReportBasedHistoryUntilTimestamp(sequenceId, endTimestamp)) {
 
-            final var reportWithExpectedActivationStateSeen = isActivationStateAsExpected(
-                    relevantReport.orElseThrow(), manipulatedHandle, expectedActivationState);
+                RemoteMdibAccess first = history.next();
+                RemoteMdibAccess second = historyNext.next();
+                // skip the first entry so that history and historyNext are off by one entry
+                final var skippedElement = historyNext.next();
+                assertNotNull(skippedElement, String.format(NO_REPORT_IN_TIME, endTimestamp));
 
-            assertTrue(
-                    reportWithExpectedActivationStateSeen,
-                    String.format(
-                            NO_REPORT_WITH_EXPECTED_ACTIVATION_STATE, manipulatedHandle, expectedActivationState));
-        } catch (IOException | NoTestData e) {
-            fail(e);
-            // unreachable
-            throw new RuntimeException(e);
-        }
-    }
-
-    private boolean isReportRelevant(final AbstractReport report, final String manipulatedHandle) {
-        boolean present = false;
-        if (report instanceof AbstractMetricReport) {
-            for (var part : ((AbstractMetricReport) report).getReportPart()) {
-                if (part.getMetricState().stream()
-                        .anyMatch(state -> state.getDescriptorHandle().equals(manipulatedHandle))) {
-                    present = true;
+                // fast-forward to last mdib state before the end timestamp
+                while (second != null) {
+                    first = history.next();
+                    second = historyNext.next();
                 }
-            }
-        } else if (report instanceof WaveformStream) {
-            present = ((WaveformStream) report)
-                    .getState().stream().anyMatch(it -> it.getDescriptorHandle().equals(manipulatedHandle));
-        }
-        return present;
-    }
-
-    private boolean isActivationStateAsExpected(
-            final AbstractReport report,
-            final String manipulatedHandle,
-            final ComponentActivation expectedActivationState) {
-
-        final var relevantMetricPresent = new AtomicBoolean(false);
-        if (report instanceof final AbstractMetricReport metricReport) {
-            for (var part : metricReport.getReportPart()) {
-                final var state = part.getMetricState().stream()
-                        .filter(it -> it.getDescriptorHandle().equals(manipulatedHandle))
-                        .findFirst();
-                state.ifPresent(abstractMetricState -> {
-                    relevantMetricPresent.set(true);
-                    Assertions.assertEquals(
-                            expectedActivationState,
-                            ImpliedValueUtil.getMetricActivation(abstractMetricState),
-                            String.format(
-                                    WRONG_ACTIVATION_STATE,
-                                    manipulatedHandle,
-                                    expectedActivationState,
-                                    ImpliedValueUtil.getMetricActivation(abstractMetricState)));
-                });
-            }
-        } else if (report instanceof final WaveformStream waveform) {
-            final var state = waveform.getState().stream()
-                    .filter(it -> it.getDescriptorHandle().equals(manipulatedHandle))
-                    .findFirst();
-            state.ifPresent(abstractMetricState -> {
-                relevantMetricPresent.set(true);
+                final var relevantMetricStateOpt = first.getState(manipulatedHandle, AbstractMetricState.class);
+                assertTrue(
+                        relevantMetricStateOpt.isPresent(),
+                        String.format(NO_METRIC_WITH_EXPECTED_HANDLE, manipulatedHandle));
+                final var relevantMetricState = relevantMetricStateOpt.orElseThrow();
                 Assertions.assertEquals(
                         expectedActivationState,
-                        ImpliedValueUtil.getMetricActivation(abstractMetricState),
+                        ImpliedValueUtil.getMetricActivation(relevantMetricState),
                         String.format(
                                 WRONG_ACTIVATION_STATE,
                                 manipulatedHandle,
                                 expectedActivationState,
-                                ImpliedValueUtil.getMetricActivation(abstractMetricState)));
-            });
+                                ImpliedValueUtil.getMetricActivation(relevantMetricState)));
+            }
+        } catch (ReportProcessingException | PreprocessingException e) {
+            fail(e);
         }
-        return relevantMetricPresent.get();
     }
 }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTest.java
@@ -63,7 +63,7 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
                     + " %s found, test failed.";
     public static final String WRONG_ACTIVATION_STATE =
             "The manipulated activation state for metric %s should be %s but is %s";
-    private long BUFFER;
+    private long buffer;
     private MessageStorage messageStorage;
     private MarshallingService marshalling;
     private SoapUtil soapUtil;
@@ -76,7 +76,7 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
         this.soapUtil = riInjector.getInstance(SoapUtil.class);
         final var timeBufferInSeconds = getInjector()
                 .getInstance(Key.get(long.class, Names.named(TestSuiteConfig.TEST_BICEPS_547_TIME_INTERVAL)));
-        BUFFER = TimeUnit.NANOSECONDS.convert(timeBufferInSeconds, TimeUnit.SECONDS);
+        buffer = TimeUnit.NANOSECONDS.convert(timeBufferInSeconds, TimeUnit.SECONDS);
     }
 
     @Test
@@ -397,7 +397,7 @@ public class InvariantParticipantModelStatePartTest extends InjectorTestBase {
                 .orElseThrow();
         try (final var relevantReports = messageStorage.getInboundMessagesByTimeIntervalAndBodyType(
                 manipulationData.getStartTimestamp(),
-                manipulationData.getFinishTimestamp() + BUFFER,
+                manipulationData.getFinishTimestamp() + buffer,
                 Constants.MSG_EPISODIC_METRIC_REPORT,
                 Constants.MSG_WAVEFORM_STREAM)) {
             assertTestData(

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ManipulationParameterUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ManipulationParameterUtil.java
@@ -159,14 +159,19 @@ public final class ManipulationParameterUtil {
     /**
      * Build manipulation parameter data containing the handle, category and activation of the metric to set the status for.
      *
+     * @param sequenceId in which the manipulation is performed
      * @param handle of the metric
      * @param category of the metric
      * @param activation of the metric
      * @return the manipulation parameter data
      */
     public static ManipulationParameterData buildMetricStatusManipulationParameterData(
-            final String handle, final MetricCategory category, final ComponentActivation activation) {
+            final String sequenceId,
+            final String handle,
+            final MetricCategory category,
+            final ComponentActivation activation) {
         return new ManipulationParameterData(List.of(
+                new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_SEQUENCE_ID, sequenceId),
                 new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_HANDLE, handle),
                 new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_METRIC_CATEGORY, category.value()),
                 new ImmutablePair<>(Constants.MANIPULATION_PARAMETER_COMPONENT_ACTIVATION, activation.value())));

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/util/Constants.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/util/Constants.java
@@ -222,6 +222,7 @@ public final class Constants {
 
     // Manipulation Data for Hibernation
     public static final String MANIPULATION_PARAMETER_HANDLE = "Handle";
+    public static final String MANIPULATION_PARAMETER_SEQUENCE_ID = "SequenceId";
     public static final String MANIPULATION_PARAMETER_LOCATION_DETAIL = "LocationDetail";
     public static final String MANIPULATION_PARAMETER_CONTEXT_ASSOCIATION = "ContextAssociation";
     public static final String MANIPULATION_PARAMETER_ALERT_ACTIVATION = "AlertActivation";

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import com.draeger.medical.sdccc.manipulation.Manipulations;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClient;
 import com.draeger.medical.sdccc.tests.test_util.InjectorUtil;
+import com.draeger.medical.sdccc.util.MdibBuilder;
 import com.draeger.medical.sdccc.util.TestRunObserver;
 import com.draeger.medical.t2iapi.ResponseTypes;
 import com.google.inject.AbstractModule;
@@ -184,7 +185,7 @@ public class ManipulationPreconditionsTest {
         mockSystemSignalActivationVis = mock(SystemSignalActivation.class);
         mockEntity = mock(MdibEntity.class);
         mockEntity2 = mock(MdibEntity.class);
-        mockMdibAccess = mock(MdibAccess.class);
+        mockMdibAccess = mock(MdibAccess.class, Answers.RETURNS_DEEP_STUBS);
 
         mockTestClient = mock(TestClient.class, Answers.RETURNS_DEEP_STUBS);
         when(mockTestClient.getSdcRemoteDevice()).thenReturn(mockDevice);
@@ -844,147 +845,6 @@ public class ManipulationPreconditionsTest {
         }
     }
 
-    @Test
-    @DisplayName("testMetricStatusManipulationMSRMTActivationStateSHTDNGood: Set ActivationState "
-            + "of all MSRMT-Metrics to SHTDN.")
-    void testMetricStatusManipulationMSRMTActivationStateSHTDNGood() {
-
-        // given
-
-        final ComponentActivation startActivationState = ComponentActivation.ON;
-        final MetricCategory metricCategory = MetricCategory.MSRMT;
-        final ComponentActivation activationState = ComponentActivation.SHTDN;
-        final String metricStateHandle = "metricStateHandle";
-
-        setupMetricStatusManipulation(metricCategory, metricStateHandle);
-
-        when(mockManipulations.setComponentActivation(metricStateHandle, startActivationState))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-        when(mockManipulations.setMetricStatus(metricStateHandle, metricCategory, activationState))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-
-        // when
-
-        final boolean result =
-                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN.manipulation(injector);
-
-        // then
-
-        assertTrue(result);
-        assertFalse(
-                testRunObserver.isInvalid(),
-                "Test run should not have been invalidated. Reason(s): " + testRunObserver.getReasons());
-        verify(mockManipulations).setComponentActivation(metricStateHandle, startActivationState);
-        verify(mockManipulations).setMetricStatus(metricStateHandle, metricCategory, activationState);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateSHTDN: The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateSHTDNAllowNotSupported1() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.SHTDN);
-    }
-
-    @Test
-    @DisplayName(
-            "MetricStatusManipulationMSRMTActivationStateSHTDN: The precondition does not fail if setMetricStatus is not supported by all metrics.")
-    void testMetricStatusManipulationMSRMTActivationStateSHTDNAllowNotSupported2() {
-        metricMockSetup(
-                MetricCategory.MSRMT, METRIC_HANDLE, SOME_HANDLE, ComponentActivation.ON, ComponentActivation.SHTDN);
-
-        // let one metric not support setMetricStatus manipulation
-        when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
-
-        assertTrue(ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN.manipulation(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, ComponentActivation.ON);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, MetricCategory.MSRMT, ComponentActivation.SHTDN);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationMSRMTActivationStateSHTDNBad: First Manipulation failed.")
-    void testMetricStatusManipulationMSRMTActivationStateSHTDNBadFirstManipulationFailed() {
-
-        // given
-
-        final ComponentActivation startActivationState = ComponentActivation.ON;
-        final MetricCategory metricCategory = MetricCategory.MSRMT;
-        final ComponentActivation activationState = ComponentActivation.SHTDN;
-        final String metricStateHandle = "metricStateHandle";
-
-        setupMetricStatusManipulation(metricCategory, metricStateHandle);
-
-        when(mockManipulations.setComponentActivation(metricStateHandle, startActivationState))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-        when(mockManipulations.setMetricStatus(metricStateHandle, metricCategory, activationState))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-
-        // when
-
-        final boolean result =
-                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN.manipulation(injector);
-
-        // then
-        assertFalse(result);
-        verify(mockManipulations).setComponentActivation(metricStateHandle, startActivationState);
-    }
-
-    @Test
-    @DisplayName("testMetricStatusManipulationMSRMTActivationStateSHTDNBad: Second Manipulation Failed.")
-    void testMetricStatusManipulationMSRMTActivationStateSHTDNBadSecondManipulationFailed() {
-
-        // given
-        final ComponentActivation startActivationState = ComponentActivation.ON;
-        final MetricCategory metricCategory = MetricCategory.MSRMT;
-        final ComponentActivation activationState = ComponentActivation.SHTDN;
-        final String metricStateHandle = "metricStateHandle";
-
-        setupMetricStatusManipulation(metricCategory, metricStateHandle);
-
-        when(mockManipulations.setComponentActivation(metricStateHandle, startActivationState))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-        when(mockManipulations.setMetricStatus(metricStateHandle, metricCategory, activationState))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        // when
-        final boolean result =
-                ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN.manipulation(injector);
-
-        // then
-        assertFalse(result);
-        verify(mockManipulations).setComponentActivation(metricStateHandle, startActivationState);
-        verify(mockManipulations).setMetricStatus(metricStateHandle, metricCategory, activationState);
-    }
-
-    private void setupMetricStatusManipulation(final MetricCategory metricCategory, final String metricStateHandle) {
-        when(mockDevice.getMdibAccess()).thenReturn(mockMdibAccess);
-        when(mockMdibAccess.findEntitiesByType(AbstractMetricDescriptor.class)).thenReturn(List.of(mockEntity));
-        when(mockEntity.getDescriptor(AbstractMetricDescriptor.class)).thenReturn(Optional.of(mockMetricDescriptor));
-        when(mockMetricDescriptor.getMetricCategory()).thenReturn(metricCategory);
-        when(mockEntity.getStates(AbstractMetricState.class)).thenReturn(List.of(mockMetricState));
-        when(mockMetricState.getDescriptorHandle()).thenReturn(metricStateHandle);
-    }
-
     private void alertConditionPresenceManipulationSetup() {
         when(mockDevice.getMdibAccess()).thenReturn(mockMdibAccess);
         when(mockMdibAccess.findEntitiesByType(AlertConditionDescriptor.class))
@@ -1372,81 +1232,48 @@ public class ManipulationPreconditionsTest {
         assertTrue(testRunObserver.isInvalid(), "Test run should have been invalid.");
     }
 
-    private void metricMockSetup(
-            final MetricCategory category,
-            final String metricHandle,
-            final String secondMetricHandle,
-            final ComponentActivation startingState,
-            final ComponentActivation endState) {
-        // create mock metric
-        when(mockMetricDescriptor.getHandle()).thenReturn(metricHandle);
-        when(mockMetricDescriptor.getMetricCategory()).thenReturn(category);
-        when(mockMetricState.getDescriptorHandle()).thenReturn(metricHandle);
-        when(mockMetricState.getActivationState()).thenReturn(startingState).thenReturn(endState);
-
-        // create second mock metric
-        when(mockMetricDescriptor2.getHandle()).thenReturn(secondMetricHandle);
-        when(mockMetricDescriptor2.getMetricCategory()).thenReturn(category);
-        when(mockMetricState2.getDescriptorHandle()).thenReturn(secondMetricHandle);
-        when(mockMetricState2.getActivationState()).thenReturn(startingState).thenReturn(endState);
-
-        // create mock entities to hold the states
-        when(mockEntity.getHandle()).thenReturn(metricHandle);
-        when(mockEntity.getDescriptor(AbstractMetricDescriptor.class)).thenReturn(Optional.of(mockMetricDescriptor));
-        when(mockEntity.getStates(AbstractMetricState.class)).thenReturn(List.of(mockMetricState));
-        when(mockEntity2.getHandle()).thenReturn(secondMetricHandle);
-        when(mockEntity2.getDescriptor(AbstractMetricDescriptor.class)).thenReturn(Optional.of(mockMetricDescriptor2));
-        when(mockEntity2.getStates(AbstractMetricState.class)).thenReturn(List.of(mockMetricState2));
-
-        // make setComponentActivation return true for the manipulations and false afterwards
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        // make setMetricStatus return true for the manipulations and false afterwards
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-    }
-
     @SuppressWarnings("SameParameterValue")
     private void setMetricStatusSetup(
             final MetricCategory category,
             final String metricHandle,
-            final ComponentActivation startingState,
+            final String otherMetricHandle,
             final ComponentActivation endState) {
         // create mock metric
         when(mockMetricDescriptor.getHandle()).thenReturn(metricHandle);
         when(mockMetricDescriptor.getMetricCategory()).thenReturn(category);
         when(mockMetricState.getDescriptorHandle()).thenReturn(metricHandle);
-        when(mockMetricState.getActivationState()).thenReturn(startingState).thenReturn(endState);
+        when(mockMetricState.getActivationState()).thenReturn(endState);
 
-        // make setComponentActivation return true for the manipulations and false afterwards
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        // make setMetricStatus return true for the manipulations and false afterwards
-        when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+        // create second mock metric
+        when(mockMetricDescriptor2.getHandle()).thenReturn(otherMetricHandle);
+        when(mockMetricDescriptor2.getMetricCategory()).thenReturn(category);
+        when(mockMetricState2.getDescriptorHandle()).thenReturn(otherMetricHandle);
+        when(mockMetricState2.getActivationState()).thenReturn(endState);
 
         // create mock entities to hold the states
         when(mockEntity.getHandle()).thenReturn(metricHandle);
         when(mockEntity.getDescriptor(AbstractMetricDescriptor.class)).thenReturn(Optional.of(mockMetricDescriptor));
         when(mockEntity.getStates(AbstractMetricState.class)).thenReturn(List.of(mockMetricState));
+        when(mockEntity2.getHandle()).thenReturn(otherMetricHandle);
+        when(mockEntity2.getDescriptor(AbstractMetricDescriptor.class)).thenReturn(Optional.of(mockMetricDescriptor2));
+        when(mockEntity2.getStates(AbstractMetricState.class)).thenReturn(List.of(mockMetricState2));
+
+        when(mockDevice.getMdibAccess().getMdibVersion().getSequenceId()).thenReturn(MdibBuilder.DEFAULT_SEQUENCE_ID);
         when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity));
+                .thenReturn(List.of(mockEntity, mockEntity2));
+        // let setMetricStatus manipulation for first handle be successful
+        when(mockManipulations.setMetricStatus(
+                        eq(MdibBuilder.DEFAULT_SEQUENCE_ID), eq(metricHandle), eq(category), eq(endState)))
+                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+        // let setMetricStatus manipulation for second handle be successful
+        when(mockManipulations.setMetricStatus(
+                        eq(MdibBuilder.DEFAULT_SEQUENCE_ID), eq(otherMetricHandle), eq(category), eq(endState)))
+                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
     }
 
     // the argument source for the setMetricStatus preconditions
     // 1. the specific method of the precondition to be tested
     // 2. the metric category
-    // 3. the component activation of the metric before the setMetricStatus manipulation
     // 4. the expected component activation after the setMetricStatus manipulation finished successfully
     private static Stream<Arguments> metricStatusManipulationXActivationStateXArguments() {
         return Stream.of(
@@ -1455,19 +1282,16 @@ public class ManipulationPreconditionsTest {
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateON::manipulation,
                         MetricCategory.MSRMT,
-                        ComponentActivation.OFF,
                         ComponentActivation.ON),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationCLCActivationStateON::manipulation,
                         MetricCategory.CLC,
-                        ComponentActivation.OFF,
                         ComponentActivation.ON),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationSETActivationStateON::manipulation,
                         MetricCategory.SET,
-                        ComponentActivation.OFF,
                         ComponentActivation.ON),
                 // arguments for MetricStatusManipulationXActivationStateNOTRDY preconditions
                 Arguments.of(
@@ -1475,21 +1299,18 @@ public class ManipulationPreconditionsTest {
                                 ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateNOTRDY
                                         ::manipulation,
                         MetricCategory.MSRMT,
-                        ComponentActivation.OFF,
                         ComponentActivation.NOT_RDY),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationCLCActivationStateNOTRDY
                                         ::manipulation,
                         MetricCategory.CLC,
-                        ComponentActivation.OFF,
                         ComponentActivation.NOT_RDY),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationSETActivationStateNOTRDY
                                         ::manipulation,
                         MetricCategory.SET,
-                        ComponentActivation.OFF,
                         ComponentActivation.NOT_RDY),
                 // arguments for MetricStatusManipulationXActivationStateSTNDBY preconditions
                 Arguments.of(
@@ -1497,21 +1318,18 @@ public class ManipulationPreconditionsTest {
                                 ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSTNDBY
                                         ::manipulation,
                         MetricCategory.MSRMT,
-                        ComponentActivation.ON,
                         ComponentActivation.STND_BY),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSTNDBY
                                         ::manipulation,
                         MetricCategory.CLC,
-                        ComponentActivation.ON,
                         ComponentActivation.STND_BY),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationSETActivationStateSTNDBY
                                         ::manipulation,
                         MetricCategory.SET,
-                        ComponentActivation.ON,
                         ComponentActivation.STND_BY),
                 // arguments for MetricStatusManipulationXActivationStateSHTDN preconditions
                 Arguments.of(
@@ -1519,38 +1337,32 @@ public class ManipulationPreconditionsTest {
                                 ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateSHTDN
                                         ::manipulation,
                         MetricCategory.MSRMT,
-                        ComponentActivation.ON,
                         ComponentActivation.SHTDN),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationCLCActivationStateSHTDN::manipulation,
                         MetricCategory.CLC,
-                        ComponentActivation.ON,
                         ComponentActivation.SHTDN),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationSETActivationStateSHTDN::manipulation,
                         MetricCategory.SET,
-                        ComponentActivation.ON,
                         ComponentActivation.SHTDN),
                 // arguments for MetricStatusManipulationXActivationStateOFF preconditions
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateOFF::manipulation,
                         MetricCategory.MSRMT,
-                        ComponentActivation.ON,
                         ComponentActivation.OFF),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationCLCActivationStateOFF::manipulation,
                         MetricCategory.CLC,
-                        ComponentActivation.ON,
                         ComponentActivation.OFF),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationSETActivationStateOFF::manipulation,
                         MetricCategory.SET,
-                        ComponentActivation.ON,
                         ComponentActivation.OFF),
                 // arguments for MetricStatusManipulationXActivationStateFAIL preconditions
                 Arguments.of(
@@ -1558,59 +1370,34 @@ public class ManipulationPreconditionsTest {
                                 ManipulationPreconditions.MetricStatusManipulationMSRMTActivationStateFAIL
                                         ::manipulation,
                         MetricCategory.MSRMT,
-                        ComponentActivation.ON,
                         ComponentActivation.FAIL),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationCLCActivationStateFAIL::manipulation,
                         MetricCategory.CLC,
-                        ComponentActivation.ON,
                         ComponentActivation.FAIL),
                 Arguments.of(
                         (Function<Injector, Boolean>)
                                 ManipulationPreconditions.MetricStatusManipulationSETActivationStateFAIL::manipulation,
                         MetricCategory.SET,
-                        ComponentActivation.ON,
                         ComponentActivation.FAIL));
     }
 
-    @DisplayName("The precondition is successful when setComponentActivation and setMetricStatus work as intended")
+    @DisplayName("The precondition is successful when setMetricStatus work as intended")
     @ParameterizedTest
     @MethodSource("metricStatusManipulationXActivationStateXArguments")
     void testMetricStatusManipulationXActivationStateXGood(
             final Function<Injector, Boolean> manipulation,
             final MetricCategory category,
-            final ComponentActivation startActivation,
             final ComponentActivation expectedActivation) {
-        setMetricStatusSetup(category, METRIC_HANDLE, startActivation, expectedActivation);
-        assertTrue(manipulation.apply(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, startActivation);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, category, expectedActivation);
-    }
-
-    @DisplayName("The precondition does not fail if setComponentActivation is not supported by all metrics.")
-    @ParameterizedTest
-    @MethodSource("metricStatusManipulationXActivationStateXArguments")
-    void testMetricStatusManipulationXActivationStateXAllowNotSupported1(
-            final Function<Injector, Boolean> manipulation,
-            final MetricCategory category,
-            final ComponentActivation startActivation,
-            final ComponentActivation expectedActivation) {
-        metricMockSetup(category, METRIC_HANDLE, SOME_HANDLE, startActivation, expectedActivation);
-
-        // let one metric not support setComponentActivation manipulation
-        when(mockManipulations.setComponentActivation(eq(SOME_HANDLE), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
+        setMetricStatusSetup(category, METRIC_HANDLE, SOME_HANDLE, expectedActivation);
 
         assertTrue(manipulation.apply(injector));
 
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, startActivation);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, startActivation);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, category, expectedActivation);
+        verify(mockManipulations)
+                .setMetricStatus(MdibBuilder.DEFAULT_SEQUENCE_ID, METRIC_HANDLE, category, expectedActivation);
+        verify(mockManipulations)
+                .setMetricStatus(MdibBuilder.DEFAULT_SEQUENCE_ID, SOME_HANDLE, category, expectedActivation);
     }
 
     @DisplayName("The precondition does not fail if setMetricStatus is not supported by all metrics.")
@@ -1619,42 +1406,20 @@ public class ManipulationPreconditionsTest {
     void testMetricStatusManipulationXActivationStateXAllowNotSupported2(
             final Function<Injector, Boolean> manipulation,
             final MetricCategory category,
-            final ComponentActivation startActivation,
             final ComponentActivation expectedActivation) {
-        metricMockSetup(category, METRIC_HANDLE, SOME_HANDLE, startActivation, expectedActivation);
+        setMetricStatusSetup(category, METRIC_HANDLE, SOME_HANDLE, expectedActivation);
 
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
-                        eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
+                        any(String.class), eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
                 .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-
-        when(mockDevice.getMdibAccess().findEntitiesByType(AbstractMetricDescriptor.class))
-                .thenReturn(List.of(mockEntity2, mockEntity));
 
         assertTrue(manipulation.apply(injector));
 
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, startActivation);
-        verify(mockManipulations).setComponentActivation(SOME_HANDLE, startActivation);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, category, expectedActivation);
-    }
-
-    @DisplayName("The precondition fails when setComponentActivation failed.")
-    @ParameterizedTest
-    @MethodSource("metricStatusManipulationXActivationStateXArguments")
-    void testMetricStatusManipulationXActivationStateXBadFirstManipulationFailed(
-            final Function<Injector, Boolean> manipulation,
-            final MetricCategory category,
-            final ComponentActivation startActivation,
-            final ComponentActivation expectedActivation) {
-        setMetricStatusSetup(category, METRIC_HANDLE, startActivation, expectedActivation);
-
-        // let setComponentActivation fail
-        when(mockManipulations.setComponentActivation(any(String.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-
-        assertFalse(manipulation.apply(injector));
-
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, startActivation);
+        verify(mockManipulations)
+                .setMetricStatus(MdibBuilder.DEFAULT_SEQUENCE_ID, METRIC_HANDLE, category, expectedActivation);
+        verify(mockManipulations)
+                .setMetricStatus(MdibBuilder.DEFAULT_SEQUENCE_ID, SOME_HANDLE, category, expectedActivation);
     }
 
     @DisplayName("The precondition fails when setMetricStatus failed.")
@@ -1663,19 +1428,21 @@ public class ManipulationPreconditionsTest {
     void testMetricStatusManipulationXActivationStateXBadSecondManipulationFailed(
             final Function<Injector, Boolean> manipulation,
             final MetricCategory category,
-            final ComponentActivation startActivation,
             final ComponentActivation expectedActivation) {
-        setMetricStatusSetup(category, METRIC_HANDLE, startActivation, expectedActivation);
+        setMetricStatusSetup(category, METRIC_HANDLE, SOME_HANDLE, expectedActivation);
 
         // let setMetricStatus fail
         when(mockManipulations.setMetricStatus(
-                        any(String.class), any(MetricCategory.class), any(ComponentActivation.class)))
+                        any(String.class),
+                        any(String.class),
+                        any(MetricCategory.class),
+                        any(ComponentActivation.class)))
                 .thenReturn(ResponseTypes.Result.RESULT_FAIL);
 
         assertFalse(manipulation.apply(injector));
 
-        verify(mockManipulations).setComponentActivation(METRIC_HANDLE, startActivation);
-        verify(mockManipulations).setMetricStatus(METRIC_HANDLE, category, expectedActivation);
+        verify(mockManipulations)
+                .setMetricStatus(MdibBuilder.DEFAULT_SEQUENCE_ID, METRIC_HANDLE, category, expectedActivation);
     }
 
     @Test

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -1275,7 +1275,7 @@ public class ManipulationPreconditionsTest {
     // 1. the specific method of the precondition to be tested
     // 2. the metric category
     // 4. the expected component activation after the setMetricStatus manipulation finished successfully
-    private static Stream<Arguments> metricStatusManipulationXActivationStateXArguments() {
+    private static Stream<Arguments> metricStatusManipulationXActivationStateYArguments() {
         return Stream.of(
                 // arguments for MetricStatusManipulationXActivationStateON preconditions
                 Arguments.of(
@@ -1385,8 +1385,8 @@ public class ManipulationPreconditionsTest {
 
     @DisplayName("The precondition is successful when setMetricStatus work as intended")
     @ParameterizedTest
-    @MethodSource("metricStatusManipulationXActivationStateXArguments")
-    void testMetricStatusManipulationXActivationStateXGood(
+    @MethodSource("metricStatusManipulationXActivationStateYArguments")
+    void testMetricStatusManipulationXActivationStateYGood(
             final Function<Injector, Boolean> manipulation,
             final MetricCategory category,
             final ComponentActivation expectedActivation) {
@@ -1402,8 +1402,8 @@ public class ManipulationPreconditionsTest {
 
     @DisplayName("The precondition does not fail if setMetricStatus is not supported by all metrics.")
     @ParameterizedTest
-    @MethodSource("metricStatusManipulationXActivationStateXArguments")
-    void testMetricStatusManipulationXActivationStateXAllowNotSupported2(
+    @MethodSource("metricStatusManipulationXActivationStateYArguments")
+    void testMetricStatusManipulationXActivationStateYAllowNotSupported2(
             final Function<Injector, Boolean> manipulation,
             final MetricCategory category,
             final ComponentActivation expectedActivation) {
@@ -1424,8 +1424,8 @@ public class ManipulationPreconditionsTest {
 
     @DisplayName("The precondition fails when setMetricStatus failed.")
     @ParameterizedTest
-    @MethodSource("metricStatusManipulationXActivationStateXArguments")
-    void testMetricStatusManipulationXActivationStateXBadSecondManipulationFailed(
+    @MethodSource("metricStatusManipulationXActivationStateYArguments")
+    void testMetricStatusManipulationXActivationStateYBadSecondManipulationFailed(
             final Function<Injector, Boolean> manipulation,
             final MetricCategory category,
             final ComponentActivation expectedActivation) {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelStatePartTestTest.java
@@ -156,6 +156,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 // Component activation should be ON to be relevant for testRequirement54700.
@@ -199,6 +200,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -232,6 +234,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -263,6 +266,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -296,6 +300,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 RTSA_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -327,6 +332,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -339,6 +345,7 @@ public class InvariantParticipantModelStatePartTestTest {
                 parameters);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -373,6 +380,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -406,6 +414,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -441,6 +450,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -473,6 +483,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -505,6 +516,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -541,6 +553,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -574,6 +587,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -605,6 +619,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -639,6 +654,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 RTSA_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -669,6 +685,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -681,6 +698,7 @@ public class InvariantParticipantModelStatePartTestTest {
                 parameters);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -715,6 +733,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -748,6 +767,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -783,6 +803,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -815,6 +836,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -847,6 +869,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -883,6 +906,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -916,6 +940,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -947,6 +972,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -978,11 +1004,13 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -1025,6 +1053,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -1058,6 +1087,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -1093,6 +1123,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -1125,6 +1156,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -1156,6 +1188,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -1192,6 +1225,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -1225,6 +1259,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -1256,6 +1291,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -1287,11 +1323,13 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -1334,6 +1372,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -1367,6 +1406,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -1402,6 +1442,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -1434,6 +1475,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -1465,6 +1507,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -1501,6 +1544,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -1534,6 +1578,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -1565,6 +1610,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -1597,11 +1643,13 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -1644,6 +1692,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -1677,6 +1726,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -1712,6 +1762,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -1744,6 +1795,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -1775,6 +1827,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -1811,6 +1864,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -1844,6 +1898,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -1875,6 +1930,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -1907,11 +1963,13 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -1954,6 +2012,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -1987,6 +2046,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -2022,6 +2082,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -2054,6 +2115,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -2085,6 +2147,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -2121,6 +2184,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -2154,6 +2218,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -2184,6 +2249,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -2220,6 +2286,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -2231,6 +2298,7 @@ public class InvariantParticipantModelStatePartTestTest {
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -2265,6 +2333,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -2298,6 +2367,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -2333,6 +2403,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -2365,6 +2436,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -2396,6 +2468,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -2432,6 +2505,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -2465,6 +2539,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -2495,6 +2570,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -2531,6 +2607,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -2543,6 +2620,7 @@ public class InvariantParticipantModelStatePartTestTest {
                 parameters);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -2578,6 +2656,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -2611,6 +2690,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -2646,6 +2726,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -2678,6 +2759,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -2709,6 +2791,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -2745,6 +2828,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -2778,6 +2862,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -2808,6 +2893,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -2844,6 +2930,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -2856,6 +2943,7 @@ public class InvariantParticipantModelStatePartTestTest {
                 parameters);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -2891,6 +2979,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -2924,6 +3013,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -2959,6 +3049,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -2991,6 +3082,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -3022,6 +3114,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -3058,6 +3151,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -3091,6 +3185,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -3121,6 +3216,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -3156,6 +3252,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -3168,6 +3265,7 @@ public class InvariantParticipantModelStatePartTestTest {
                 parameters);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -3203,6 +3301,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -3236,6 +3335,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -3271,6 +3371,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -3303,6 +3404,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -3334,6 +3436,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -3370,6 +3473,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -3405,6 +3509,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -3435,6 +3540,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -3466,6 +3572,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -3478,6 +3585,7 @@ public class InvariantParticipantModelStatePartTestTest {
                 parameters);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -3512,6 +3620,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -3545,6 +3654,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -3580,6 +3690,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -3612,6 +3723,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -3643,6 +3755,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -3679,6 +3792,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -3714,6 +3828,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -3744,6 +3859,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -3775,6 +3891,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -3787,6 +3904,7 @@ public class InvariantParticipantModelStatePartTestTest {
                 parameters);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -3821,6 +3939,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -3854,6 +3973,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -3889,6 +4009,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -3921,6 +4042,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -3952,6 +4074,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -3988,6 +4111,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -4021,6 +4145,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -4051,6 +4176,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -4083,6 +4209,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -4094,6 +4221,7 @@ public class InvariantParticipantModelStatePartTestTest {
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -4128,6 +4256,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -4161,6 +4290,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -4196,6 +4326,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -4228,6 +4359,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -4259,6 +4391,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.ON);
@@ -4295,6 +4428,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -4328,6 +4462,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 MSRMT_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.MSRMT,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -4358,6 +4493,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -4391,6 +4527,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -4402,6 +4539,7 @@ public class InvariantParticipantModelStatePartTestTest {
                 Constants.MANIPULATION_NAME_SET_METRIC_STATUS,
                 parameters);
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -4436,6 +4574,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -4469,6 +4608,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -4504,6 +4644,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -4536,6 +4677,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -4567,6 +4709,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.NOT_RDY);
@@ -4603,6 +4746,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -4636,6 +4780,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -4666,6 +4811,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -4697,11 +4843,13 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -4744,6 +4892,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -4777,6 +4926,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -4812,6 +4962,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -4844,6 +4995,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -4875,6 +5027,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.STND_BY);
@@ -4911,6 +5064,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -4944,6 +5098,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -4974,6 +5129,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -5005,11 +5161,13 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -5052,6 +5210,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -5085,6 +5244,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -5120,6 +5280,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -5152,6 +5313,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -5183,6 +5345,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.SHTDN);
@@ -5219,6 +5382,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -5252,6 +5416,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -5282,6 +5447,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -5314,11 +5480,13 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -5361,6 +5529,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -5394,6 +5563,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -5429,6 +5599,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -5461,6 +5632,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -5492,6 +5664,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.OFF);
@@ -5528,6 +5701,7 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -5561,6 +5735,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 SET_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.SET,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -5591,6 +5766,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -5623,11 +5799,13 @@ public class InvariantParticipantModelStatePartTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
 
         final var parameters2 = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE2,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -5670,6 +5848,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -5703,6 +5882,7 @@ public class InvariantParticipantModelStatePartTestTest {
 
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -5738,6 +5918,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -5770,6 +5951,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);
@@ -5801,6 +5983,7 @@ public class InvariantParticipantModelStatePartTestTest {
         final var result = ResponseTypes.Result.RESULT_SUCCESS;
         final var methodName = Constants.MANIPULATION_NAME_SET_METRIC_STATUS;
         final var parameters = ManipulationParameterUtil.buildMetricStatusManipulationParameterData(
+                MdibBuilder.DEFAULT_SEQUENCE_ID,
                 CLC_METRIC_HANDLE,
                 org.somda.sdc.biceps.model.participant.MetricCategory.CLC,
                 org.somda.sdc.biceps.model.participant.ComponentActivation.FAIL);


### PR DESCRIPTION
The revision of the test cases for biceps:5-4-7 includes several changes: 

- the setMetricStatus manipulation of the T2IAPI is persistent now
- added new configuration parameter `Biceps547TimeInterval=5`.
- manipulateMetricStatus in ManipulationPrecondition now waits for the specified `Biceps547TimeInterval` between manipulations to avoid changes to the activation state of the metric
- added sequenceId as parameter for setMetricStatus manipulation to be able to assign stored messages to the manipulation
- the biceps:5-4-7 test cases create an mdib for the point just before the end of each time interval between manipulations of the manipulateMetricStatus precondition and check if the activation state of the metric is as expected

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
