### PR TITLE
Extended ImpliedValueUtil

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ImpliedValueUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ImpliedValueUtil.java
@@ -509,6 +509,29 @@ public final class ImpliedValueUtil {
     }
 
     /**
+     * Retrieves the version of an mdib or the implied value.
+     *
+     * @param mdib to retrieve the version from
+     * @return the version
+     */
+    public static BigInteger getMdibMdibVersion(final MdibAccess mdib) {
+        final var version = mdib.getMdibVersion().getVersion();
+        return version != null ? version : BigInteger.ZERO;
+    }
+
+    /**
+     * Retrieves the version of an mdib or the implied value.
+     *
+     * @param mdibVersion to retrieve the version from
+     * @return the version
+     */
+    public static BigInteger getMdibMdibVersion(final MdibVersion mdibVersion) {
+        final var version = mdibVersion.getVersion();
+        return version != null ? version : BigInteger.ZERO;
+    }
+
+
+    /**
      * Retrieves the instance id of an mdib or the implied value.
      *
      * @param mdib to retrieve the instance id from

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ImpliedValueUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ImpliedValueUtil.java
@@ -530,7 +530,6 @@ public final class ImpliedValueUtil {
         return version != null ? version : BigInteger.ZERO;
     }
 
-
     /**
      * Retrieves the instance id of an mdib or the implied value.
      *


### PR DESCRIPTION
This PR adds 2 overrides to ImpliedValueUtil.getMdibMdibVersion() that allow applying it to MdibAccess and MdibVersion.
These are neccessary to handle situations in which no Mdib is availlable, but the Architectural Rule still needs to be followed.


// Describe the purpose of the pull request here and remove this line. Keep the checklist.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [ ] Reviewer
