### PR TITLE
Document Reasons for missing Preconditions

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantBicepsNormativeAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantBicepsNormativeAnnexTest.java
@@ -42,6 +42,10 @@ public class InvariantBicepsNormativeAnnexTest extends InjectorTestBase {
         this.messageStorage = injector.getInstance(MessageStorage.class);
     }
 
+    // NOTE: No PreCondition can ensure that there are Localized texts with a @Ref attribute. This is because
+    //       a device either provides a LocalizationService, in which case all Localized texts will have a @Ref attribute,
+    //       or it doesn't, in which case no Localized text will have a @Ref attribute.
+    //       When a device does not provide a LocalizationService, then this test should not be applied to it.
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_R5006)
     @TestDescription(

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantBicepsNormativeAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantBicepsNormativeAnnexTest.java
@@ -42,10 +42,9 @@ public class InvariantBicepsNormativeAnnexTest extends InjectorTestBase {
         this.messageStorage = injector.getInstance(MessageStorage.class);
     }
 
-    // NOTE: No PreCondition can ensure that there are Localized texts with a @Ref attribute. This is because
-    //       a device either provides a LocalizationService, in which case all Localized texts will have a @Ref attribute,
-    //       or it doesn't, in which case no Localized text will have a @Ref attribute.
-    //       When a device does not provide a LocalizationService, then this test should not be applied to it.
+    // NOTE: The way that a Device uses LocalizedTexts is usually static. It does hence not make sense to implement
+    //       a manipulation that causes LocalizedTests that have no @Ref attribute to get one.
+    //       When a device does not use @Ref attributes in its LocalizedTexts, then this test is not applicable to it.
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_R5006)
     @TestDescription(

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelAnnexTest.java
@@ -121,6 +121,9 @@ public class InvariantParticipantModelAnnexTest extends InjectorTestBase {
                 acceptableSequenceSeen.get(), "No AbstractOperationDescriptors seen during test run, test failed.");
     }
 
+    // NOTE: No PreCondition can ensure that an ApprovedJurisdictions list is present or absent as this
+    //       list is supposed to be static for a Mds. When all Mds in a Device's Mdib have an ApprovedJurisdictions
+    //       list, then this test case should not be applied to it.
     @Test
     @DisplayName("OperatingJurisdiction SHALL NOT be present if there is no pm:MdsDescriptor/pm:ApprovedJurisdictions"
             + " list present.")
@@ -166,6 +169,9 @@ public class InvariantParticipantModelAnnexTest extends InjectorTestBase {
         assertTestData(acceptableSequenceSeen.get(), "No acceptable sequence seen, test failed.");
     }
 
+    // NOTE: No PreCondition can ensure that an ApprovedJurisdictions list is present or absent as this
+    //       list is supposed to be static for a Vmd. When all Vmds in a Device's Mdib have an ApprovedJurisdictions
+    //       list, then this test case should not be applied to it.
     @Test
     @DisplayName("OperatingJurisdiction SHALL NOT be present if there is no pm:VmdDescriptor/pm:ApprovedJurisdictions"
             + " list present.")

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/dpws/invariant/InvariantMessagingTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/dpws/invariant/InvariantMessagingTest.java
@@ -40,6 +40,8 @@ public class InvariantMessagingTest extends InjectorTestBase {
     private static final String RELATIONSHIP_ATTRIBUTE = "RelationshipType";
     private static final String BROKEN_R0019_IRI = "wsa:Reply";
 
+    // NOTE: No PreCondition is necessary for this test case as the Basic Messaging Check should be
+    //       sufficient to ensure that there is suitable test data available.
     @Test
     @TestIdentifier(EnabledTestConfig.DPWS_R0019)
     @TestDescription("Verifies the relationship property is set in all response messages from the DUT.")

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/invariant/InvariantNonFunctionalQualityAttributesTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/invariant/InvariantNonFunctionalQualityAttributesTest.java
@@ -298,7 +298,7 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
         assertTestData(acceptableSequenceSeen.get(), "No AlertConditionState seen during the test run, test failed.");
     }
 
-    // TODO: Add a Precondition (as part of SDCCC-1348)
+    // TODO: Add a Precondition
     @Test
     @TestIdentifier(EnabledTestConfig.GLUE_R0013)
     @TestDescription("Starting from the initially retrieved mdib, applies every episodic report to the mdib and"
@@ -342,7 +342,7 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
         assertTestData(acceptableSequenceSeen.get(), "No suitable context states seen, test failed.");
     }
 
-    // TODO: Add a Precondition (as part of SDCCC-1348)
+    // TODO: Add a Precondition
     @Test
     @TestIdentifier(EnabledTestConfig.GLUE_R0072)
     @TestDescription("Starting from the initially retrieved mdib, applies every episodic report to the mdib and"

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/invariant/InvariantNonFunctionalQualityAttributesTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/invariant/InvariantNonFunctionalQualityAttributesTest.java
@@ -298,7 +298,6 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
         assertTestData(acceptableSequenceSeen.get(), "No AlertConditionState seen during the test run, test failed.");
     }
 
-    // TODO: Add a Precondition
     @Test
     @TestIdentifier(EnabledTestConfig.GLUE_R0013)
     @TestDescription("Starting from the initially retrieved mdib, applies every episodic report to the mdib and"
@@ -342,7 +341,6 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
         assertTestData(acceptableSequenceSeen.get(), "No suitable context states seen, test failed.");
     }
 
-    // TODO: Add a Precondition
     @Test
     @TestIdentifier(EnabledTestConfig.GLUE_R0072)
     @TestDescription("Starting from the initially retrieved mdib, applies every episodic report to the mdib and"

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/invariant/InvariantNonFunctionalQualityAttributesTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/invariant/InvariantNonFunctionalQualityAttributesTest.java
@@ -298,6 +298,7 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
         assertTestData(acceptableSequenceSeen.get(), "No AlertConditionState seen during the test run, test failed.");
     }
 
+    // TODO: Add a Precondition (as part of SDCCC-1348)
     @Test
     @TestIdentifier(EnabledTestConfig.GLUE_R0013)
     @TestDescription("Starting from the initially retrieved mdib, applies every episodic report to the mdib and"
@@ -341,6 +342,7 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
         assertTestData(acceptableSequenceSeen.get(), "No suitable context states seen, test failed.");
     }
 
+    // TODO: Add a Precondition (as part of SDCCC-1348)
     @Test
     @TestIdentifier(EnabledTestConfig.GLUE_R0072)
     @TestDescription("Starting from the initially retrieved mdib, applies every episodic report to the mdib and"

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/mdpws/invariant/InvariantSOAPOverHTTPTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/mdpws/invariant/InvariantSOAPOverHTTPTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Test;
  */
 public class InvariantSOAPOverHTTPTest extends InjectorTestBase {
 
+    // NOTE: No PreCondition is necessary for this test case as the Basic Messaging Check should be
+    //       sufficient to ensure that there is suitable test data available.
     @Test
     @TestIdentifier(EnabledTestConfig.MDPWS_R0006)
     @TestDescription("Verifies for all incoming http messages that the transmitted"


### PR DESCRIPTION
Added either a Note explaining the reason or a TODO for adding a Precondition to Invariant Test Cases that do not have a Precondition, although they seem to need one.


# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
