### PR TITLE
make test run injector configurable

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
@@ -34,8 +34,13 @@ public class FallbackManipulations implements Manipulations {
 
     private final InteractionFactory interactionFactory;
 
+    /**
+     * Create FallbackManipulations.
+     *
+     * @param interactionFactory to create user interactions
+     */
     @Inject
-    FallbackManipulations(final InteractionFactory interactionFactory) {
+    public FallbackManipulations(final InteractionFactory interactionFactory) {
         this.interactionFactory = interactionFactory;
     }
 
@@ -270,6 +275,10 @@ public class FallbackManipulations implements Manipulations {
                 })
                 .displayYesNoUserInteraction(interactionMessage);
         return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+    }
+
+    public InteractionFactory getInteractionFactory() {
+        return interactionFactory;
     }
 
     private String getMetricStatus(final ComponentActivation activation) {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
@@ -427,6 +427,26 @@ public class GRpcManipulations implements Manipulations {
         return response;
     }
 
+    public ActivationStateServiceGrpc.ActivationStateServiceBlockingStub getActivationStateStub() {
+        return activationStateStub;
+    }
+
+    public AlertServiceGrpc.AlertServiceBlockingStub getAlertStub() {
+        return alertStub;
+    }
+
+    public ContextServiceGrpc.ContextServiceBlockingStub getContextStub() {
+        return contextStub;
+    }
+
+    public DeviceServiceGrpc.DeviceServiceBlockingStub getDeviceStub() {
+        return deviceStub;
+    }
+
+    public MetricServiceGrpc.MetricServiceBlockingStub getMetricStub() {
+        return metricStub;
+    }
+
     ContextTypes.ContextAssociation toApiContextType(final ContextAssociation contextAssociation) {
         return switch (contextAssociation) {
             case NO -> ContextTypes.ContextAssociation.CONTEXT_ASSOCIATION_NOT_ASSOCIATED;

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/UserInteraction.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/UserInteraction.java
@@ -89,7 +89,7 @@ public class UserInteraction {
      * @param interaction text to display
      * @return user provided text input
      */
-    String displayStringInputUserInteraction(final String interaction) {
+    public String displayStringInputUserInteraction(final String interaction) {
         final String result;
 
         LOG.debug("displayStringInputUserInteraction called for interaction: {}", interaction);


### PR DESCRIPTION
- Allow passing an AbtractModule into the Testsuite to make the test run injector externally configurable
-  made manipulations extendable

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
