### PR TITLE
Correct inconsistent messaging in sdccc logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - inconsistent messaging in SDCcc logs ("No problems were found" and "Test run was invalid" one after another.)
+- incorrect behavior of the configuration option SDCcc.SummarizeMessageEncodingErrors
 
 ## [9.0.0] - 2024-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - sdc-ri version to 6.0.0-SNAPSHOT
 
+### Fixed
+
+- inconsistent messaging in SDCcc logs ("No problems were found" and "Test run was invalid" one after another.)
+
 ## [9.0.0] - 2024-02-23
 
 ### Added

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -595,17 +595,17 @@ public class TestSuite {
 
         if (testRunObserver.isInvalid()) {
             LOG.info(
-                    "Test run with {} tests was invalid. Please consult the logfiles in {} for further information.",
+                    "Test run with {} test(s) was invalid. Please consult the logfiles in {} for further information.",
                     testRunObserver.getTotalNumberOfTestsRun(),
                     testRunDir);
         } else {
             if (numberOfTestFailures == 0) {
                 LOG.info(
-                        "Test run with {} tests was valid. No problems were found.",
+                        "Test run with {} test(s) was valid. No problems were found.",
                         testRunObserver.getTotalNumberOfTestsRun());
             } else {
                 LOG.info(
-                        "Test run with {} tests was valid, but problems were found. Please consult the logfiles in {} for further information.",
+                        "Test run with {} test(s) was valid, but problems were found. Please consult the logfiles in {} for further information.",
                         testRunObserver.getTotalNumberOfTestsRun(),
                         testRunDir);
             }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -593,22 +593,22 @@ public class TestSuite {
             }
         }
 
-        if (numberOfTestFailures == 0) {
-            if (testRunObserver.isInvalid()) {
+        if (testRunObserver.isInvalid()) {
+            LOG.info(
+                    "Test run with {} tests was invalid. Please consult the logfiles in {} for further information.",
+                    testRunObserver.getTotalNumberOfTestsRun(),
+                    testRunDir);
+        } else {
+            if (numberOfTestFailures == 0) {
                 LOG.info(
-                        "Test run with {} Tests was completed successfully but other problems were found. Please consult the logfiles in {} for further information.",
-                        testRunObserver.getTotalNumberOfTestsRun(),
-                        testRunDir);
-                LOG.info("Test run was invalid.");
+                        "Test run with {} tests was valid. No problems were found.",
+                        testRunObserver.getTotalNumberOfTestsRun());
             } else {
                 LOG.info(
-                        "Test run with {} Tests was completed successfully. No problems were found.",
-                        testRunObserver.getTotalNumberOfTestsRun());
-                LOG.info("Test run was valid.");
+                        "Test run with {} tests was valid, but problems were found. Please consult the logfiles in {} for further information.",
+                        testRunObserver.getTotalNumberOfTestsRun(),
+                        testRunDir);
             }
-        } else {
-            LOG.info("Test run found problems. Please consult the logfiles in {} for further information.", testRunDir);
-            LOG.info("Test run was invalid.");
         }
     }
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -594,17 +594,21 @@ public class TestSuite {
         }
 
         if (numberOfTestFailures == 0) {
-            LOG.info(
-                    "Test run with {} Tests was completed successfully. No problems were found.",
-                    testRunObserver.getTotalNumberOfTestsRun());
+            if (testRunObserver.isInvalid()) {
+                LOG.info(
+                        "Test run with {} Tests was completed successfully but other problems were found. Please consult the logfiles in {} for further information.",
+                        testRunObserver.getTotalNumberOfTestsRun(),
+                        testRunDir);
+                LOG.info("Test run was invalid.");
+            } else {
+                LOG.info(
+                        "Test run with {} Tests was completed successfully. No problems were found.",
+                        testRunObserver.getTotalNumberOfTestsRun());
+                LOG.info("Test run was valid.");
+            }
         } else {
             LOG.info("Test run found problems. Please consult the logfiles in {} for further information.", testRunDir);
-        }
-
-        if (testRunObserver.isInvalid()) {
             LOG.info("Test run was invalid.");
-        } else {
-            LOG.info("Test run was valid.");
         }
     }
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
@@ -49,12 +49,14 @@ public class XmlReportWriter {
     private final TestRunObserver testRunObserver;
     private final ClassUtil classUtil;
     private final MessageStorage messageStorage;
+
     /**
      * Initializes an XmlReportWriter.
      *
      * @param reportData      list of results representing test cases
      * @param classUtil       utility
      * @param testRunObserver observer which contains information on validity of test run
+     * @param messageStorage  storage to retrieve error counts from
      */
     @AssistedInject
     XmlReportWriter(
@@ -217,7 +219,7 @@ public class XmlReportWriter {
      * @throws XMLStreamException on xml writing errors
      */
     private void writeInvalidTestRunTestCase(final XMLStreamWriter xmlWriter) throws XMLStreamException {
-        List<String> listOfReasons = new ArrayList<>();
+        final List<String> listOfReasons = new ArrayList<>();
         final long messageEncodingErrorCount = messageStorage.getMessageEncodingErrorCount();
         final long invalidMimeTypeErrorCount = messageStorage.getInvalidMimeTypeErrorCount();
         if (messageEncodingErrorCount > 0) {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/util/junit/XmlReportWriter.java
@@ -7,6 +7,7 @@
 
 package com.draeger.medical.sdccc.util.junit;
 
+import com.draeger.medical.sdccc.messages.MessageStorage;
 import com.draeger.medical.sdccc.tests.annotations.TestDescription;
 import com.draeger.medical.sdccc.util.TestRunObserver;
 import com.draeger.medical.sdccc.util.junit.util.ClassUtil;
@@ -18,6 +19,7 @@ import java.lang.annotation.Annotation;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -46,7 +48,7 @@ public class XmlReportWriter {
     private final List<ReportData> reportData;
     private final TestRunObserver testRunObserver;
     private final ClassUtil classUtil;
-
+    private final MessageStorage messageStorage;
     /**
      * Initializes an XmlReportWriter.
      *
@@ -58,10 +60,12 @@ public class XmlReportWriter {
     XmlReportWriter(
             @Assisted final List<ReportData> reportData,
             final ClassUtil classUtil,
-            final TestRunObserver testRunObserver) {
+            final TestRunObserver testRunObserver,
+            final MessageStorage messageStorage) {
         this.reportData = reportData;
         this.testRunObserver = testRunObserver;
         this.classUtil = classUtil;
+        this.messageStorage = messageStorage;
     }
 
     protected void writeXmlReport(final Path reportsDir, final String xmlReportName, final Duration duration)
@@ -213,7 +217,17 @@ public class XmlReportWriter {
      * @throws XMLStreamException on xml writing errors
      */
     private void writeInvalidTestRunTestCase(final XMLStreamWriter xmlWriter) throws XMLStreamException {
-        if (testRunObserver.isInvalid()) {
+        List<String> listOfReasons = new ArrayList<>();
+        final long messageEncodingErrorCount = messageStorage.getMessageEncodingErrorCount();
+        final long invalidMimeTypeErrorCount = messageStorage.getInvalidMimeTypeErrorCount();
+        if (messageEncodingErrorCount > 0) {
+            listOfReasons.add(String.format("%s MessageEncodingError(s) were observed.", messageEncodingErrorCount));
+        }
+        if (invalidMimeTypeErrorCount > 0) {
+            listOfReasons.add(String.format("%s InvalidMimeTypeError(s) were observed.", invalidMimeTypeErrorCount));
+        }
+        if (testRunObserver.isInvalid() || messageEncodingErrorCount > 0 || invalidMimeTypeErrorCount > 0) {
+            listOfReasons.addAll(testRunObserver.getReasons());
             xmlWriter.writeStartElement("testcase");
             xmlWriter.writeAttribute("name", INVALID_TEST_RUN_TEST_NAME);
             xmlWriter.writeAttribute("classname", INVALID_TEST_RUN_CLASS_NAME);
@@ -223,11 +237,12 @@ public class XmlReportWriter {
             xmlWriter.writeStartElement("error");
             xmlWriter.writeAttribute("message", "SDCcc test run was marked as invalid");
             xmlWriter.writeAttribute("type", "InvalidTestRun");
+
             handleCDataSection(
                     xmlWriter,
                     String.format(
                             "SDCcc test run was marked as invalid for the following reasons:%s",
-                            String.join("\n- ", testRunObserver.getReasons())));
+                            String.join("\n- ", listOfReasons)));
             xmlWriter.writeEndElement();
             writeNewLine(xmlWriter);
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/util/junit/XmlReportWriterTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/util/junit/XmlReportWriterTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.w3c.dom.Node.ELEMENT_NODE;
 
+import com.draeger.medical.sdccc.messages.MessageStorage;
 import com.draeger.medical.sdccc.tests.annotations.TestDescription;
 import com.draeger.medical.sdccc.util.TestRunObserver;
 import com.draeger.medical.sdccc.util.XPathExtractor;
@@ -252,11 +253,12 @@ public class XmlReportWriterTest {
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final var observer = mock(TestRunObserver.class);
+        final var messageStorage = mock(MessageStorage.class);
         try (final OutputStreamWriter outputStreamWriter = new OutputStreamWriter(baos, StandardCharsets.UTF_8)) {
             final var factory = XMLOutputFactory.newInstance();
             final var xmlWriter = factory.createXMLStreamWriter(outputStreamWriter);
 
-            final var writer = new XmlReportWriter(data, classUtil, observer);
+            final var writer = new XmlReportWriter(data, classUtil, observer, messageStorage);
             writer.writeXmlReport(xmlWriter, Duration.ofSeconds(1));
         }
 
@@ -345,11 +347,12 @@ public class XmlReportWriterTest {
     public void testAdditionalTags() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final var observer = mock(TestRunObserver.class);
+        final var messageStorage = mock(MessageStorage.class);
         try (final OutputStreamWriter outputStreamWriter = new OutputStreamWriter(baos, StandardCharsets.UTF_8)) {
             final var factory = XMLOutputFactory.newInstance();
             final var xmlWriter = factory.createXMLStreamWriter(outputStreamWriter);
 
-            final var writer = new XmlReportWriter(data, classUtil, observer);
+            final var writer = new XmlReportWriter(data, classUtil, observer, messageStorage);
             writer.writeXmlReport(xmlWriter, Duration.ofSeconds(1));
         }
 
@@ -466,7 +469,8 @@ public class XmlReportWriterTest {
             final var factory = XMLOutputFactory.newInstance();
             final var xmlWriter = factory.createXMLStreamWriter(outputStreamWriter);
 
-            final var writer = new XmlReportWriter(data, classUtil, mock(TestRunObserver.class));
+            final var writer =
+                    new XmlReportWriter(data, classUtil, mock(TestRunObserver.class), mock(MessageStorage.class));
             final var error = assertThrows(
                     XMLStreamException.class,
                     () -> writer.writeXmlReport(xmlWriter, Duration.ofSeconds(1)),
@@ -517,7 +521,8 @@ public class XmlReportWriterTest {
             final var factory = XMLOutputFactory.newInstance();
             final var xmlWriter = factory.createXMLStreamWriter(outputStreamWriter);
 
-            final var writer = new XmlReportWriter(data, classUtil, mock(TestRunObserver.class));
+            final var writer =
+                    new XmlReportWriter(data, classUtil, mock(TestRunObserver.class), mock(MessageStorage.class));
             final var error = assertThrows(
                     XMLStreamException.class,
                     () -> writer.writeXmlReport(xmlWriter, Duration.ofSeconds(1)),
@@ -543,7 +548,7 @@ public class XmlReportWriterTest {
         final var factory = XMLOutputFactory.newInstance();
         final var xmlWriter = factory.createXMLStreamWriter(outputStreamWriter);
 
-        final var writer = new XmlReportWriter(data, classUtil, observer);
+        final var writer = new XmlReportWriter(data, classUtil, observer, mock(MessageStorage.class));
         writer.writeXmlReport(xmlWriter, Duration.ofSeconds(1));
 
         outputStreamWriter.close();
@@ -593,7 +598,7 @@ public class XmlReportWriterTest {
         final var factory = XMLOutputFactory.newInstance();
         final var xmlWriter = factory.createXMLStreamWriter(outputStreamWriter);
 
-        final var writer = new XmlReportWriter(data, classUtil, observer);
+        final var writer = new XmlReportWriter(data, classUtil, observer, mock(MessageStorage.class));
         writer.writeXmlReport(xmlWriter, Duration.ofSeconds(1));
 
         outputStreamWriter.close();


### PR DESCRIPTION
The purpose of the pull request is to correct inconsistent messaging in SDCcc logs, in particular "No problems were found" together with "Test run was invalid" one after another.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] @maximilianpilz 
  * [x] @ben-Draeger 
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] @maximilianpilz 
  * [x] @ben-Draeger 
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] @maximilianpilz 
  * [x] @ben-Draeger 
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] @maximilianpilz 
  * [x] @ben-Draeger 
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] @maximilianpilz 
  * [x] @ben-Draeger 
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] @maximilianpilz 
  * [x] @ben-Draeger 
