### PR TITLE
Move the manipulation trigger for glue:R0036_0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - biceps:R0034_0 does not track changes when reinserting descriptors.
 - report duplication issue in biceps:C11-C15, biceps:C5, biceps:R5046_0, biceps:B-284_0 as well as biceps:R5003.
 - biceps:5-4-7 tests confusing changes made by SetComponentActivation manipulations with changes made by SetMetricStatus.
+- glue:R0036_0 test can be blocked by long-running t2iapi RPCs.
 
 ## [7.0.1] - 2023-03-17
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/direct/DirectSubscriptionHandlingTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/direct/DirectSubscriptionHandlingTest.java
@@ -418,8 +418,8 @@ public class DirectSubscriptionHandlingTest extends InjectorTestBase {
         LOG.info("Triggering a Report and intentionally causing a failure...");
         triggerableReport.setReportReceived(false);
         triggerableReport.setFailOnReceivingReport(true);
+        triggerableReport.trigger();
         synchronized (triggerableReport.getSyncPoint()) {
-            triggerableReport.trigger();
             final long timeout = System.nanoTime() + TIMEOUT_NANOS;
             while (!triggerableReport.getReportReceived() && System.nanoTime() < timeout) {
                 try {


### PR DESCRIPTION
Move the manipulation trigger for `glue:R0036_0` outside the synchronization to avoid blocking notifications through long running RPCs.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
