### PR TITLE
Fix confusing error messages

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -211,26 +211,30 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
 
                                     } else if (modificationType.equals(DescriptionModificationType.CRT)) {
                                         assertTrue(
-                                                descriptorBeforeReportOpt.isEmpty()
-                                                        && descriptorAfterReportOpt.isPresent(),
+                                                descriptorBeforeReportOpt.isEmpty(),
                                                 String.format(
-                                                        "The descriptor with handle %s is missing before applying the report:"
-                                                                + " %s and is present after applying the report: %s,"
+                                                        "The descriptor with handle %s is present before applying the report"
                                                                 + " for modification type create",
-                                                        modifiedDescriptor.getHandle(),
-                                                        descriptorBeforeReportOpt.isEmpty(),
-                                                        descriptorAfterReportOpt.isPresent()));
+                                                        modifiedDescriptor.getHandle()));
+                                        assertTrue(
+                                                descriptorAfterReportOpt.isPresent(),
+                                                String.format(
+                                                        "The descriptor with handle %s is missing after applying the report"
+                                                                + " for modification type create",
+                                                        modifiedDescriptor.getHandle()));
                                     } else {
                                         assertTrue(
-                                                descriptorBeforeReportOpt.isPresent()
-                                                        && descriptorAfterReportOpt.isEmpty(),
+                                                descriptorBeforeReportOpt.isPresent(),
                                                 String.format(
-                                                        "The descriptor with handle %s is present before applying the report:"
-                                                                + " %s and is missing after applying the report: %s,"
+                                                        "The descriptor with handle %s is missing before applying the report"
                                                                 + " for modification type delete",
-                                                        modifiedDescriptor.getHandle(),
-                                                        descriptorBeforeReportOpt.isPresent(),
-                                                        descriptorAfterReportOpt.isEmpty()));
+                                                        modifiedDescriptor.getHandle()));
+                                        assertTrue(
+                                                descriptorAfterReportOpt.isEmpty(),
+                                                String.format(
+                                                        "The descriptor with handle %s is missing after applying the report"
+                                                                + " for modification type delete",
+                                                        modifiedDescriptor.getHandle()));
                                     }
                                 }
                             }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -232,7 +232,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                                         assertTrue(
                                                 descriptorAfterReportOpt.isEmpty(),
                                                 String.format(
-                                                        "The descriptor with handle %s is missing after applying the report"
+                                                        "The descriptor with handle %s is present after applying the report"
                                                                 + " for modification type delete",
                                                         modifiedDescriptor.getHandle()));
                                     }


### PR DESCRIPTION
 Fixed confusing error message in Biceps:C-5 test case

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [X] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [X] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [X] Pull Request Assignee
  * [x] Reviewer
