### PR TITLE
Bumped t2iapi version and updated readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - the precondition of biceps:C5 and biceps:R5052 so that it can be satisfied by devices that do not support updating
   MDS descriptors.
 - SDCri version 5.0.0
+- t2iapi version 3.0.0
 
 ### Fixed
 - the occurrence of the sequence ']]>' in the content of CDATA sections in the result xmls

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Enable=true
 will make all devices match during discovery.
 
 ### Manipulation API
-The test tool uses *T2IAPI* version `2.0.0`. The *T2IAPI* is required for some test cases to put the DUT in a certain
+The test tool uses *T2IAPI* version `3.0.0`. The *T2IAPI* is required for some test cases to put the DUT in a certain
 state, or to trigger a certain behavior. When using SDCcc with automated manipulations, it must be ensured that the same
 version of *T2IAPI* is used for the test execution by both parties. It must also be ensured that the device's 
 manipulations are implemented according to the descriptions in the T2IAPI sources. Further information can be found 

--- a/README.md
+++ b/README.md
@@ -320,11 +320,11 @@ this case in order to minimize the risk of such an invalid application going unn
 
 [GLUE]
 
-| **Requirement** | **T2IAPI Manipulation** |
-|-----------------|-------------------------|
-| R0036_0         | SetLocationDetail       |
-| R0056           | TriggerDescriptorUpdate |
-| R0078_0         | TriggerReport           |
+| **Requirement** | **T2IAPI Manipulation**    |
+|-----------------|----------------------------|
+| R0036_0         | SetLocationDetail          |
+| R0056           | TriggerAnyDescriptorUpdate |
+| R0078_0         | TriggerReport              |
 
 
 ## Notices

--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>com.draeger.medical</groupId>
             <artifactId>t2iapi</artifactId>
-            <version>3.0.0.296</version>
+            <version>3.0.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
bumped t2iapi version to 3.0.0.
Updated the t2iapi version in the readme.
Updated used manipulation ofglue:R0056 in the readme 

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
