### PR TITLE
Fix spotbugs findings

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
@@ -36,6 +36,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.google.protobuf.Empty;
 import com.google.protobuf.StringValue;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.Channel;
 import io.grpc.ManagedChannelBuilder;
 import java.util.List;
@@ -520,6 +521,9 @@ public class GRpcManipulations implements Manipulations {
         }
     }
 
+    @SuppressFBWarnings(
+            value = {"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"},
+            justification = "There is a null check before access.")
     private static ContextTypes.LocationDetail locationDetailToProto(final LocationDetail locationDetail) {
         final var builder = ContextTypes.LocationDetail.newBuilder();
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTest.java
@@ -8,6 +8,7 @@
 package com.draeger.medical.sdccc.tests.biceps.direct;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -23,7 +24,6 @@ import com.draeger.medical.sdccc.util.MessageGeneratingUtil;
 import com.draeger.medical.sdccc.util.MessagingException;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,10 +59,10 @@ public class DirectParticipantModelContextStateTest extends InjectorTestBase {
         final var getMdibResponse = messageGeneratingUtil.getMdib();
         final var mdib = (GetMdibResponse)
                 getMdibResponse.getOriginalEnvelope().getBody().getAny().get(0);
-        final var systemContexts = Optional.ofNullable(mdib.getMdib().getMdDescription())
-                .orElseThrow(() -> new NoTestData("No MdDescription present"))
-                .getMds()
-                .stream()
+        final var mdDescription = mdib.getMdib().getMdDescription();
+        assertTestData(mdDescription != null, "Mdib without MdDescription present, no data");
+        assertNotNull(mdDescription); // make spotbugs happy, should never happen
+        final var systemContexts = mdDescription.getMds().stream()
                 .map(MdsDescriptor::getSystemContext)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTest.java
@@ -23,6 +23,7 @@ import com.draeger.medical.sdccc.util.MessageGeneratingUtil;
 import com.draeger.medical.sdccc.util.MessagingException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,7 +59,10 @@ public class DirectParticipantModelContextStateTest extends InjectorTestBase {
         final var getMdibResponse = messageGeneratingUtil.getMdib();
         final var mdib = (GetMdibResponse)
                 getMdibResponse.getOriginalEnvelope().getBody().getAny().get(0);
-        final var systemContexts = mdib.getMdib().getMdDescription().getMds().stream()
+        final var systemContexts = Optional.ofNullable(mdib.getMdib().getMdDescription())
+                .orElseThrow(() -> new NoTestData("No MdDescription present"))
+                .getMds()
+                .stream()
                 .map(MdsDescriptor::getSystemContext)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/direct/DirectSubscriptionHandlingTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/direct/DirectSubscriptionHandlingTest.java
@@ -57,6 +57,7 @@ import org.somda.sdc.biceps.model.participant.AbstractContextState;
 import org.somda.sdc.biceps.model.participant.LocationContextDescriptor;
 import org.somda.sdc.biceps.model.participant.LocationContextState;
 import org.somda.sdc.biceps.model.participant.LocationDetail;
+import org.somda.sdc.biceps.model.participant.MdDescription;
 import org.somda.sdc.biceps.model.participant.Mdib;
 import org.somda.sdc.biceps.model.participant.MdsDescriptor;
 import org.somda.sdc.dpws.DpwsConstants;
@@ -474,13 +475,18 @@ public class DirectSubscriptionHandlingTest extends InjectorTestBase {
                         .getAny()
                         .get(0);
                 final Mdib mdib = mdibResponse.getMdib();
-                final List<MdsDescriptor> mds = mdib.getMdDescription().getMds();
+                final List<MdsDescriptor> mds = Optional.ofNullable(mdib.getMdDescription())
+                        .map(MdDescription::getMds)
+                        .orElse(Collections.emptyList());
                 LocationContextDescriptor locationContextDescriptor = null;
                 for (MdsDescriptor md : mds) {
-                    final LocationContextDescriptor lcDesc =
-                            md.getSystemContext().getLocationContext();
-                    if (lcDesc != null) {
-                        locationContextDescriptor = lcDesc;
+                    final var systemContext = md.getSystemContext();
+
+                    if (systemContext != null) {
+                        final LocationContextDescriptor lcDesc = systemContext.getLocationContext();
+                        if (lcDesc != null) {
+                            locationContextDescriptor = lcDesc;
+                        }
                     }
                 }
                 if (locationContextDescriptor == null) {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/invariant/InvariantSubscriptionHandlingTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/invariant/InvariantSubscriptionHandlingTest.java
@@ -242,9 +242,13 @@ public class InvariantSubscriptionHandlingTest extends InjectorTestBase {
             if (state.getDescriptorHandle().equals(handle)
                     && ImpliedValueUtil.getStateVersion(state, impliedValueMap).equals(stateVersion)
                     && ((state instanceof RealTimeSampleArrayMetricState rtsaMetric
-                                    && (rtsaMetric.getMetricValue().equals(sampleArrayValue)))
+                                    && Optional.ofNullable(rtsaMetric.getMetricValue())
+                                            .map(it -> it.equals(sampleArrayValue))
+                                            .orElse(false))
                             || (state instanceof DistributionSampleArrayMetricState dsaMetric
-                                    && (dsaMetric.getMetricValue().equals(sampleArrayValue))))) {
+                                    && Optional.ofNullable(dsaMetric.getMetricValue())
+                                            .map(it -> it.equals(sampleArrayValue))
+                                            .orElse(false)))) {
                 foundState = true;
             }
         }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ImpliedValueUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ImpliedValueUtil.java
@@ -365,9 +365,12 @@ public final class ImpliedValueUtil {
      * @param mdDescription to retrieve the description version from
      * @return the description version
      */
-    public static BigInteger getDescriptionVersion(final MdDescription mdDescription) {
-        final var descriptionVersion = mdDescription.getDescriptionVersion();
-        return descriptionVersion != null ? descriptionVersion : BigInteger.ZERO;
+    public static BigInteger getDescriptionVersion(final @Nullable MdDescription mdDescription) {
+        if (mdDescription != null) {
+            final var descriptionVersion = mdDescription.getDescriptionVersion();
+            return descriptionVersion != null ? descriptionVersion : BigInteger.ZERO;
+        }
+        return BigInteger.ZERO;
     }
 
     /**
@@ -409,9 +412,12 @@ public final class ImpliedValueUtil {
      * @param mdState to retrieve the state version from
      * @return the state version
      */
-    public static BigInteger getMdStateStateVersion(final MdState mdState) {
-        final var stateVersion = mdState.getStateVersion();
-        return stateVersion != null ? stateVersion : BigInteger.ZERO;
+    public static BigInteger getMdStateStateVersion(final @Nullable MdState mdState) {
+        if (mdState != null) {
+            final var stateVersion = mdState.getStateVersion();
+            return stateVersion != null ? stateVersion : BigInteger.ZERO;
+        }
+        return BigInteger.ZERO;
     }
 
     /**

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTestTest.java
@@ -22,6 +22,7 @@ import com.draeger.medical.sdccc.tests.test_util.InjectorUtil;
 import com.draeger.medical.sdccc.tests.util.NoTestData;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -399,6 +400,9 @@ public class DirectParticipantModelContextStateTestTest {
         assertThrows(AssertionError.class, testClass::testRequirement0125);
     }
 
+    @SuppressFBWarnings(
+            value = {"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"},
+            justification = "everything is mocked")
     private void testSetup(
             final @Nullable PatientContextDescriptor patientContextDescriptor,
             final @Nullable LocationContextDescriptor locationContextDescriptor,

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelServiceOperationsTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelServiceOperationsTestTest.java
@@ -21,6 +21,7 @@ import com.draeger.medical.sdccc.tests.util.NoTestData;
 import com.draeger.medical.sdccc.util.MessageGeneratingUtil;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -615,6 +616,9 @@ public class DirectParticipantModelServiceOperationsTestTest {
         assertThrows(AssertionError.class, testClass::testRequirementR5039);
     }
 
+    @SuppressFBWarnings(
+            value = {"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"},
+            justification = "everything is mocked")
     private void testSetupR5039(
             final @Nullable PatientContextDescriptor patientContextDescriptor,
             final @Nullable LocationContextDescriptor locationContextDescriptor,

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/util/MdibHistorianTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/util/MdibHistorianTest.java
@@ -42,6 +42,7 @@ import com.draeger.medical.sdccc.util.MessageStorageUtil;
 import com.draeger.medical.sdccc.util.TestRunObserver;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.xml.bind.JAXBException;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -492,6 +493,9 @@ public class MdibHistorianTest {
      *
      * @throws Exception on any exception
      */
+    @SuppressFBWarnings(
+            value = {"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"},
+            justification = "everything is mocked")
     @Test
     void testModificationsWithSameStateVersion() throws Exception {
         final var contextReportMdibVersion = BigInteger.ONE;


### PR DESCRIPTION
sdc-ri-model changed its `@Nullable` annotation, now spotbugs detects issues with nullable values.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [X] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [X] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [X] Pull Request Assignee
  * [x] Reviewer
