### PR TITLE
TestSuite extension mechanism

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -90,7 +90,6 @@
         <module name="MissingOverride"/>
         <module name="PackageAnnotation"/>
 
-        <module name="HideUtilityClassConstructor"/>
         <module name="InnerTypeLast"/>
         <module name="InterfaceIsType"/>
         <module name="MutableException"/>

--- a/pom.xml
+++ b/pom.xml
@@ -37,25 +37,6 @@
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>${execPluginVersion}</version>
-                <configuration>
-                    <skip>true</skip>
-                    <executable>${java.home}/bin/java</executable>
-                    <arguments>
-                        <argument>-classpath</argument>
-                        <classpath/>
-                        <argument>com.draeger.medical.sdccc.TestSuite</argument>
-                        <argument>-c</argument>
-                        <argument>${project.basedir}/../configuration/config.toml</argument>
-                        <argument>-t</argument>
-                        <argument>${project.basedir}/../configuration/test_configuration.toml</argument>
-                    </arguments>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <version>2.0.0</version>
                 <executions>
@@ -92,6 +73,58 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${execPluginVersion}</version>
+                <configuration>
+                    <skip>true</skip>
+                    <executable>${java.home}/bin/java</executable>
+                    <arguments>
+                        <argument>-classpath</argument>
+                        <classpath/>
+                        <argument>com.draeger.medical.sdccc.TestSuite</argument>
+                        <argument>-c</argument>
+                        <argument>${project.basedir}/../configuration/config.toml</argument>
+                        <argument>-t</argument>
+                        <argument>${project.basedir}/../configuration/test_configuration.toml</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>exec-sdccc</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${execPluginVersion}</version>
+                        <executions>
+                            <execution>
+                                <id>951d1725-bb0b-40db-9d4e-d1947a8318ed</id>
+                                <configuration>
+                                    <skip>false</skip>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <arguments>
+                                        <argument>-classpath</argument>
+                                        <classpath/>
+                                        <argument>com.draeger.medical.sdccc.TestSuite</argument>
+                                        <argument>-c</argument>
+                                        <argument>${project.basedir}/../configuration/config.toml</argument>
+                                        <argument>-t</argument>
+                                        <argument>${project.basedir}/../configuration/test_configuration.toml</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -423,19 +423,26 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>${execPluginVersion}</version>
-                <configuration>
-                    <skip>false</skip>
-                    <executable>${java.home}/bin/java</executable>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
     <profiles>
+        <profile>
+            <id>exec-sdccc</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${execPluginVersion}</version>
+                        <configuration>
+                            <skip>false</skip>
+                            <executable>${java.home}/bin/java</executable>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>executable</id>
             <build>
@@ -472,7 +479,7 @@
                                         <fileVersion>${revision}.0</fileVersion>
                                         <txtFileVersion>${revision}${changelist}</txtFileVersion>
                                         <fileDescription>${project.name}</fileDescription>
-                                        <copyright>2023 Draegerwerk AG &amp; Co. KGaA</copyright>
+                                        <copyright>2024 Draegerwerk AG &amp; Co. KGaA</copyright>
                                         <productVersion>${revision}.0</productVersion>
                                         <txtProductVersion>${revision}${changelist}</txtProductVersion>
                                         <productName>${project.name}</productName>

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
@@ -16,6 +16,13 @@ import org.somda.sdc.common.guice.AbstractConfigurationModule;
  */
 public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
 
+    public static final String[] DEFAULT_DIRECTORIES = {
+        "com.draeger.medical.sdccc.tests.biceps",
+        "com.draeger.medical.sdccc.tests.mdpws",
+        "com.draeger.medical.sdccc.tests.dpws",
+        "com.draeger.medical.sdccc.tests.glue",
+    };
+
     private static final int BUFFER_SIZE = 100;
 
     @Override
@@ -80,12 +87,7 @@ public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
     }
 
     void configureInternalSettings() {
-        bind(TestSuiteConfig.SDC_TEST_DIRECTORIES, String[].class, new String[] {
-            "com.draeger.medical.sdccc.tests.biceps",
-            "com.draeger.medical.sdccc.tests.mdpws",
-            "com.draeger.medical.sdccc.tests.dpws",
-            "com.draeger.medical.sdccc.tests.glue",
-        });
+        bind(TestSuiteConfig.SDC_TEST_DIRECTORIES, String[].class, DEFAULT_DIRECTORIES);
     }
 
     protected void configureCommlogSettings() {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
@@ -7,6 +7,7 @@
 
 package com.draeger.medical.sdccc.configuration;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.somda.sdc.common.guice.AbstractConfigurationModule;
 
 /**
@@ -16,6 +17,10 @@ import org.somda.sdc.common.guice.AbstractConfigurationModule;
  */
 public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
 
+    @SuppressFBWarnings(
+            value = {"MS_MUTABLE_ARRAY"},
+            justification = "In case this is wrong there will be an error (for test cases that couldn't be found)"
+                    + " and thus this being wrong due to modification will always be noticed.")
     public static final String[] DEFAULT_DIRECTORIES = {
         "com.draeger.medical.sdccc.tests.biceps",
         "com.draeger.medical.sdccc.tests.mdpws",

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/EnabledTestConfig.java
@@ -1,6 +1,6 @@
 /*
  * This Source Code Form is subject to the terms of the MIT License.
- * Copyright (c) 2023 Draegerwerk AG & Co. KGaA.
+ * Copyright (c) 2023, 2024 Draegerwerk AG & Co. KGaA.
  *
  * SPDX-License-Identifier: MIT
  */
@@ -11,7 +11,7 @@ package com.draeger.medical.sdccc.configuration;
  * Constants used to map the content of the configuration for enabled
  * test cases.
  */
-public final class EnabledTestConfig {
+public class EnabledTestConfig {
 
     // BICEPS
     private static final String BICEPS = "BICEPS.";
@@ -124,5 +124,8 @@ public final class EnabledTestConfig {
     public static final String GLUE_R0080 = GLUE + "R0080";
     public static final String GLUE_813 = GLUE + "8-1-3";
 
-    private EnabledTestConfig() {}
+    /**
+     * Default constructor for extending the constants list.
+     */
+    public EnabledTestConfig() {}
 }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/guice/TomlConfigParser.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/guice/TomlConfigParser.java
@@ -1,6 +1,6 @@
 /*
  * This Source Code Form is subject to the terms of the MIT License.
- * Copyright (c) 2023 Draegerwerk AG & Co. KGaA.
+ * Copyright (c) 2023, 2024 Draegerwerk AG & Co. KGaA.
  *
  * SPDX-License-Identifier: MIT
  */
@@ -38,13 +38,12 @@ public class TomlConfigParser {
      * This parser only allows known keys and will throw an exception otherwise.
      *
      * @param constantsClass to verify toml keys against
-     * @throws IOException in case an error occurred during parsing.
      */
     public TomlConfigParser(final Class constantsClass) {
         // track allowed keys
         this.allowedKeys = new HashSet<>();
 
-        Arrays.stream(constantsClass.getDeclaredFields()).forEach(field -> {
+        Arrays.stream(constantsClass.getFields()).forEach(field -> {
             if (java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
                 try {
                     allowedKeys.add((String) field.get(null));


### PR DESCRIPTION
Make it easier to extend TestSuite with test cases and let TomlConfigParser read in inherited fields as well.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] @maximilianpilz 
  * [x] @belagertem 
* Adherence to javadoc conventions
  * [x] @maximilianpilz 
  * [x] @belagertem 
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] @maximilianpilz 
  * [x] @belagertem 
* README update (necessity checked and entry added or not added respectively)
  * [x] @maximilianpilz 
  * [x] @belagertem 
* config update (necessity checked and entry added or not added respectively)
  * [x] @maximilianpilz 
  * [x] @belagertem 
* SDCcc executable ran against a test device (if necessary)
  * [x] @maximilianpilz 
  * [x] @belagertem 
