### PR TITLE
Remove consumer test related implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - inconsistent messaging in SDCcc logs ("No problems were found" and "Test run was invalid" one after another.)
 - incorrect behavior of the configuration option SDCcc.SummarizeMessageEncodingErrors
 
+### Removed
+
+- consumer test related implementations
+
 ## [9.0.0] - 2024-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -108,14 +108,12 @@ all the given filter criteria have to be fulfilled for initiating a connection.
 For example the configuration
 ```
 [SDCcc.Consumer] 
-Enable=true
 DeviceEpr="urn:uuid:857bf583-8a51-475f-a77f-d0ca7de69b11"
 ```
 will make only those devices match during discovery that have the EPR "urn:uuid:857bf583-8a51-475f-a77f-d0ca7de69b11",
 the configuration
 ```
 [SDCcc.Consumer] 
-Enable=true
 DeviceEpr="urn:uuid:857bf583-8a51-475f-a77f-d0ca7de69b11"
 DeviceLocationBed="bed32"
 ```
@@ -123,14 +121,12 @@ only those that have the EPR "urn:uuid:857bf583-8a51-475f-a77f-d0ca7de69b11" and
 the configuration
 ```
 [SDCcc.Consumer] 
-Enable=true
 DeviceLocationBed="bed32"
 ```
 only those that have the bed "bed32" in the location query,
 and the configuration
 ```
 [SDCcc.Consumer]
-Enable=true
 ```
 will make all devices match during discovery.
 

--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -36,9 +36,6 @@ DeviceEpr="urn:uuid:857bf583-8a51-475f-a77f-d0ca7de69b11"
 # DeviceLocationPointOfCare="poc32"
 # etc.
 
-[SDCcc.Provider]
-Enable=false
-
 [SDCcc.gRPC]
 ServerAddress="localhost:50051"
 

--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -30,7 +30,6 @@ MaxWait=10
 MulticastTTL=128
 
 [SDCcc.Consumer]
-Enable=true
 DeviceEpr="urn:uuid:857bf583-8a51-475f-a77f-d0ca7de69b11"
 # DeviceLocationBed="bed32"
 # DeviceLocationPointOfCare="poc32"

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -228,7 +228,6 @@ public class TestSuite {
         } catch (final TimeoutException e) {
             testRunObserver.invalidateTestRun("Could not stop the test client", e);
         }
-        // TODO: Stop provider (https://github.com/Draegerwerk/SDCcc/issues/1)
 
         // flush all data so invariant tests run on most current data
         injector.getInstance(MessageStorage.class).flush();
@@ -368,8 +367,6 @@ public class TestSuite {
     private Boolean setupDeviceAndProvider() {
         final var isConsumerEnabled =
                 injector.getInstance(Key.get(Boolean.class, Names.named(TestSuiteConfig.CONSUMER_ENABLE)));
-        final var isProviderEnabled =
-                injector.getInstance(Key.get(Boolean.class, Names.named(TestSuiteConfig.PROVIDER_ENABLE)));
 
         if (isConsumerEnabled) {
             LOG.info("Starting TestSuite Client");
@@ -387,10 +384,6 @@ public class TestSuite {
                     client.getHostingServiceProxy().getHostedServices().values().stream()
                             .anyMatch(service ->
                                     service.getType().getTypes().contains(WsdlConstants.PORT_TYPE_ARCHIVE_QNAME)));
-        }
-        if (isProviderEnabled) {
-            LOG.info("Starting TestSuite Provider");
-            // TODO: Start provider (https://github.com/Draegerwerk/SDCcc/issues/1)
         }
         return isConsumerEnabled;
     }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -167,6 +167,11 @@ public class TestSuite {
 
         long totalTestFailures = 0L;
         /*
+         * Starting TestSuite Client and connect, check for an archive service of the DUT
+         */
+        startClient();
+
+        /*
          * Phase 1, generate messages
          */
         phase1();
@@ -271,7 +276,6 @@ public class TestSuite {
     }
 
     private void phase1() {
-        setupDevice();
         performBasicMessagingCheck();
 
         try {
@@ -361,7 +365,7 @@ public class TestSuite {
         LOG.info("SDC Basic Messaging Check completed" + statusline + ".");
     }
 
-    private void setupDevice() {
+    private void startClient() {
         LOG.info("Starting TestSuite Client");
         try {
             client.startService(MAX_WAIT);

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -165,7 +165,7 @@ public class TestSuite {
         final SummaryGeneratingListener directSummary = new SummaryGeneratingListener();
         directTestLauncher.registerTestExecutionListeners(directSummary);
 
-        final Boolean isConsumerEnabled = setupDeviceAndProvider();
+        final Boolean isConsumerEnabled = setupDevice();
 
         long totalTestFailures = 0L;
         /*
@@ -186,7 +186,7 @@ public class TestSuite {
         /*
          * Phase 4, invariant tests
          */
-        // stop client and provider now
+        // stop client now
         totalTestFailures =
                 phase4(totalTestFailures, outWriter, invariantTestLauncher, invariantTestPlan, invariantSummary);
 
@@ -364,7 +364,7 @@ public class TestSuite {
         LOG.info("SDC Basic Messaging Check completed" + statusline + ".");
     }
 
-    private Boolean setupDeviceAndProvider() {
+    private Boolean setupDevice() {
         final var isConsumerEnabled =
                 injector.getInstance(Key.get(Boolean.class, Names.named(TestSuiteConfig.CONSUMER_ENABLE)));
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -109,14 +109,14 @@ public class TestSuite {
      * Used by the main injector to create a TestSuite instance.
      * It is also useful for extending the TestSuite class.
      *
-     * @param injector a reference to the injector injecting here
-     * @param testRunObserver observer for invalidating test runs
-     * @param sdcTestDirectories directories to search for test cases
-     * @param testRunDir directory to run the tests in and store artifacts
+     * @param injector             a reference to the injector injecting here
+     * @param testRunObserver      observer for invalidating test runs
+     * @param sdcTestDirectories   directories to search for test cases
+     * @param testRunDir           directory to run the tests in and store artifacts
      * @param testExecutionLogging whether logging of test case starts etc. shall be done
-     * @param messageGenerator utility for generating messages to send
-     * @param testRunInformation utility where information of the test run is stored
-     * @param client client to use for direct tests
+     * @param messageGenerator     utility for generating messages to send
+     * @param testRunInformation   utility where information of the test run is stored
+     * @param client               client to use for direct tests
      */
     @Inject
     public TestSuite(
@@ -365,27 +365,22 @@ public class TestSuite {
     }
 
     private Boolean setupDevice() {
-        final var isConsumerEnabled =
-                injector.getInstance(Key.get(Boolean.class, Names.named(TestSuiteConfig.CONSUMER_ENABLE)));
-
-        if (isConsumerEnabled) {
-            LOG.info("Starting TestSuite Client");
-            try {
-                client.startService(MAX_WAIT);
-                client.connect();
-            } catch (final InterceptorException | TransportException | IOException | TimeoutException e) {
-                LOG.error("Could not connect to target device {}", client.getTargetEpr());
-                testRunObserver.invalidateTestRun("Could not connect to target device", e);
-                throw new RuntimeException(e);
-            }
-
-            // check the DUT for an archive service, currently needed for MDPWS:R0006
-            this.testRunInformation.setArchiveServicePresent(
-                    client.getHostingServiceProxy().getHostedServices().values().stream()
-                            .anyMatch(service ->
-                                    service.getType().getTypes().contains(WsdlConstants.PORT_TYPE_ARCHIVE_QNAME)));
+        LOG.info("Starting TestSuite Client");
+        try {
+            client.startService(MAX_WAIT);
+            client.connect();
+        } catch (final InterceptorException | TransportException | IOException | TimeoutException e) {
+            LOG.error("Could not connect to target device {}", client.getTargetEpr());
+            testRunObserver.invalidateTestRun("Could not connect to target device", e);
+            throw new RuntimeException(e);
         }
-        return isConsumerEnabled;
+
+        // check the DUT for an archive service, currently needed for MDPWS:R0006
+        this.testRunInformation.setArchiveServicePresent(
+                client.getHostingServiceProxy().getHostedServices().values().stream()
+                        .anyMatch(service ->
+                                service.getType().getTypes().contains(WsdlConstants.PORT_TYPE_ARCHIVE_QNAME)));
+        return true;
     }
 
     /**
@@ -658,9 +653,9 @@ public class TestSuite {
      * Run the test suite with the given already parsed command line arguments and the
      * specified enabled test config constants.
      *
-     * @param cmdLine parsed command line arguments
+     * @param cmdLine                parsed command line arguments
      * @param enabledTestConfigClass class containing test identifier constants
-     * @param sdcTestDirectories directories to search for test cases
+     * @param sdcTestDirectories     directories to search for test cases
      */
     public static void runWithArgs(
             final CommandLineOptions cmdLine,

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -165,13 +165,11 @@ public class TestSuite {
         final SummaryGeneratingListener directSummary = new SummaryGeneratingListener();
         directTestLauncher.registerTestExecutionListeners(directSummary);
 
-        final Boolean isConsumerEnabled = setupDevice();
-
         long totalTestFailures = 0L;
         /*
          * Phase 1, generate messages
          */
-        phase1(isConsumerEnabled);
+        phase1();
 
         /*
          * Phase 2, execute direct tests
@@ -272,10 +270,9 @@ public class TestSuite {
         return totalTestFailures + directSummary.getSummary().getTotalFailureCount();
     }
 
-    private void phase1(final Boolean isConsumerEnabled) {
-        if (isConsumerEnabled) {
-            performBasicMessagingCheck();
-        }
+    private void phase1() {
+        setupDevice();
+        performBasicMessagingCheck();
 
         try {
             Thread.sleep(TIME_BETWEEN_PHASES);
@@ -364,7 +361,7 @@ public class TestSuite {
         LOG.info("SDC Basic Messaging Check completed" + statusline + ".");
     }
 
-    private Boolean setupDevice() {
+    private void setupDevice() {
         LOG.info("Starting TestSuite Client");
         try {
             client.startService(MAX_WAIT);
@@ -380,7 +377,6 @@ public class TestSuite {
                 client.getHostingServiceProxy().getHostedServices().values().stream()
                         .anyMatch(service ->
                                 service.getType().getTypes().contains(WsdlConstants.PORT_TYPE_ARCHIVE_QNAME)));
-        return true;
     }
 
     /**

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
@@ -35,7 +35,6 @@ public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
         configureTestSuite();
         configureTLS();
         configureNetwork();
-        configureProvider();
         configureGRpc();
         configureTestParameter();
         configureInternalSettings();
@@ -77,10 +76,6 @@ public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
         bind(TestSuiteConfig.NETWORK_INTERFACE_ADDRESS, String.class, "127.0.0.1");
         bind(TestSuiteConfig.NETWORK_MAX_WAIT, long.class, 10L);
         bind(TestSuiteConfig.NETWORK_MULTICAST_TTL, long.class, 128L);
-    }
-
-    void configureProvider() {
-        bind(TestSuiteConfig.PROVIDER_ENABLE, Boolean.class, false);
     }
 
     void configureGRpc() {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
@@ -49,7 +49,6 @@ public final class TestSuiteConfig {
      * Consumer configuration
      */
     private static final String CONSUMER = "Consumer.";
-    public static final String CONSUMER_ENABLE = SDCCC + CONSUMER + Constants.ENABLE_SETTING_POSTFIX;
     public static final String CONSUMER_DEVICE_EPR = SDCCC + CONSUMER + Constants.DEVICE_EPR_POSTFIX;
     public static final String CONSUMER_DEVICE_LOCATION_FACILITY = SDCCC + CONSUMER + "DeviceLocationFacility";
     public static final String CONSUMER_DEVICE_LOCATION_BUILDING = SDCCC + CONSUMER + "DeviceLocationBuilding";

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
@@ -19,7 +19,7 @@ public final class TestSuiteConfig {
     /*
      * General configuration
      */
-    private static final String SDCCC = "SDCcc.";
+    public static final String SDCCC = "SDCcc.";
     public static final String CI_MODE = SDCCC + "CIMode";
     public static final String GRAPHICAL_POPUPS = SDCCC + "GraphicalPopups";
     public static final String TEST_EXECUTION_LOGGING = SDCCC + "TestExecutionLogging";
@@ -57,13 +57,6 @@ public final class TestSuiteConfig {
     public static final String CONSUMER_DEVICE_LOCATION_FLOOR = SDCCC + CONSUMER + "DeviceLocationFloor";
     public static final String CONSUMER_DEVICE_LOCATION_ROOM = SDCCC + CONSUMER + "DeviceLocationRoom";
     public static final String CONSUMER_DEVICE_LOCATION_BED = SDCCC + CONSUMER + "DeviceLocationBed";
-
-    /*
-     * Provider configuration
-     */
-    private static final String PROVIDER = "Provider.";
-    public static final String PROVIDER_ENABLE = SDCCC + PROVIDER + Constants.ENABLE_SETTING_POSTFIX;
-    public static final String PROVIDER_DEVICE_EPR = SDCCC + PROVIDER + Constants.DEVICE_EPR_POSTFIX;
 
     /*
      * GRPC configuration

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
@@ -586,7 +586,6 @@ public class TestSuiteIT {
             bind(CryptoSettings.class).toInstance(cryptoSettings);
 
             bind(TestSuiteConfig.CI_MODE, Boolean.class, true);
-            bind(TestSuiteConfig.CONSUMER_ENABLE, Boolean.class, true);
             bind(TestSuiteConfig.CONSUMER_DEVICE_EPR, String.class, DUT_EPR);
             bind(TestSuiteConfig.CONSUMER_DEVICE_LOCATION_FACILITY, String.class, this.locationConfig.facility);
             bind(TestSuiteConfig.CONSUMER_DEVICE_LOCATION_BUILDING, String.class, this.locationConfig.building);

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
@@ -594,7 +594,6 @@ public class TestSuiteIT {
             bind(TestSuiteConfig.CONSUMER_DEVICE_LOCATION_ROOM, String.class, this.locationConfig.room);
             bind(TestSuiteConfig.CONSUMER_DEVICE_LOCATION_BED, String.class, this.locationConfig.bed);
 
-            bind(TestProviderConfig.PROVIDER_ENABLE, Boolean.class, true);
             bind(TestProviderConfig.PROVIDER_DEVICE_EPR, String.class, DUT_EPR);
 
             bind(TestSuiteConfig.NETWORK_INTERFACE_ADDRESS, String.class, "127.0.0.1");

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/TestSuiteIT.java
@@ -29,9 +29,6 @@ import com.draeger.medical.sdccc.manipulation.precondition.PreconditionException
 import com.draeger.medical.sdccc.manipulation.precondition.PreconditionRegistry;
 import com.draeger.medical.sdccc.messages.HibernateConfig;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClient;
-import com.draeger.medical.sdccc.sdcri.testprovider.TestProvider;
-import com.draeger.medical.sdccc.sdcri.testprovider.TestProviderImpl;
-import com.draeger.medical.sdccc.sdcri.testprovider.guice.ProviderFactory;
 import com.draeger.medical.sdccc.tests.InjectorTestBase;
 import com.draeger.medical.sdccc.util.HibernateConfigInMemoryImpl;
 import com.draeger.medical.sdccc.util.TestRunObserver;
@@ -43,6 +40,10 @@ import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.util.Modules;
 import it.com.draeger.medical.sdccc.test_util.SslMetadata;
+import it.com.draeger.medical.sdccc.test_util.testprovider.TestProvider;
+import it.com.draeger.medical.sdccc.test_util.testprovider.TestProviderConfig;
+import it.com.draeger.medical.sdccc.test_util.testprovider.TestProviderImpl;
+import it.com.draeger.medical.sdccc.test_util.testprovider.guice.ProviderFactory;
 import it.com.draeger.medical.sdccc.testsuite_it_mock_tests.Identifiers;
 import it.com.draeger.medical.sdccc.testsuite_it_mock_tests.WasRunObserver;
 import java.io.File;
@@ -594,8 +595,8 @@ public class TestSuiteIT {
             bind(TestSuiteConfig.CONSUMER_DEVICE_LOCATION_ROOM, String.class, this.locationConfig.room);
             bind(TestSuiteConfig.CONSUMER_DEVICE_LOCATION_BED, String.class, this.locationConfig.bed);
 
-            bind(TestSuiteConfig.PROVIDER_ENABLE, Boolean.class, true);
-            bind(TestSuiteConfig.PROVIDER_DEVICE_EPR, String.class, DUT_EPR);
+            bind(TestProviderConfig.PROVIDER_ENABLE, Boolean.class, true);
+            bind(TestProviderConfig.PROVIDER_DEVICE_EPR, String.class, DUT_EPR);
 
             bind(TestSuiteConfig.NETWORK_INTERFACE_ADDRESS, String.class, "127.0.0.1");
             bind(DpwsConfig.MULTICAST_TTL, Integer.class, 128);

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProvider.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProvider.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package com.draeger.medical.sdccc.sdcri.testprovider;
+package it.com.draeger.medical.sdccc.test_util.testprovider;
 
 import com.google.inject.Injector;
 import java.time.Duration;

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProviderConfig.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProviderConfig.java
@@ -22,7 +22,6 @@ public final class TestProviderConfig {
      * Provider configuration
      */
     private static final String PROVIDER = "Provider.";
-    public static final String PROVIDER_ENABLE = TestSuiteConfig.SDCCC + PROVIDER + Constants.ENABLE_SETTING_POSTFIX;
     public static final String PROVIDER_DEVICE_EPR = TestSuiteConfig.SDCCC + PROVIDER + Constants.DEVICE_EPR_POSTFIX;
 
     private TestProviderConfig() {}

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProviderConfig.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProviderConfig.java
@@ -1,0 +1,29 @@
+/*
+ * This Source Code Form is subject to the terms of the MIT License.
+ * Copyright (c) 2023, 2024 Draegerwerk AG & Co. KGaA.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package it.com.draeger.medical.sdccc.test_util.testprovider;
+
+import com.draeger.medical.sdccc.configuration.DefaultTestSuiteConfig;
+import com.draeger.medical.sdccc.configuration.TestSuiteConfig;
+import com.draeger.medical.sdccc.util.Constants;
+
+/**
+ * Configuration of the SDCcc package.
+ *
+ * @see DefaultTestSuiteConfig
+ */
+public final class TestProviderConfig {
+
+    /*
+     * Provider configuration
+     */
+    private static final String PROVIDER = "Provider.";
+    public static final String PROVIDER_ENABLE = TestSuiteConfig.SDCCC + PROVIDER + Constants.ENABLE_SETTING_POSTFIX;
+    public static final String PROVIDER_DEVICE_EPR = TestSuiteConfig.SDCCC + PROVIDER + Constants.DEVICE_EPR_POSTFIX;
+
+    private TestProviderConfig() {}
+}

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProviderHostingServicePlugin.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProviderHostingServicePlugin.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package com.draeger.medical.sdccc.sdcri.testprovider;
+package it.com.draeger.medical.sdccc.test_util.testprovider;
 
 import com.google.inject.Inject;
 import org.somda.sdc.dpws.DpwsUtil;

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProviderImpl.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProviderImpl.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package com.draeger.medical.sdccc.sdcri.testprovider;
+package it.com.draeger.medical.sdccc.test_util.testprovider;
 
 import com.draeger.medical.sdccc.configuration.TestSuiteConfig;
 import com.google.common.util.concurrent.AbstractIdleService;
@@ -39,7 +39,7 @@ import org.somda.sdc.glue.provider.factory.SdcDeviceFactory;
 import org.somda.sdc.glue.provider.sco.OperationInvocationReceiver;
 
 /**
- * SDCri provider used to test SDC consumers.
+ * SDCri provider used integration tests.
  */
 public class TestProviderImpl extends AbstractIdleService implements TestProvider {
     private static final Logger LOG = LogManager.getLogger();
@@ -54,7 +54,7 @@ public class TestProviderImpl extends AbstractIdleService implements TestProvide
     @Inject
     TestProviderImpl(
             @Assisted final InputStream mdibAsStream,
-            @Named(TestSuiteConfig.PROVIDER_DEVICE_EPR) final String providerEpr,
+            @Named(TestProviderConfig.PROVIDER_DEVICE_EPR) final String providerEpr,
             @Named(TestSuiteConfig.NETWORK_INTERFACE_ADDRESS) final String adapterAddress,
             final TestProviderUtil testProviderUtil) {
         this.injector = testProviderUtil.getInjector();

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProviderUtil.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/TestProviderUtil.java
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package com.draeger.medical.sdccc.sdcri.testprovider;
+package it.com.draeger.medical.sdccc.test_util.testprovider;
 
 import com.draeger.medical.sdccc.configuration.TestSuiteConfig;
 import com.draeger.medical.sdccc.messages.MessageStorage;

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/guice/ProviderFactory.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/guice/ProviderFactory.java
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-package com.draeger.medical.sdccc.sdcri.testprovider.guice;
+package it.com.draeger.medical.sdccc.test_util.testprovider.guice;
 
-import com.draeger.medical.sdccc.sdcri.testprovider.TestProviderImpl;
 import com.google.inject.assistedinject.Assisted;
+import it.com.draeger.medical.sdccc.test_util.testprovider.TestProviderImpl;
 import java.io.InputStream;
 
 /**

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/guice/package-info.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/guice/package-info.java
@@ -9,6 +9,6 @@
  * SDCcc test provider guice factory.
  */
 @ParametersAreNonnullByDefault
-package com.draeger.medical.sdccc.sdcri.testprovider.guice;
+package it.com.draeger.medical.sdccc.test_util.testprovider.guice;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/package-info.java
+++ b/sdccc/src/test/java/it/com/draeger/medical/sdccc/test_util/testprovider/package-info.java
@@ -9,6 +9,6 @@
  * SDCcc test provider.
  */
 @ParametersAreNonnullByDefault
-package com.draeger.medical.sdccc.sdcri.testprovider;
+package it.com.draeger.medical.sdccc.test_util.testprovider;
 
 import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
SDCcc is not going to be used for consumer tests. Therefore, the purpose of the PR is to remove consumer test related implementations resp. move implementation of the test provider to test utils in order to use it for integration tests.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
