### PR TITLE
Fix annotations for Konsist tests

### DIFF
--- a/sdccc/src/test/java/com/draeger/medical/sdccc/architecture/KonsistArchitecturalRules.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/architecture/KonsistArchitecturalRules.kt
@@ -5,7 +5,7 @@ import com.draeger.medical.sdccc.tests.annotations.TestIdentifier
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withAnnotationOf
 import com.lemonappdev.konsist.api.verify.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Checks the listed architectural rules for Kotlin.


### PR DESCRIPTION
Changed the test annotations in KonsistArchitecturalRules to junit5 annotations.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
