### PR TITLE
Increased detekt NestedBlockDepth threshold to 6.

### DIFF
--- a/dev_config/detekt.yml
+++ b/dev_config/detekt.yml
@@ -12,6 +12,8 @@ complexity:
     active: true
   ReplaceSafeCallChainWithRun:
     active: true
+  NestedBlockDepth:
+    threshold: 6
 exceptions:
   ObjectExtendsThrowable:
     active: true


### PR DESCRIPTION
The NestedBlockDepth threshold should be increased to 6.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
