### PR TITLE
Introduce Response base interface for all manipulation results

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
@@ -45,7 +45,7 @@ public class FallbackManipulations implements Manipulations {
     }
 
     @Override
-    public ResponseTypes.Result setLocationDetail(final LocationDetail locationDetail) {
+    public ResultResponse setLocationDetail(final LocationDetail locationDetail) {
         final var interactionMessage = String.format(
                 "Set location for currently associated location context to %s",
                 // better formatting
@@ -56,11 +56,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public List<String> getRemovableDescriptorsOfClass() {
+    public ManipulationResponse<List<String>> getRemovableDescriptorsOfClass() {
         final var interactionMessage = "Provide a whitespace-separated list of removable descriptors."
                 + " Includes handles which have been removed already and can be reinserted."
                 + " Handles must stay the same once reinserted into the MDIB."
@@ -73,13 +74,14 @@ public class FallbackManipulations implements Manipulations {
                 })
                 .displayStringInputUserInteraction(interactionMessage);
         if (data == null || data.isBlank()) {
-            return Collections.emptyList();
+            return ManipulationResponse.from(ResponseTypes.Result.RESULT_FAIL, Collections.emptyList());
         }
-        return List.of(data.split(" "));
+        return ManipulationResponse.from(ResponseTypes.Result.RESULT_SUCCESS, List.of(data.split(" ")));
     }
 
     @Override
-    public List<String> getRemovableDescriptorsOfClass(final Class<? extends AbstractDescriptor> descriptorType) {
+    public ManipulationResponse<List<String>> getRemovableDescriptorsOfClass(
+            final Class<? extends AbstractDescriptor> descriptorType) {
         final var interactionMessage = "Provide a whitespace-separated list of those removable descriptors"
                 + " that are of type " + descriptorType.getName() + " (at least one of every possible kind)."
                 + " Includes handles which have been removed already and can be reinserted."
@@ -91,13 +93,13 @@ public class FallbackManipulations implements Manipulations {
                 })
                 .displayStringInputUserInteraction(interactionMessage);
         if (data == null || data.isBlank()) {
-            return Collections.emptyList();
+            return ManipulationResponse.from(ResponseTypes.Result.RESULT_FAIL, Collections.emptyList());
         }
-        return List.of(data.split(" "));
+        return ManipulationResponse.from(ResponseTypes.Result.RESULT_SUCCESS, List.of(data.split(" ")));
     }
 
     @Override
-    public ResponseTypes.Result removeDescriptor(final String handle) {
+    public ResultResponse removeDescriptor(final String handle) {
         final var interactionMessage = String.format("Remove the descriptor %s from the MDIB.", handle);
         final var interactionResult = interactionFactory
                 .createUserInteraction(new FilterInputStream(System.in) {
@@ -105,11 +107,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public ResponseTypes.Result insertDescriptor(final String handle) {
+    public ResultResponse insertDescriptor(final String handle) {
         final var interactionMessage = String.format("Insert the descriptor %s into the MDIB.", handle);
         final var interactionResult = interactionFactory
                 .createUserInteraction(new FilterInputStream(System.in) {
@@ -117,11 +120,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public ResponseTypes.Result sendHello() {
+    public ResultResponse sendHello() {
         final var interactionMessage =
                 "Announce the presence of the device in the network via a WS-Discovery Hello message.";
         final var interactionResult = interactionFactory
@@ -130,11 +134,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public Optional<String> createContextStateWithAssociation(
+    public ManipulationResponse<Optional<String>> createContextStateWithAssociation(
             final String descriptorHandle, final ContextAssociation association) {
         final var interactionMessage = String.format(
                 "Create a NEW context state for the descriptor %s and set the context association to %s."
@@ -147,13 +152,13 @@ public class FallbackManipulations implements Manipulations {
                 })
                 .displayStringInputUserInteraction(interactionMessage);
         if (data == null || data.isBlank()) {
-            return Optional.empty();
+            return ManipulationResponse.from(ResponseTypes.Result.RESULT_FAIL, Optional.empty());
         }
-        return Optional.of(data);
+        return ManipulationResponse.from(ResponseTypes.Result.RESULT_FAIL, Optional.of(data));
     }
 
     @Override
-    public ResponseTypes.Result setAlertActivation(final String handle, final AlertActivation activationState) {
+    public ResultResponse setAlertActivation(final String handle, final AlertActivation activationState) {
         final var interactionMessage =
                 String.format("Set activation state for handle %s to %s", handle, activationState.name());
         final var interactionResult = interactionFactory
@@ -162,11 +167,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public ResponseTypes.Result setAlertConditionPresence(final String handle, final boolean presence) {
+    public ResultResponse setAlertConditionPresence(final String handle, final boolean presence) {
         final var interactionMessage =
                 String.format("Set the presence attribute for handle %s to %s", handle, presence);
         final var interactionResult = interactionFactory
@@ -175,11 +181,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public ResponseTypes.Result setSystemSignalActivation(
+    public ResultResponse setSystemSignalActivation(
             final String handle, final AlertSignalManifestation manifestation, final AlertActivation activation) {
         final var interactionMessage = String.format(
                 "Set the system signal activation for handle %s and manifestation %s to %s",
@@ -190,11 +197,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public ResponseTypes.Result setComponentActivation(final String handle, final ComponentActivation activationState) {
+    public ResultResponse setComponentActivation(final String handle, final ComponentActivation activationState) {
         final var interactionMessage =
                 String.format("Set activation state for handle %s to %s", handle, activationState.name());
         final var interactionResult = interactionFactory
@@ -203,18 +211,19 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public ResponseTypes.Result setMetricStatus(
+    public ResultResponse setMetricStatus(
             final String sequenceId,
             final String handle,
             final MetricCategory category,
             final ComponentActivation activation) {
 
         final var metricStatusString = getMetricStatus(activation);
-        if (metricStatusString.isEmpty()) return ResponseTypes.Result.RESULT_FAIL;
+        if (metricStatusString.isEmpty()) return ResultResponse.from(ResponseTypes.Result.RESULT_FAIL);
 
         final var interactionMessage = String.format(metricStatusString, handle, category);
         final var interactionResult = interactionFactory
@@ -223,11 +232,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public ResponseTypes.Result triggerDescriptorUpdate(final String handle) {
+    public ResultResponse triggerDescriptorUpdate(final String handle) {
         final var triggerReportString = "Trigger a descriptor update for handle %s";
         final var interactionMessage = String.format(triggerReportString, handle);
         final var interactionResult = interactionFactory
@@ -236,11 +246,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public ResponseTypes.Result triggerDescriptorUpdate(final List<String> handles) {
+    public ResultResponse triggerDescriptorUpdate(final List<String> handles) {
         final var triggerReportString = "Trigger a descriptor update for handles %s";
         final var interactionMessage = String.format(triggerReportString, String.join(", ", handles));
         final var interactionResult = interactionFactory
@@ -249,11 +260,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public ResponseTypes.Result triggerAnyDescriptorUpdate() {
+    public ResultResponse triggerAnyDescriptorUpdate() {
         final var interactionMessage = "Trigger a descriptor update for some descriptor";
         final var interactionResult = interactionFactory
                 .createUserInteraction(new FilterInputStream(System.in) {
@@ -261,11 +273,12 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     @Override
-    public ResponseTypes.Result triggerReport(final QName reportType) {
+    public ResultResponse triggerReport(final QName reportType) {
         final var triggerReportString = "Trigger a report for type %s";
         final var interactionMessage = String.format(triggerReportString, reportType);
         final var interactionResult = interactionFactory
@@ -274,7 +287,8 @@ public class FallbackManipulations implements Manipulations {
                     public void close() {}
                 })
                 .displayYesNoUserInteraction(interactionMessage);
-        return interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL;
+        return ResultResponse.from(
+                interactionResult ? ResponseTypes.Result.RESULT_SUCCESS : ResponseTypes.Result.RESULT_FAIL);
     }
 
     public InteractionFactory getInteractionFactory() {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
@@ -154,7 +154,7 @@ public class FallbackManipulations implements Manipulations {
         if (data == null || data.isBlank()) {
             return ManipulationResponse.from(ResponseTypes.Result.RESULT_FAIL, Optional.empty());
         }
-        return ManipulationResponse.from(ResponseTypes.Result.RESULT_FAIL, Optional.of(data));
+        return ManipulationResponse.from(ResponseTypes.Result.RESULT_SUCCESS, Optional.of(data));
     }
 
     @Override

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationResponse.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationResponse.kt
@@ -1,0 +1,94 @@
+package com.draeger.medical.sdccc.manipulation
+
+import com.draeger.medical.t2iapi.BasicResponses
+import com.draeger.medical.t2iapi.ResponseTypes
+
+/**
+ * Container for Manipulation responses with only a result.
+ */
+data class ResultResponse(
+    /**
+     * Result of the manipulation.
+     */
+    override val result: ResponseTypes.Result,
+) : Response {
+    companion object {
+        /**
+         * Creates a ResultResponse from a ResponseTypes.Result.
+         */
+        @JvmStatic
+        fun from(status: ResponseTypes.Result) = ResultResponse(status)
+
+        /**
+         * Creates a ResultResponse from a BasicResponses.BasicResponse.
+         */
+        @JvmStatic
+        fun from(basicResponses: BasicResponses.BasicResponse): ResultResponse = from(basicResponses.result)
+
+        /**
+         * Creates a ResultResponse with [ResponseTypes.Result.RESULT_SUCCESS].
+         */
+        @JvmStatic
+        fun success(): ResultResponse = from(ResponseTypes.Result.RESULT_SUCCESS)
+
+        /**
+         * Creates a ResultResponse with [ResponseTypes.Result.RESULT_FAIL].
+         */
+        @JvmStatic
+        fun fail(): ResultResponse = from(ResponseTypes.Result.RESULT_FAIL)
+
+        /**
+         * Creates a ResultResponse with [ResponseTypes.Result.RESULT_NOT_SUPPORTED].
+         */
+        @JvmStatic
+        fun notSupported(): ResultResponse = from(ResponseTypes.Result.RESULT_NOT_SUPPORTED)
+
+        /**
+         * Creates a ResultResponse with [ResponseTypes.Result.RESULT_NOT_IMPLEMENTED].
+         */
+        @JvmStatic
+        fun notImplemented(): ResultResponse = from(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED)
+    }
+}
+
+/**
+ * ManipulationResponse containing the result and the response.
+ */
+data class ManipulationResponse<T>(
+    /**
+     * Result of the manipulation.
+     */
+    override val result: ResponseTypes.Result,
+    /**
+     * Response of the manipulation.
+     */
+    val response: T
+) : Response {
+    companion object {
+        /**
+         * Creates a ManipulationResponse from a ResponseTypes.Result and response content.
+         */
+        @JvmStatic
+        fun <T> from(status: ResponseTypes.Result, response: T): ManipulationResponse<T> =
+            ManipulationResponse(status, response)
+
+        /**
+         * Creates a ManipulationResponse from a BasicResponses.BasicResponse and response content.
+         */
+        @JvmStatic
+        fun <T> from(status: BasicResponses.BasicResponse, response: T): ManipulationResponse<T> =
+            from(status.result, response)
+
+        /**
+         * Creates a ManipulationResponse with [ResponseTypes.Result.RESULT_SUCCESS] and response content.
+         */
+        @JvmStatic
+        fun <T> success(response: T): ManipulationResponse<T> = from(ResponseTypes.Result.RESULT_SUCCESS, response)
+
+        /**
+         * Creates a ManipulationResponse with [ResponseTypes.Result.RESULT_FAIL] and response content.
+         */
+        @JvmStatic
+        fun <T> fail(response: T): ManipulationResponse<T> = from(ResponseTypes.Result.RESULT_FAIL, response)
+    }
+}

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
@@ -32,7 +32,7 @@ public interface Manipulations {
     ResultResponse setLocationDetail(LocationDetail locationDetail);
 
     /**
-     * @return all descriptors which can be removed from and reinserted into the device MDIB.
+     * @return result and all descriptors which can be removed from and reinserted into the device MDIB.
      */
     ManipulationResponse<List<String>> getRemovableDescriptorsOfClass();
 
@@ -41,7 +41,7 @@ public interface Manipulations {
      * the MDIB.
      * @param descriptorType type of descriptor to filter for. Currently, only AbstractDescriptor
      *                       and MdsDescriptor are supported.
-     * @return all descriptors of the given type which can be removed from and reinserted into the device MDIB
+     * @return result and all descriptors of the given type which can be removed from and reinserted into the device MDIB
      *          and have a type matching descriptorType.
      */
     ManipulationResponse<List<String>> getRemovableDescriptorsOfClass(
@@ -75,7 +75,7 @@ public interface Manipulations {
      *
      * @param descriptorHandle to associate a new context for
      * @param association      to set for new state
-     * @return handle of the newly created state, empty if unsuccessful
+     * @return result and handle of the newly created state, empty if unsuccessful
      */
     ManipulationResponse<Optional<String>> createContextStateWithAssociation(
             String descriptorHandle, ContextAssociation association);

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
@@ -7,7 +7,6 @@
 
 package com.draeger.medical.sdccc.manipulation;
 
-import com.draeger.medical.t2iapi.ResponseTypes;
 import java.util.List;
 import java.util.Optional;
 import javax.xml.namespace.QName;
@@ -30,12 +29,12 @@ public interface Manipulations {
      * @param locationDetail new location
      * @return the result of the manipulation
      */
-    ResponseTypes.Result setLocationDetail(LocationDetail locationDetail);
+    ResultResponse setLocationDetail(LocationDetail locationDetail);
 
     /**
      * @return all descriptors which can be removed from and reinserted into the device MDIB.
      */
-    List<String> getRemovableDescriptorsOfClass();
+    ManipulationResponse<List<String>> getRemovableDescriptorsOfClass();
 
     /**
      * Retrieves a list of descriptor handles for descriptors that can be removed from and reinserted into
@@ -45,7 +44,8 @@ public interface Manipulations {
      * @return all descriptors of the given type which can be removed from and reinserted into the device MDIB
      *          and have a type matching descriptorType.
      */
-    List<String> getRemovableDescriptorsOfClass(Class<? extends AbstractDescriptor> descriptorType);
+    ManipulationResponse<List<String>> getRemovableDescriptorsOfClass(
+            Class<? extends AbstractDescriptor> descriptorType);
 
     /**
      * Removes a descriptor from the device MDIB.
@@ -53,7 +53,7 @@ public interface Manipulations {
      * @param handle to remove from the MDIB
      * @return the result of the manipulation
      */
-    ResponseTypes.Result removeDescriptor(String handle);
+    ResultResponse removeDescriptor(String handle);
 
     /**
      * Inserts a descriptor into the device MDIB.
@@ -61,14 +61,14 @@ public interface Manipulations {
      * @param handle to insert into the MDIB
      * @return the result of the manipulation
      */
-    ResponseTypes.Result insertDescriptor(String handle);
+    ResultResponse insertDescriptor(String handle);
 
     /**
      * Announce the presence of the device in the network via a WS-Discovery Hello message.
      *
      * @return the result of the manipulation
      */
-    ResponseTypes.Result sendHello();
+    ResultResponse sendHello();
 
     /**
      * Associates a <em>new</em> context state for the given descriptor handle and sets the association.
@@ -77,7 +77,8 @@ public interface Manipulations {
      * @param association      to set for new state
      * @return handle of the newly created state, empty if unsuccessful
      */
-    Optional<String> createContextStateWithAssociation(String descriptorHandle, ContextAssociation association);
+    ManipulationResponse<Optional<String>> createContextStateWithAssociation(
+            String descriptorHandle, ContextAssociation association);
 
     /**
      * Set the activation state of an alert system.
@@ -86,7 +87,7 @@ public interface Manipulations {
      * @param activationState new activation state to set
      * @return the result of the manipulation
      */
-    ResponseTypes.Result setAlertActivation(String handle, AlertActivation activationState);
+    ResultResponse setAlertActivation(String handle, AlertActivation activationState);
 
     /**
      * Set the presence attribute of an alert condition state.
@@ -95,7 +96,7 @@ public interface Manipulations {
      * @param presence new presence attribute to set
      * @return the result of the manipulation
      */
-    ResponseTypes.Result setAlertConditionPresence(String handle, boolean presence);
+    ResultResponse setAlertConditionPresence(String handle, boolean presence);
 
     /**
      * Set the system signal activation of an alert system.
@@ -105,7 +106,7 @@ public interface Manipulations {
      * @param activation    the activation state
      * @return the result of the manipulation
      */
-    ResponseTypes.Result setSystemSignalActivation(
+    ResultResponse setSystemSignalActivation(
             String handle, AlertSignalManifestation manifestation, AlertActivation activation);
 
     /**
@@ -115,7 +116,7 @@ public interface Manipulations {
      * @param activationState new activation state to set
      * @return the result of the manipulation
      */
-    ResponseTypes.Result setComponentActivation(String handle, ComponentActivation activationState);
+    ResultResponse setComponentActivation(String handle, ComponentActivation activationState);
 
     /**
      * Set the metric to a specific state to trigger the setting of the ActivationState.
@@ -126,7 +127,7 @@ public interface Manipulations {
      * @param activation the activation state the metric should have, after manipulation
      * @return the result of the manipulation
      */
-    ResponseTypes.Result setMetricStatus(
+    ResultResponse setMetricStatus(
             String sequenceId, String handle, MetricCategory category, ComponentActivation activation);
 
     /**
@@ -135,7 +136,7 @@ public interface Manipulations {
      * @param handle handle of the descriptor to trigger an Update for.
      * @return the result of the manipulation
      */
-    ResponseTypes.Result triggerDescriptorUpdate(String handle);
+    ResultResponse triggerDescriptorUpdate(String handle);
 
     /**
      * Trigger a descriptor update for the provided descriptor handles.
@@ -143,14 +144,14 @@ public interface Manipulations {
      * @param handles list of descriptor handles to trigger an update for.
      * @return the result of the manipulation
      */
-    ResponseTypes.Result triggerDescriptorUpdate(List<String> handles);
+    ResultResponse triggerDescriptorUpdate(List<String> handles);
 
     /**
      * Trigger a descriptor update for some descriptor (chosen by the device).
      *
      * @return the result of the manipulation
      */
-    ResponseTypes.Result triggerAnyDescriptorUpdate();
+    ResultResponse triggerAnyDescriptorUpdate();
 
     /**
      * Trigger a report message of the provided type.
@@ -158,5 +159,5 @@ public interface Manipulations {
      * @param reportType type of report a message should be triggered for.
      * @return the result of the manipulation
      */
-    ResponseTypes.Result triggerReport(QName reportType);
+    ResultResponse triggerReport(QName reportType);
 }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Response.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Response.kt
@@ -1,0 +1,14 @@
+package com.draeger.medical.sdccc.manipulation
+
+import com.draeger.medical.t2iapi.ResponseTypes
+import java.io.Serializable
+
+/**
+ * Basic functionality necessary for every manipulation response.
+ */
+interface Response : Serializable {
+    /**
+     * Result of the manipulation.
+     */
+    val result: ResponseTypes.Result
+}

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
@@ -124,7 +124,8 @@ public class ConditionalPreconditions {
         }
         mdibAccess = remoteDevice.getMdibAccess();
 
-        final var modifiableDescriptors = manipulations.getRemovableDescriptorsOfClass();
+        final var modifiableDescriptors =
+                manipulations.getRemovableDescriptorsOfClass().getResponse();
         logger.debug("Changing presence for descriptors {}", modifiableDescriptors);
 
         if (modifiableDescriptors.isEmpty()) {
@@ -140,7 +141,7 @@ public class ConditionalPreconditions {
 
             // if the descriptor is not present, insert it first
             if (descriptorEntity.isEmpty()) {
-                manipulationResults.add(manipulations.insertDescriptor(handle));
+                manipulationResults.add(manipulations.insertDescriptor(handle).getResult());
                 descriptorEntity = mdibAccess.getEntity(handle);
                 if (descriptorEntity.isEmpty()) {
                     manipulationResults.add(ResponseTypes.Result.RESULT_FAIL);
@@ -150,7 +151,7 @@ public class ConditionalPreconditions {
             }
 
             // remove descriptor
-            manipulationResults.add(manipulations.removeDescriptor(handle));
+            manipulationResults.add(manipulations.removeDescriptor(handle).getResult());
             descriptorEntity = mdibAccess.getEntity(handle);
             if (descriptorEntity.isPresent()) {
                 manipulationResults.add(ResponseTypes.Result.RESULT_FAIL);
@@ -159,7 +160,7 @@ public class ConditionalPreconditions {
             logger.debug("Descriptor {} presence: {}", handle, descriptorEntity.isPresent());
 
             // reinsert descriptor
-            manipulationResults.add(manipulations.insertDescriptor(handle));
+            manipulationResults.add(manipulations.insertDescriptor(handle).getResult());
             descriptorEntity = mdibAccess.getEntity(handle);
             if (descriptorEntity.isEmpty()) {
                 manipulationResults.add(ResponseTypes.Result.RESULT_FAIL);
@@ -181,7 +182,8 @@ public class ConditionalPreconditions {
     private static boolean descriptionUpdateManipulation(final Injector injector) {
         final var manipulations = injector.getInstance(Manipulations.class);
 
-        final ResponseTypes.Result manipulationResult = manipulations.triggerAnyDescriptorUpdate();
+        final ResponseTypes.Result manipulationResult =
+                manipulations.triggerAnyDescriptorUpdate().getResult();
 
         return ResponseTypes.Result.RESULT_SUCCESS.equals(manipulationResult);
     }
@@ -207,7 +209,7 @@ public class ConditionalPreconditions {
             final Injector injector, final Logger log, final QName reportType) {
         final var manipulations = injector.getInstance(Manipulations.class);
         log.info("Executing triggerReport manipulation for {}", reportType);
-        final var result = manipulations.triggerReport(reportType);
+        final var result = manipulations.triggerReport(reportType).getResult();
         return result == ResponseTypes.Result.RESULT_SUCCESS;
     }
 
@@ -237,7 +239,7 @@ public class ConditionalPreconditions {
 
         static boolean manipulation(final Injector injector) {
             final var manipulations = injector.getInstance(Manipulations.class);
-            final var result = manipulations.sendHello();
+            final var result = manipulations.sendHello().getResult();
             LOG.info("Manipulation to send Hello message was {}", result);
             return result == ResponseTypes.Result.RESULT_SUCCESS;
         }
@@ -280,8 +282,6 @@ public class ConditionalPreconditions {
      * received, triggering description modifications otherwise.
      */
     public static class DescriptionModificationUptPrecondition extends SimplePrecondition {
-
-        private static final Logger LOG = LogManager.getLogger(DescriptionModificationUptPrecondition.class);
 
         /**
          * Creates a description modification upt precondition check.
@@ -419,8 +419,9 @@ public class ConditionalPreconditions {
             }
             mdibAccess = remoteDevice.getMdibAccess();
 
-            final List<String> removableMdsDescriptors =
-                    manipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class);
+            final List<String> removableMdsDescriptors = manipulations
+                    .getRemovableDescriptorsOfClass(MdsDescriptor.class)
+                    .getResponse();
             if (removableMdsDescriptors.isEmpty()) {
                 LOG.error("No removable MdsDescriptors could be found via the GetRemovableDescriptorsOfType "
                         + "manipulation. Please check if the test case applying this precondition is applicable to "
@@ -486,7 +487,8 @@ public class ConditionalPreconditions {
                 throws UnexpectedManipulationResultException {
 
             // 1. insert
-            ResponseTypes.Result result = manipulations.insertDescriptor(initiallyAbsentMdsDescriptor);
+            ResponseTypes.Result result =
+                    manipulations.insertDescriptor(initiallyAbsentMdsDescriptor).getResult();
             LOG.info("Manipulation insertDescriptor({}) returned result {}", initiallyAbsentMdsDescriptor, result);
             switch (result) {
                 case RESULT_SUCCESS:
@@ -500,7 +502,9 @@ public class ConditionalPreconditions {
             }
 
             // 2. update
-            result = manipulations.triggerDescriptorUpdate(initiallyAbsentMdsDescriptor);
+            result = manipulations
+                    .triggerDescriptorUpdate(initiallyAbsentMdsDescriptor)
+                    .getResult();
             LOG.info(
                     "Manipulation triggerDescriptorUpdate({}) returned result {}",
                     initiallyAbsentMdsDescriptor,
@@ -517,7 +521,8 @@ public class ConditionalPreconditions {
             }
 
             // 3. remove
-            result = manipulations.removeDescriptor(initiallyAbsentMdsDescriptor);
+            result =
+                    manipulations.removeDescriptor(initiallyAbsentMdsDescriptor).getResult();
             LOG.info("Manipulation removeDescriptor({}) returned result {}", initiallyAbsentMdsDescriptor, result);
             switch (result) {
                 case RESULT_SUCCESS:
@@ -539,7 +544,9 @@ public class ConditionalPreconditions {
                 throws UnexpectedManipulationResultException {
 
             // 1. update
-            ResponseTypes.Result result = manipulations.triggerDescriptorUpdate(initiallyPresentMdsDescriptor);
+            ResponseTypes.Result result = manipulations
+                    .triggerDescriptorUpdate(initiallyPresentMdsDescriptor)
+                    .getResult();
             LOG.info(
                     "Manipulation triggerDescriptorUpdate({}) returned result {}",
                     initiallyPresentMdsDescriptor,
@@ -556,7 +563,9 @@ public class ConditionalPreconditions {
             }
 
             // 2. remove
-            result = manipulations.removeDescriptor(initiallyPresentMdsDescriptor);
+            result = manipulations
+                    .removeDescriptor(initiallyPresentMdsDescriptor)
+                    .getResult();
             LOG.info("Manipulation removeDescriptor({}) returned result {}", initiallyPresentMdsDescriptor, result);
             switch (result) {
                 case RESULT_SUCCESS:
@@ -570,7 +579,9 @@ public class ConditionalPreconditions {
             }
 
             // 3. re-insert
-            result = manipulations.insertDescriptor(initiallyPresentMdsDescriptor);
+            result = manipulations
+                    .insertDescriptor(initiallyPresentMdsDescriptor)
+                    .getResult();
             LOG.info("Manipulation insertDescriptor({}) returned result {}", initiallyPresentMdsDescriptor, result);
             switch (result) {
                 case RESULT_SUCCESS:
@@ -648,7 +659,7 @@ public class ConditionalPreconditions {
             LOG.info("Executing triggerReport manipulation for {}", reportTypes);
             final var results = new HashSet<ResponseTypes.Result>();
             for (var reportType : reportTypes) {
-                results.add(manipulations.triggerReport(reportType));
+                results.add(manipulations.triggerReport(reportType).getResult());
             }
             return results.contains(ResponseTypes.Result.RESULT_SUCCESS)
                     && !results.contains(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED)
@@ -886,7 +897,9 @@ public class ConditionalPreconditions {
                 final Collection<String> previousStateHandles,
                 final Class<? extends AbstractContextState> contextStateClass) {
             LOG.debug("Associating new context state for handle {}", handle);
-            var stateHandle = manipulations.createContextStateWithAssociation(handle, ContextAssociation.ASSOC);
+            var stateHandle = manipulations
+                    .createContextStateWithAssociation(handle, ContextAssociation.ASSOC)
+                    .getResponse();
             if (stateHandle.isEmpty()) {
                 LOG.error("Associating new context state failed for handle {}", handle);
                 return Optional.empty();

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -10,7 +10,6 @@ package com.draeger.medical.sdccc.manipulation.precondition.impl;
 import com.draeger.medical.sdccc.configuration.TestSuiteConfig;
 import com.draeger.medical.sdccc.manipulation.Manipulations;
 import com.draeger.medical.sdccc.manipulation.precondition.ManipulationPrecondition;
-import com.draeger.medical.sdccc.manipulation.precondition.PreconditionException;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClient;
 import com.draeger.medical.sdccc.tests.util.ImpliedValueUtil;
 import com.draeger.medical.sdccc.util.TestRunObserver;
@@ -95,8 +94,9 @@ public class ManipulationPreconditions {
                         .getMdibAccess()
                         .getMdibVersion()
                         .getSequenceId();
-                final var manipulationResult =
-                        manipulations.setMetricStatus(sequenceId, handle, category, activationState);
+                final var manipulationResult = manipulations
+                        .setMetricStatus(sequenceId, handle, category, activationState)
+                        .getResult();
                 log.debug(
                         "Manipulation setMetricStatus was {} for metric state with handle {}",
                         manipulationResult,
@@ -134,7 +134,8 @@ public class ManipulationPreconditions {
 
         mdibAccess = remoteDevice.getMdibAccess();
 
-        final var modifiableDescriptors = manipulations.getRemovableDescriptorsOfClass();
+        final var modifiableDescriptors =
+                manipulations.getRemovableDescriptorsOfClass().getResponse();
         if (modifiableDescriptors.isEmpty()) {
             log.info("No modifiable descriptors available for manipulation");
             return false;
@@ -148,7 +149,7 @@ public class ManipulationPreconditions {
 
             // if the descriptor is not present, insert it first
             if (descriptorEntity.isEmpty()) {
-                manipulationResults.add(manipulations.insertDescriptor(handle));
+                manipulationResults.add(manipulations.insertDescriptor(handle).getResult());
                 descriptorEntity = mdibAccess.getEntity(handle);
                 if (descriptorEntity.isEmpty()) {
                     manipulationResults.add(ResponseTypes.Result.RESULT_FAIL);
@@ -157,7 +158,7 @@ public class ManipulationPreconditions {
             }
 
             // remove descriptor
-            manipulationResults.add(manipulations.removeDescriptor(handle));
+            manipulationResults.add(manipulations.removeDescriptor(handle).getResult());
             descriptorEntity = mdibAccess.getEntity(handle);
             if (descriptorEntity.isPresent()) {
                 manipulationResults.add(ResponseTypes.Result.RESULT_FAIL);
@@ -165,7 +166,7 @@ public class ManipulationPreconditions {
             log.debug("Descriptor {} presence: {}", handle, descriptorEntity.isPresent());
 
             // reinsert descriptor
-            manipulationResults.add(manipulations.insertDescriptor(handle));
+            manipulationResults.add(manipulations.insertDescriptor(handle).getResult());
             descriptorEntity = mdibAccess.getEntity(handle);
             if (descriptorEntity.isEmpty()) {
                 manipulationResults.add(ResponseTypes.Result.RESULT_FAIL);
@@ -196,8 +197,9 @@ public class ManipulationPreconditions {
         final String childDescriptorHandle = descriptorHandles.getRight();
         final var manipulations = injector.getInstance(Manipulations.class);
 
-        final ResponseTypes.Result manipulationResult =
-                manipulations.triggerDescriptorUpdate(List.of(childDescriptorHandle, parentDescriptorHandle));
+        final ResponseTypes.Result manipulationResult = manipulations
+                .triggerDescriptorUpdate(List.of(childDescriptorHandle, parentDescriptorHandle))
+                .getResult();
 
         return ResponseTypes.Result.RESULT_SUCCESS.equals(manipulationResult);
     }
@@ -311,7 +313,9 @@ public class ManipulationPreconditions {
                 final String handle,
                 final Collection<String> previousStateHandles) {
             LOG.debug("Associating new patient for handle {}", handle);
-            var stateHandle = manipulations.createContextStateWithAssociation(handle, ContextAssociation.ASSOC);
+            var stateHandle = manipulations
+                    .createContextStateWithAssociation(handle, ContextAssociation.ASSOC)
+                    .getResponse();
             if (stateHandle.isEmpty()) {
                 LOG.error("Associating new patient failed for handle {}", handle);
                 return Optional.empty();
@@ -405,8 +409,9 @@ public class ManipulationPreconditions {
                         .getFirstState(AbstractDeviceComponentState.class)
                         .orElseThrow();
 
-                final ResponseTypes.Result result =
-                        manipulations.setComponentActivation(state.getDescriptorHandle(), ComponentActivation.OFF);
+                final ResponseTypes.Result result = manipulations
+                        .setComponentActivation(state.getDescriptorHandle(), ComponentActivation.OFF)
+                        .getResult();
 
                 switch (result) {
                     case RESULT_NOT_SUPPORTED:
@@ -511,7 +516,9 @@ public class ManipulationPreconditions {
                 final String handle,
                 final Collection<String> previousStateHandles) {
             LOG.debug("Associating new location for handle {}", handle);
-            var stateHandle = manipulations.createContextStateWithAssociation(handle, ContextAssociation.ASSOC);
+            var stateHandle = manipulations
+                    .createContextStateWithAssociation(handle, ContextAssociation.ASSOC)
+                    .getResponse();
             if (stateHandle.isEmpty()) {
                 LOG.error("Associating new location failed for handle {}", handle);
                 return Optional.empty();
@@ -735,7 +742,8 @@ public class ManipulationPreconditions {
                 final String handle,
                 final AlertActivation activationState) {
             LOG.debug("Setting the activation state {} for handle {}", activationState, handle);
-            var manipulationResult = manipulations.setAlertActivation(handle, activationState);
+            var manipulationResult =
+                    manipulations.setAlertActivation(handle, activationState).getResult();
             switch (manipulationResult) {
                 case RESULT_SUCCESS -> {
                     LOG.debug("Setting the activation state {} for handle {} was successful", activationState, handle);
@@ -864,7 +872,8 @@ public class ManipulationPreconditions {
                 final String handle,
                 final boolean presence) {
             LOG.debug("Setting the presence attribute {} for handle {}", presence, handle);
-            var manipulationResult = manipulations.setAlertConditionPresence(handle, presence);
+            var manipulationResult =
+                    manipulations.setAlertConditionPresence(handle, presence).getResult();
             switch (manipulationResult) {
                 case RESULT_SUCCESS -> {
                     LOG.debug("Setting the presence {} for handle {} was successful", presence, handle);
@@ -903,7 +912,8 @@ public class ManipulationPreconditions {
                 final String handle,
                 final AlertActivation activation) {
             LOG.debug("Setting the activation state {} for handle {}", activation, handle);
-            var manipulationResult = manipulations.setAlertActivation(handle, activation);
+            var manipulationResult =
+                    manipulations.setAlertActivation(handle, activation).getResult();
             switch (manipulationResult) {
                 case RESULT_SUCCESS -> {
                     LOG.debug("Setting the activation state {} for handle {} was successful", activation, handle);
@@ -1010,7 +1020,7 @@ public class ManipulationPreconditions {
                     alertSystemEntities.size());
             for (MdibEntity alertSystemEntity : alertSystemEntities) {
 
-                final var manipulationResults = new HashSet<ResponseTypes.Result>(setSystemSignalActivation(
+                final var manipulationResults = new HashSet<>(setSystemSignalActivation(
                         testClient.getSdcRemoteDevice(),
                         manipulations,
                         alertSystemEntity.getHandle(),
@@ -1103,7 +1113,7 @@ public class ManipulationPreconditions {
          * @param manifestation     the manifestation of the system signal activation
          * @param childAlertSignals the alert signals of the alert system
          * @param testRunObserver   to register unexpected failures during test run
-         * @return true if successful, false otherwise
+         * @return a set of results of the manipulations
          */
         static Set<ResponseTypes.Result> setSystemSignalActivation(
                 final SdcRemoteDevice sdcRemoteDevice,
@@ -1156,7 +1166,9 @@ public class ManipulationPreconditions {
 
             LOG.debug("Setting the system signal activation attribute {} for handle {}", activation, handle);
 
-            var manipulationResult = manipulations.setSystemSignalActivation(handle, manifestation, activation);
+            var manipulationResult = manipulations
+                    .setSystemSignalActivation(handle, manifestation, activation)
+                    .getResult();
             if (manipulationResult != ResponseTypes.Result.RESULT_SUCCESS
                     && manipulationResult != ResponseTypes.Result.RESULT_NOT_SUPPORTED) {
                 LOG.error("Setting the system signal activation attribute {} for handle {} failed", activation, handle);
@@ -1169,7 +1181,9 @@ public class ManipulationPreconditions {
             }
 
             for (var child : childAlertSignals) {
-                final var childActivation = manipulations.setAlertActivation(child.getDescriptorHandle(), activation);
+                final var childActivation = manipulations
+                        .setAlertActivation(child.getDescriptorHandle(), activation)
+                        .getResult();
                 if (childActivation != ResponseTypes.Result.RESULT_SUCCESS
                         && childActivation != ResponseTypes.Result.RESULT_NOT_SUPPORTED) {
                     LOG.error(
@@ -1744,7 +1758,6 @@ public class ManipulationPreconditions {
          *
          * @param injector to analyze mdib on
          * @return true if successful, false otherwise
-         * @throws PreconditionException on errors
          */
         static boolean manipulation(final Injector injector) {
             final boolean result1 = removeAndReinsertDescriptors(injector, LOG);

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTest.java
@@ -89,8 +89,9 @@ public class DirectParticipantModelContextStateTest extends InjectorTestBase {
         if (contextDescriptor == null) {
             return 0;
         }
-        final var newHandle = manipulations.createContextStateWithAssociation(
-                contextDescriptor.getHandle(), ContextAssociation.ASSOC);
+        final var newHandle = manipulations
+                .createContextStateWithAssociation(contextDescriptor.getHandle(), ContextAssociation.ASSOC)
+                .getResponse();
         assertTrue(
                 newHandle.isPresent(),
                 String.format("Manipulation was unsuccessful for handle %s", contextDescriptor.getHandle()));

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
@@ -38,6 +38,7 @@ import com.draeger.medical.sdccc.util.Constants;
 import com.draeger.medical.sdccc.util.MessageBuilder;
 import com.draeger.medical.sdccc.util.MessageStorageUtil;
 import com.draeger.medical.sdccc.util.TestRunObserver;
+import com.draeger.medical.t2iapi.ResponseTypes;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -1744,7 +1745,7 @@ public class ConditionalPreconditionsTest {
 
         // Manipulation of WorkflowContext is not supported
         when(mockManipulations.createContextStateWithAssociation(eq(WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE), any()))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED, Optional.empty()));
 
         final var expectedContextStateHandleCount = Map.of(
                 MEANS_CONTEXT_DESCRIPTOR_HANDLE, 2L,

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
@@ -23,7 +23,9 @@ import com.draeger.medical.biceps.model.message.DescriptionModificationType;
 import com.draeger.medical.biceps.model.participant.AbstractContextState;
 import com.draeger.medical.biceps.model.participant.AbstractDescriptor;
 import com.draeger.medical.biceps.model.participant.ObjectFactory;
+import com.draeger.medical.sdccc.manipulation.ManipulationResponse;
 import com.draeger.medical.sdccc.manipulation.Manipulations;
+import com.draeger.medical.sdccc.manipulation.ResultResponse;
 import com.draeger.medical.sdccc.manipulation.precondition.PreconditionException;
 import com.draeger.medical.sdccc.marshalling.MarshallingUtil;
 import com.draeger.medical.sdccc.messages.MessageStorage;
@@ -36,7 +38,6 @@ import com.draeger.medical.sdccc.util.Constants;
 import com.draeger.medical.sdccc.util.MessageBuilder;
 import com.draeger.medical.sdccc.util.MessageStorageUtil;
 import com.draeger.medical.sdccc.util.TestRunObserver;
-import com.draeger.medical.t2iapi.ResponseTypes;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -255,9 +256,7 @@ public class ConditionalPreconditionsTest {
     @DisplayName("HelloMessagePrecondition correctly calls manipulation")
     public void testHelloMessageManipulation() {
         final var manipulations = mock(Manipulations.class);
-        when(manipulations.sendHello())
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+        when(manipulations.sendHello()).thenReturn(ResultResponse.success()).thenReturn(ResultResponse.fail());
 
         final var injector = Guice.createInjector(new AbstractModule() {
             @Override
@@ -317,15 +316,15 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass())
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(testClient.getSdcRemoteDevice().getMdibAccess().getEntity(anyString()))
                 .thenAnswer((Answer<Optional<MdibEntity>>) invocation -> {
@@ -422,15 +421,15 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass())
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(testClient.getSdcRemoteDevice().getMdibAccess().getEntity(anyString()))
                 .thenAnswer((Answer<Optional<MdibEntity>>) invocation -> {
@@ -561,7 +560,7 @@ public class ConditionalPreconditionsTest {
     @Test
     @DisplayName("DescriptionModificationUptPrecondition correctly calls manipulation")
     public void testDescriptionModificationUptManipulation() {
-        when(mockManipulations.triggerAnyDescriptorUpdate()).thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+        when(mockManipulations.triggerAnyDescriptorUpdate()).thenReturn(ResultResponse.success());
 
         new ConditionalPreconditions.DescriptionModificationUptPrecondition();
 
@@ -624,15 +623,15 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass())
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(testClient.getSdcRemoteDevice().getMdibAccess().getEntity(anyString()))
                 .thenAnswer((Answer<Optional<MdibEntity>>) invocation -> {
@@ -682,6 +681,8 @@ public class ConditionalPreconditionsTest {
     @DisplayName("DescriptionModificationPrecondition throws exception if no removable descriptors are present")
     void testDescriptionModificationModificationNoDescriptors() {
         // must fail without any removable descriptors
+        when(mockManipulations.getRemovableDescriptorsOfClass())
+                .thenReturn(ManipulationResponse.fail(Collections.emptyList()));
         assertFalse(ConditionalPreconditions.DescriptionModificationCrtOrDelPrecondition.manipulation(testInjector));
         reset(mockManipulations);
     }
@@ -701,18 +702,18 @@ public class ConditionalPreconditionsTest {
         final var presenceMap = new HashMap<>(Map.of(descriptor1Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_SUCCESS);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.success());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -756,18 +757,18 @@ public class ConditionalPreconditionsTest {
         final var presenceMap = new HashMap<>(Map.of(descriptor1Handle, false));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_SUCCESS);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.success());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -814,23 +815,23 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, false));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             final String handle = invocation.getArgument(0);
             if (descriptor1Handle.equals(handle)) {
-                return ResponseTypes.Result.RESULT_NOT_SUPPORTED;
+                return ResultResponse.notSupported();
             } else {
                 presenceMap.put(handle, true);
-                return ResponseTypes.Result.RESULT_SUCCESS;
+                return ResultResponse.success();
             }
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_SUCCESS);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.success());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -880,23 +881,23 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             final String handle = invocation.getArgument(0);
             if (descriptor1Handle.equals(handle)) {
-                return ResponseTypes.Result.RESULT_NOT_SUPPORTED;
+                return ResultResponse.notSupported();
             } else {
                 presenceMap.put(handle, false);
-                return ResponseTypes.Result.RESULT_SUCCESS;
+                return ResultResponse.success();
             }
         });
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_SUCCESS);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.success());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -946,25 +947,24 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
-                    final String handle = invocation.getArgument(0);
-                    if (descriptor1Handle.equals(handle)) {
-                        return ResponseTypes.Result.RESULT_NOT_SUPPORTED;
-                    } else {
-                        return ResponseTypes.Result.RESULT_SUCCESS;
-                    }
-                });
+        when(mockManipulations.triggerDescriptorUpdate(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
+            final String handle = invocation.getArgument(0);
+            if (descriptor1Handle.equals(handle)) {
+                return ResultResponse.notSupported();
+            } else {
+                return ResultResponse.success();
+            }
+        });
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -1013,16 +1013,16 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
         when(mockManipulations.insertDescriptor(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.notSupported());
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_SUCCESS);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.success());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -1069,16 +1069,16 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(mockManipulations.removeDescriptor(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.notSupported());
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_SUCCESS);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.success());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -1126,18 +1126,18 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.notSupported());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -1187,22 +1187,22 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
             if (invocation.getArgument(0).equals(descriptor1Handle)) {
-                return ResponseTypes.Result.RESULT_FAIL;
+                return ResultResponse.fail();
             } else {
-                return ResponseTypes.Result.RESULT_SUCCESS;
+                return ResultResponse.success();
             }
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_SUCCESS);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.success());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -1246,24 +1246,23 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
-                    if (invocation.getArgument(0).equals(descriptor1Handle)) {
-                        return ResponseTypes.Result.RESULT_FAIL;
-                    } else {
-                        return ResponseTypes.Result.RESULT_SUCCESS;
-                    }
-                });
+        when(mockManipulations.triggerDescriptorUpdate(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
+            if (invocation.getArgument(0).equals(descriptor1Handle)) {
+                return ResultResponse.fail();
+            } else {
+                return ResultResponse.success();
+            }
+        });
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -1309,18 +1308,18 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_FAIL;
+            return ResultResponse.fail();
         });
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_SUCCESS);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.success());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -1368,22 +1367,22 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
             if (invocation.getArgument(0).equals(descriptor1Handle)) {
-                return ResponseTypes.Result.RESULT_FAIL;
+                return ResultResponse.fail();
             } else {
-                return ResponseTypes.Result.RESULT_SUCCESS;
+                return ResultResponse.success();
             }
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_SUCCESS);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.success());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -1426,24 +1425,23 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
-                    if (invocation.getArgument(0).equals(descriptor1Handle)) {
-                        return ResponseTypes.Result.RESULT_FAIL;
-                    } else {
-                        return ResponseTypes.Result.RESULT_SUCCESS;
-                    }
-                });
+        when(mockManipulations.triggerDescriptorUpdate(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
+            if (invocation.getArgument(0).equals(descriptor1Handle)) {
+                return ResultResponse.fail();
+            } else {
+                return ResultResponse.success();
+            }
+        });
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -1487,18 +1485,18 @@ public class ConditionalPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass(MdsDescriptor.class))
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_FAIL;
+            return ResultResponse.fail();
         });
         when(mockManipulations.triggerDescriptorUpdate(anyString()))
-                .thenAnswer((Answer<ResponseTypes.Result>) invocation -> ResponseTypes.Result.RESULT_SUCCESS);
+                .thenAnswer((Answer<ResultResponse>) invocation -> ResultResponse.success());
         when(testClient.getSdcRemoteDevice().getMdibAccess().getDescriptor(anyString()))
                 .thenAnswer((Answer<Optional<AbstractDescriptor>>) invocation -> {
                     final String handle = invocation.getArgument(0);
@@ -1746,7 +1744,7 @@ public class ConditionalPreconditionsTest {
 
         // Manipulation of WorkflowContext is not supported
         when(mockManipulations.createContextStateWithAssociation(eq(WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE), any()))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         final var expectedContextStateHandleCount = Map.of(
                 MEANS_CONTEXT_DESCRIPTOR_HANDLE, 2L,
@@ -1941,9 +1939,9 @@ public class ConditionalPreconditionsTest {
             // introduce error, manipulation returns same handle twice
             when(mockManipulations.createContextStateWithAssociation(
                             PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(Optional.of(PATIENT_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.of(PATIENT_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.empty());
+                    .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -1951,9 +1949,9 @@ public class ConditionalPreconditionsTest {
             associateAllContextStatesSetup();
             when(mockManipulations.createContextStateWithAssociation(
                             LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(Optional.of(LOCATION_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.of(LOCATION_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.empty());
+                    .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -1961,9 +1959,9 @@ public class ConditionalPreconditionsTest {
             associateAllContextStatesSetup();
             when(mockManipulations.createContextStateWithAssociation(
                             ENSEMBLE_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.empty());
+                    .thenReturn(ManipulationResponse.success(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.success(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -1971,9 +1969,9 @@ public class ConditionalPreconditionsTest {
             associateAllContextStatesSetup();
             when(mockManipulations.createContextStateWithAssociation(
                             MEANS_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(Optional.of(MEANS_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.of(MEANS_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.empty());
+                    .thenReturn(ManipulationResponse.success(Optional.of(MEANS_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.success(Optional.of(MEANS_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -1981,9 +1979,9 @@ public class ConditionalPreconditionsTest {
             associateAllContextStatesSetup();
             when(mockManipulations.createContextStateWithAssociation(
                             OPERATOR_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.empty());
+                    .thenReturn(ManipulationResponse.success(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.success(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -1991,9 +1989,9 @@ public class ConditionalPreconditionsTest {
             associateAllContextStatesSetup();
             when(mockManipulations.createContextStateWithAssociation(
                             WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE))
-                    .thenReturn(Optional.empty());
+                    .thenReturn(ManipulationResponse.success(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.success(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE)))
+                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -2063,44 +2061,44 @@ public class ConditionalPreconditionsTest {
         // make manipulation return our two patient context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(PATIENT_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.of(PATIENT_CONTEXT_STATE_HANDLE2))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE2)))
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         // make manipulation return our two location context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(LOCATION_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.of(LOCATION_CONTEXT_STATE_HANDLE2))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE2)))
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         // make manipulation return our two ensemble context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         ENSEMBLE_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE2))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.success(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.success(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE2)))
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         // make manipulation return our two means context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         MEANS_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(MEANS_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.of(MEANS_CONTEXT_STATE_HANDLE2))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.success(Optional.of(MEANS_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.success(Optional.of(MEANS_CONTEXT_STATE_HANDLE2)))
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         // make manipulation return our two operator context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         OPERATOR_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE2))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.success(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.success(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE2)))
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         // make manipulation return our two workflow context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE2))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.success(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.success(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE2)))
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         // return mock states on request
         when(mockDevice.getMdibAccess().getState(PATIENT_CONTEXT_STATE_HANDLE, PatientContextState.class))
@@ -2344,8 +2342,8 @@ public class ConditionalPreconditionsTest {
         // TriggerEpisodicAlertReportPrecondition
         {
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_ALERT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
 
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
@@ -2364,8 +2362,8 @@ public class ConditionalPreconditionsTest {
         // TriggerEpisodicComponentReportPrecondition
         {
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_COMPONENT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
 
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
@@ -2384,8 +2382,8 @@ public class ConditionalPreconditionsTest {
         // TriggerEpisodicContextReportPrecondition
         {
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_CONTEXT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
 
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
@@ -2404,8 +2402,8 @@ public class ConditionalPreconditionsTest {
         // TriggerEpisodicMetricReportPrecondition
         {
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_METRIC_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
 
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
@@ -2424,8 +2422,8 @@ public class ConditionalPreconditionsTest {
         // TriggerEpisodicOperationalStateReportPrecondition
         {
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_OPERATIONAL_STATE_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
 
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
@@ -2446,8 +2444,8 @@ public class ConditionalPreconditionsTest {
         // TriggerOperationInvokedReportPrecondition
         {
             when(manipulations.triggerReport(Constants.MSG_OPERATION_INVOKED_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
 
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
@@ -2466,8 +2464,8 @@ public class ConditionalPreconditionsTest {
         // TriggerDescriptionModificationReportPrecondition
         {
             when(manipulations.triggerReport(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
 
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
@@ -2561,20 +2559,20 @@ public class ConditionalPreconditionsTest {
         {
             final var manipulations = mock(Manipulations.class);
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_ALERT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_COMPONENT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_METRIC_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_OPERATIONAL_STATE_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_CONTEXT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
                 protected void configure() {
@@ -2589,16 +2587,16 @@ public class ConditionalPreconditionsTest {
         {
             final var manipulations = mock(Manipulations.class);
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_ALERT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                    .thenReturn(ResultResponse.notSupported());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_COMPONENT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                    .thenReturn(ResultResponse.notSupported());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_METRIC_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                    .thenReturn(ResultResponse.notSupported());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_OPERATIONAL_STATE_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                    .thenReturn(ResultResponse.notSupported());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_CONTEXT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.success())
+                    .thenReturn(ResultResponse.fail());
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
                 protected void configure() {
@@ -2613,15 +2611,15 @@ public class ConditionalPreconditionsTest {
         {
             final var manipulations = mock(Manipulations.class);
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_ALERT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                    .thenReturn(ResultResponse.success());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_COMPONENT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                    .thenReturn(ResultResponse.success());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_METRIC_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED);
+                    .thenReturn(ResultResponse.notImplemented());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_OPERATIONAL_STATE_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                    .thenReturn(ResultResponse.success());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_CONTEXT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                    .thenReturn(ResultResponse.success());
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
                 protected void configure() {
@@ -2635,15 +2633,15 @@ public class ConditionalPreconditionsTest {
         {
             final var manipulations = mock(Manipulations.class);
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_ALERT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                    .thenReturn(ResultResponse.success());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_COMPONENT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                    .thenReturn(ResultResponse.success());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_METRIC_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                    .thenReturn(ResultResponse.success());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_OPERATIONAL_STATE_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                    .thenReturn(ResultResponse.fail());
             when(manipulations.triggerReport(Constants.MSG_EPISODIC_CONTEXT_REPORT))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                    .thenReturn(ResultResponse.success());
             final var injector = Guice.createInjector(new AbstractModule() {
                 @Override
                 protected void configure() {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -24,7 +24,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.draeger.medical.sdccc.configuration.TestSuiteConfig;
+import com.draeger.medical.sdccc.manipulation.ManipulationResponse;
 import com.draeger.medical.sdccc.manipulation.Manipulations;
+import com.draeger.medical.sdccc.manipulation.ResultResponse;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClient;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClientUtil;
 import com.draeger.medical.sdccc.tests.InjectorTestBase;
@@ -234,9 +236,9 @@ public class ManipulationPreconditionsTest {
         // make manipulation return our two patient context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(PATIENT_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.of(PATIENT_CONTEXT_STATE_HANDLE2))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE2)))
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         // return mock states on request
         when(mockDevice.getMdibAccess().getState(PATIENT_CONTEXT_STATE_HANDLE, PatientContextState.class))
@@ -265,9 +267,9 @@ public class ManipulationPreconditionsTest {
         // make manipulation return our two location context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(LOCATION_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.of(LOCATION_CONTEXT_STATE_HANDLE2))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE2)))
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         // return mock states on request
         when(mockDevice.getMdibAccess().getState(LOCATION_CONTEXT_STATE_HANDLE, LocationContextState.class))
@@ -354,9 +356,9 @@ public class ManipulationPreconditionsTest {
         // introduce error, manipulation returns same handle twice
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(PATIENT_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.of(PATIENT_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         assertFalse(
                 ManipulationPreconditions.AssociatePatientsManipulation.manipulation(injector),
@@ -803,9 +805,9 @@ public class ManipulationPreconditionsTest {
         // introduce error, manipulation returns same handle twice
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(LOCATION_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.of(LOCATION_CONTEXT_STATE_HANDLE))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
 
         final MdibAccessObservable mockMdibAccessObservable = mock(MdibAccessObservable.class);
         when(mockTestClient.getSdcRemoteDevice().getMdibAccessObservable()).thenReturn(mockMdibAccessObservable);
@@ -926,9 +928,8 @@ public class ManipulationPreconditionsTest {
     void testSetPresenceForAlertConditionSuccessful() {
         alertConditionPresenceManipulationSetup();
         when(mockManipulations.setAlertActivation(anyString(), eq(AlertActivation.OFF)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-        when(mockManipulations.setAlertConditionPresence(anyString(), eq(true)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.success());
+        when(mockManipulations.setAlertConditionPresence(anyString(), eq(true))).thenReturn(ResultResponse.success());
 
         assertTrue(
                 ManipulationPreconditions.AlertConditionPresenceManipulation.manipulation(injector),
@@ -949,12 +950,12 @@ public class ManipulationPreconditionsTest {
     void testSetPresenceForAlertConditionAllowNotSupported1() {
         alertConditionPresenceManipulationSetup();
         when(mockManipulations.setAlertActivation(anyString(), eq(AlertActivation.OFF)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.success());
         // setAlertConditionPresence is not supported for first alert condition
         when(mockManipulations.setAlertConditionPresence(ALERT_CONDITION_HANDLE, true))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED));
         when(mockManipulations.setAlertConditionPresence(ALERT_CONDITION_HANDLE2, true))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.success());
 
         assertTrue(
                 ManipulationPreconditions.AlertConditionPresenceManipulation.manipulation(injector),
@@ -978,9 +979,8 @@ public class ManipulationPreconditionsTest {
         alertConditionPresenceManipulationSetup();
         // manipulation of alert activation is not supported from DUT
         when(mockManipulations.setAlertActivation(anyString(), eq(AlertActivation.OFF)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
-        when(mockManipulations.setAlertConditionPresence(anyString(), eq(true)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED));
+        when(mockManipulations.setAlertConditionPresence(anyString(), eq(true))).thenReturn(ResultResponse.success());
 
         assertTrue(
                 ManipulationPreconditions.AlertConditionPresenceManipulation.manipulation(injector),
@@ -1001,9 +1001,8 @@ public class ManipulationPreconditionsTest {
         alertConditionPresenceManipulationSetup();
         // manipulation of alert activation fails
         when(mockManipulations.setAlertActivation(anyString(), eq(AlertActivation.OFF)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
-        when(mockManipulations.setAlertConditionPresence(anyString(), eq(true)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.fail());
+        when(mockManipulations.setAlertConditionPresence(anyString(), eq(true))).thenReturn(ResultResponse.success());
 
         // precondition should return false, since RESULT_FAIL was seen
         assertFalse(
@@ -1028,9 +1027,8 @@ public class ManipulationPreconditionsTest {
         alertConditionPresenceManipulationSetup();
         // manipulation of alert activation fails
         when(mockManipulations.setAlertActivation(anyString(), eq(AlertActivation.OFF)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED);
-        when(mockManipulations.setAlertConditionPresence(anyString(), eq(true)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED));
+        when(mockManipulations.setAlertConditionPresence(anyString(), eq(true))).thenReturn(ResultResponse.success());
 
         // precondition should return false, since RESULT_NOT_IMPLEMENTED was seen
         assertFalse(
@@ -1055,9 +1053,8 @@ public class ManipulationPreconditionsTest {
         alertConditionPresenceManipulationSetup();
         // manipulation of alert activation fails
         when(mockManipulations.setAlertActivation(anyString(), eq(AlertActivation.OFF)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
-        when(mockManipulations.setAlertConditionPresence(anyString(), eq(true)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.success());
+        when(mockManipulations.setAlertConditionPresence(anyString(), eq(true))).thenReturn(ResultResponse.fail());
 
         // precondition should return false, since RESULT_NOT_IMPLEMENTED was seen
         assertFalse(
@@ -1082,9 +1079,9 @@ public class ManipulationPreconditionsTest {
         alertConditionPresenceManipulationSetup();
         // manipulation of alert activation fails
         when(mockManipulations.setAlertActivation(anyString(), eq(AlertActivation.OFF)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.success());
         when(mockManipulations.setAlertConditionPresence(anyString(), eq(true)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED));
 
         // precondition should return false, since RESULT_NOT_IMPLEMENTED was seen
         assertFalse(
@@ -1138,13 +1135,13 @@ public class ManipulationPreconditionsTest {
 
         // make manipulation return true for the manipulations and false afterwards
         when(mockManipulations.setAlertActivation(any(String.class), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.fail());
 
         final var expectedManipulationCalls = 6;
         final var expectedActivationStates = List.of(
@@ -1185,16 +1182,16 @@ public class ManipulationPreconditionsTest {
         setActivationStateSetup();
         // let one alert system not support manipulations
         when(mockManipulations.setAlertActivation(eq(ALERT_SYSTEM_CONTEXT_HANDLE), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED));
         // make manipulation for the other alert system return true for the manipulations and false afterwards
         when(mockManipulations.setAlertActivation(eq(ALERT_SYSTEM_CONTEXT_HANDLE2), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.fail());
 
         final var expectedManipulationCalls = 6;
         final var expectedActivationStates = List.of(
@@ -1234,13 +1231,13 @@ public class ManipulationPreconditionsTest {
         setActivationStateSetup();
         // make manipulation return true for the manipulations and false afterwards
         when(mockManipulations.setAlertActivation(any(String.class), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.fail());
 
         when(mockAlertSystemState.getActivationState()).thenReturn(AlertActivation.OFF);
 
@@ -1282,11 +1279,11 @@ public class ManipulationPreconditionsTest {
         // let setMetricStatus manipulation for first handle be successful
         when(mockManipulations.setMetricStatus(
                         eq(MdibBuilder.DEFAULT_SEQUENCE_ID), eq(metricHandle), eq(category), eq(endState)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.success());
         // let setMetricStatus manipulation for second handle be successful
         when(mockManipulations.setMetricStatus(
                         eq(MdibBuilder.DEFAULT_SEQUENCE_ID), eq(otherMetricHandle), eq(category), eq(endState)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.success());
     }
 
     // the argument source for the setMetricStatus preconditions
@@ -1430,7 +1427,7 @@ public class ManipulationPreconditionsTest {
         // let one metric not support setMetricStatus manipulation
         when(mockManipulations.setMetricStatus(
                         any(String.class), eq(SOME_HANDLE), any(MetricCategory.class), any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED));
 
         assertTrue(manipulation.apply(injector));
 
@@ -1455,7 +1452,7 @@ public class ManipulationPreconditionsTest {
                         any(String.class),
                         any(MetricCategory.class),
                         any(ComponentActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.fail());
 
         assertFalse(manipulation.apply(injector));
 
@@ -1484,9 +1481,9 @@ public class ManipulationPreconditionsTest {
         setupRemoveAndReinsertDescriptor(SOME_HANDLE, List.of(SOME_HANDLE));
 
         when(mockManipulations.insertDescriptor(any(String.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.fail());
 
         when(mockDevice.getMdibAccess().getEntity(anyString()))
                 .thenReturn(Optional.empty())
@@ -1524,7 +1521,7 @@ public class ManipulationPreconditionsTest {
     void testRemoveAndReinsertDescriptorManipulationBad2() {
         setupRemoveAndReinsertDescriptor(SOME_HANDLE, List.of(SOME_HANDLE));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenReturn(ResponseTypes.Result.RESULT_FAIL);
+        when(mockManipulations.insertDescriptor(anyString())).thenReturn(ResultResponse.fail());
         assertFalse(ManipulationPreconditions.RemoveAndReinsertDescriptorManipulation.manipulation(injector));
         assertTrue(testRunObserver.isInvalid(), "Test run should have been invalidated.");
 
@@ -1538,7 +1535,7 @@ public class ManipulationPreconditionsTest {
     void testRemoveAndReinsertDescriptorManipulationBad3() {
         setupRemoveAndReinsertDescriptor(SOME_HANDLE, List.of(SOME_HANDLE));
 
-        when(mockManipulations.removeDescriptor(anyString())).thenReturn(ResponseTypes.Result.RESULT_FAIL);
+        when(mockManipulations.removeDescriptor(anyString())).thenReturn(ResultResponse.fail());
         assertFalse(ManipulationPreconditions.RemoveAndReinsertDescriptorManipulation.manipulation(injector));
         assertTrue(testRunObserver.isInvalid(), "Test run should have been invalidated.");
 
@@ -1549,15 +1546,16 @@ public class ManipulationPreconditionsTest {
 
     private void setupRemoveAndReinsertDescriptor(
             final String descriptorHandle, final List<String> removableDescriptors) {
-        when(mockManipulations.getRemovableDescriptorsOfClass()).thenReturn(removableDescriptors);
+        when(mockManipulations.getRemovableDescriptorsOfClass())
+                .thenReturn(ManipulationResponse.success(removableDescriptors));
 
         when(mockManipulations.removeDescriptor(any(String.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.fail());
 
         when(mockManipulations.insertDescriptor(any(String.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS)
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.success())
+                .thenReturn(ResultResponse.fail());
 
         when(mockEntity.getHandle()).thenReturn(descriptorHandle);
         when(mockDevice.getMdibAccess().getEntity(anyString()))
@@ -1570,7 +1568,7 @@ public class ManipulationPreconditionsTest {
         final var entities = new ArrayList<MdibEntity>();
         for (var state : states) {
             when(mockManipulations.setComponentActivation(state.getDescriptorHandle(), ComponentActivation.OFF))
-                    .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                    .thenReturn(ResultResponse.success());
             final var mock = mock(MdibEntity.class);
             when(mock.getFirstState(AbstractDeviceComponentState.class)).thenReturn(Optional.of(state));
             entities.add(mock);
@@ -1622,7 +1620,7 @@ public class ManipulationPreconditionsTest {
         setUpAbstractDeviceComponentStateOFFManipulation(mockVmdState);
         // let all manipulations return not supported
         when(mockManipulations.setComponentActivation(anyString(), eq(ComponentActivation.OFF)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED));
 
         assertFalse(ManipulationPreconditions.AbstractDeviceComponentStateOFFManipulation.manipulation(injector));
 
@@ -1638,7 +1636,7 @@ public class ManipulationPreconditionsTest {
         setUpAbstractDeviceComponentStateOFFManipulation(mockVmdState, mockVmdState2);
         // let manipulation for first vmd return not supported
         when(mockManipulations.setComponentActivation(VMD_HANDLE, ComponentActivation.OFF))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED));
 
         assertTrue(ManipulationPreconditions.AbstractDeviceComponentStateOFFManipulation.manipulation(injector));
 
@@ -1655,7 +1653,7 @@ public class ManipulationPreconditionsTest {
         setUpAbstractDeviceComponentStateOFFManipulation(mockScoState, mockClockState);
         // let one manipulation fail
         when(mockManipulations.setComponentActivation(CLOCK_HANDLE, ComponentActivation.OFF))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.fail());
 
         assertFalse(ManipulationPreconditions.AbstractDeviceComponentStateOFFManipulation.manipulation(injector));
 
@@ -1673,7 +1671,7 @@ public class ManipulationPreconditionsTest {
         setUpAbstractDeviceComponentStateOFFManipulation(mockScoState, mockClockState);
         // let one manipulation return not implemented
         when(mockManipulations.setComponentActivation(CLOCK_HANDLE, ComponentActivation.OFF))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED));
 
         assertFalse(ManipulationPreconditions.AbstractDeviceComponentStateOFFManipulation.manipulation(injector));
 
@@ -1730,9 +1728,9 @@ public class ManipulationPreconditionsTest {
                 .thenReturn(Optional.of(mockAlertSystemState));
         when(mockManipulations.setSystemSignalActivation(
                         anyString(), any(AlertSignalManifestation.class), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.success());
         when(mockManipulations.setAlertActivation(anyString(), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+                .thenReturn(ResultResponse.success());
     }
 
     private void buildSystemSignalActivation(
@@ -1816,7 +1814,7 @@ public class ManipulationPreconditionsTest {
         setUpSystemSignalActivation();
         when(mockManipulations.setSystemSignalActivation(
                         anyString(), any(AlertSignalManifestation.class), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED));
 
         assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
@@ -1828,7 +1826,7 @@ public class ManipulationPreconditionsTest {
         setUpSystemSignalActivation();
         when(mockManipulations.setSystemSignalActivation(
                         anyString(), eq(AlertSignalManifestation.OTH), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED));
 
         assertTrue(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
@@ -1839,7 +1837,7 @@ public class ManipulationPreconditionsTest {
     void testSystemSignalActivationChildNotSupported() {
         setUpSystemSignalActivation();
         when(mockManipulations.setAlertActivation(anyString(), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_SUPPORTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED));
 
         assertTrue(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
@@ -1850,7 +1848,7 @@ public class ManipulationPreconditionsTest {
     void testSystemSignalActivationChildNotImplemented() {
         setUpSystemSignalActivation();
         when(mockManipulations.setAlertActivation(anyString(), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED));
 
         assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
@@ -1860,7 +1858,7 @@ public class ManipulationPreconditionsTest {
     void testSystemSignalActivationChildFailed() {
         setUpSystemSignalActivation();
         when(mockManipulations.setAlertActivation(anyString(), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.fail());
 
         assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
@@ -1872,7 +1870,7 @@ public class ManipulationPreconditionsTest {
         setUpSystemSignalActivation();
         when(mockManipulations.setSystemSignalActivation(
                         anyString(), any(AlertSignalManifestation.class), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED));
 
         assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
@@ -1884,7 +1882,7 @@ public class ManipulationPreconditionsTest {
         setUpSystemSignalActivation();
         when(mockManipulations.setSystemSignalActivation(
                         anyString(), eq(AlertSignalManifestation.AUD), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED);
+                .thenReturn(ResultResponse.from(ResponseTypes.Result.RESULT_NOT_IMPLEMENTED));
 
         assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
@@ -1896,7 +1894,7 @@ public class ManipulationPreconditionsTest {
         setUpSystemSignalActivation();
         when(mockManipulations.setSystemSignalActivation(
                         anyString(), any(AlertSignalManifestation.class), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.fail());
 
         assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
         verify(mockManipulations, times(3))
@@ -1911,7 +1909,7 @@ public class ManipulationPreconditionsTest {
         setUpSystemSignalActivation();
         when(mockManipulations.setSystemSignalActivation(
                         anyString(), eq(AlertSignalManifestation.TAN), any(AlertActivation.class)))
-                .thenReturn(ResponseTypes.Result.RESULT_FAIL);
+                .thenReturn(ResultResponse.fail());
 
         assertFalse(ManipulationPreconditions.SystemSignalActivationManipulation.manipulation(injector));
     }
@@ -1930,17 +1928,17 @@ public class ManipulationPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass())
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.triggerDescriptorUpdate(anyList())).thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+        when(mockManipulations.triggerDescriptorUpdate(anyList())).thenReturn(ResultResponse.success());
         final MdibEntity mockEntityB2 = mock(MdibEntity.class);
         when(mockEntityB2.getHandle()).thenReturn(parentDescriptorHandle);
         when(mockEntityB2.getChildren()).thenReturn(List.of(childDescriptorHandle));
@@ -2011,7 +2009,9 @@ public class ManipulationPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass())
-                .thenReturn(List.of()); // When the manipulation is NOT_SUPPORTED, an empty list is returned.
+                .thenReturn(ManipulationResponse.from(
+                        ResponseTypes.Result.RESULT_NOT_SUPPORTED,
+                        List.of())); // When the manipulation is NOT_SUPPORTED, an empty list is returned.
 
         when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
@@ -2021,7 +2021,7 @@ public class ManipulationPreconditionsTest {
             presenceMap.put(invocation.getArgument(0), false);
             return ResponseTypes.Result.RESULT_SUCCESS;
         });
-        when(mockManipulations.triggerDescriptorUpdate(anyList())).thenReturn(ResponseTypes.Result.RESULT_SUCCESS);
+        when(mockManipulations.triggerDescriptorUpdate(anyList())).thenReturn(ResultResponse.success());
         final MdibEntity mockEntityB = mock(MdibEntity.class);
         when(mockEntityB.getHandle()).thenReturn(parentDescriptorHandle);
         when(mockEntityB.getChildren()).thenReturn(List.of(childDescriptorHandle));
@@ -2067,17 +2067,17 @@ public class ManipulationPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass())
-                .thenReturn(List.of(descriptor1Handle, descriptor2Handle));
+                .thenReturn(ManipulationResponse.success(List.of(descriptor1Handle, descriptor2Handle)));
 
-        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), true);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
+        when(mockManipulations.removeDescriptor(anyString())).thenAnswer((Answer<ResultResponse>) invocation -> {
             presenceMap.put(invocation.getArgument(0), false);
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
-        when(mockManipulations.triggerDescriptorUpdate(anyList())).thenReturn(ResponseTypes.Result.RESULT_FAIL);
+        when(mockManipulations.triggerDescriptorUpdate(anyList())).thenReturn(ResultResponse.fail());
         final MdibEntity mockEntityB = mock(MdibEntity.class);
         when(mockEntityB.getHandle()).thenReturn(parentDescriptorHandle);
         when(mockEntityB.getChildren()).thenReturn(List.of(childDescriptorHandle));
@@ -2147,7 +2147,9 @@ public class ManipulationPreconditionsTest {
                 descriptor2Handle, true));
 
         when(mockManipulations.getRemovableDescriptorsOfClass())
-                .thenReturn(List.of()); // When the manipulation returns RESULT_NOT_SUPPORTED, then an empty list
+                .thenReturn(ManipulationResponse.from(
+                        ResponseTypes.Result.RESULT_NOT_SUPPORTED,
+                        List.of())); // When the manipulation returns RESULT_NOT_SUPPORTED, then an empty list
         // is returned
 
         when(mockManipulations.insertDescriptor(anyString())).thenAnswer((Answer<ResponseTypes.Result>) invocation -> {
@@ -2158,7 +2160,7 @@ public class ManipulationPreconditionsTest {
             presenceMap.put(invocation.getArgument(0), false);
             return ResponseTypes.Result.RESULT_SUCCESS;
         });
-        when(mockManipulations.triggerDescriptorUpdate(anyList())).thenReturn(ResponseTypes.Result.RESULT_FAIL);
+        when(mockManipulations.triggerDescriptorUpdate(anyList())).thenReturn(ResultResponse.fail());
         final MdibEntity mockEntityB = mock(MdibEntity.class);
         when(mockEntityB.getHandle()).thenReturn(parentDescriptorHandle);
         when(mockEntityB.getChildren()).thenReturn(List.of(childDescriptorHandle));

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTestTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.draeger.medical.sdccc.manipulation.ManipulationResponse;
 import com.draeger.medical.sdccc.manipulation.Manipulations;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClient;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClientUtil;
@@ -192,22 +193,22 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE)));
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_LOCATION_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_LOCATION_CONTEXT_STATE_HANDLE)));
         when(mockManipulations.createContextStateWithAssociation(
                         ENSEMBLE_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_ENSEMBLE_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_ENSEMBLE_CONTEXT_STATE_HANDLE)));
         when(mockManipulations.createContextStateWithAssociation(
                         MEANS_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_MEANS_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_MEANS_CONTEXT_STATE_HANDLE)));
         when(mockManipulations.createContextStateWithAssociation(
                         OPERATOR_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_OPERATOR_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_OPERATOR_CONTEXT_STATE_HANDLE)));
         when(mockManipulations.createContextStateWithAssociation(
                         WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_WORKFLOW_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_WORKFLOW_CONTEXT_STATE_HANDLE)));
 
         testClass.testRequirement0125();
     }
@@ -247,10 +248,10 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_WORKFLOW_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_WORKFLOW_CONTEXT_STATE_HANDLE)));
         when(mockManipulations.createContextStateWithAssociation(
                         WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE2, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_WORKFLOW_CONTEXT_STATE_HANDLE2));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_WORKFLOW_CONTEXT_STATE_HANDLE2)));
 
         testClass.testRequirement0125();
     }
@@ -288,10 +289,10 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE)));
         when(mockManipulations.createContextStateWithAssociation(
                         OPERATOR_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_OPERATOR_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_OPERATOR_CONTEXT_STATE_HANDLE)));
 
         testClass.testRequirement0125();
     }
@@ -313,7 +314,7 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.empty());
+                .thenReturn(ManipulationResponse.fail(Optional.empty()));
         final var error = assertThrows(AssertionError.class, testClass::testRequirement0125);
         assertTrue(error.getMessage().contains(PATIENT_CONTEXT_DESCRIPTOR_HANDLE));
     }
@@ -349,10 +350,10 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE)));
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_LOCATION_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_LOCATION_CONTEXT_STATE_HANDLE)));
 
         final var error = assertThrows(AssertionError.class, testClass::testRequirement0125);
         assertTrue(error.getMessage().contains(NEW_LOCATION_CONTEXT_STATE_HANDLE));
@@ -392,10 +393,10 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE)));
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(Optional.of(NEW_LOCATION_CONTEXT_STATE_HANDLE));
+                .thenReturn(ManipulationResponse.success(Optional.of(NEW_LOCATION_CONTEXT_STATE_HANDLE)));
 
         assertThrows(AssertionError.class, testClass::testRequirement0125);
     }

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/glue/direct/DirectSubscriptionHandlingTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/glue/direct/DirectSubscriptionHandlingTestTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.draeger.medical.sdccc.manipulation.Manipulations;
+import com.draeger.medical.sdccc.manipulation.ResultResponse;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClient;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClientUtil;
 import com.draeger.medical.sdccc.tests.InjectorTestBase;
@@ -30,7 +31,6 @@ import com.draeger.medical.sdccc.tests.test_util.InjectorUtil;
 import com.draeger.medical.sdccc.tests.util.HostedServiceVerifier;
 import com.draeger.medical.sdccc.tests.util.NoTestData;
 import com.draeger.medical.sdccc.util.MessageGeneratingUtil;
-import com.draeger.medical.t2iapi.ResponseTypes;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
@@ -929,7 +929,7 @@ public class DirectSubscriptionHandlingTestTest {
                 }
             }
             thread.start();
-            return ResponseTypes.Result.RESULT_SUCCESS;
+            return ResultResponse.success();
         });
 
         when(eventSink.getStatus(anyString())).thenAnswer(call -> {


### PR DESCRIPTION
Such an interface ensures we never have to guess the status of of a manipulation, be they via gRPC or via user interactions.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
