### PR TITLE
Add type adapters for java time classes

### DIFF
--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -270,6 +270,12 @@
             <artifactId>gson</artifactId>
             <version>2.11.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.fatboyindustrial.gson-javatime-serialisers</groupId>
+            <artifactId>gson-javatime-serialisers</artifactId>
+            <version>1.1.2</version>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GsonManipulationSerializer.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GsonManipulationSerializer.kt
@@ -7,19 +7,34 @@
 
 package com.draeger.medical.sdccc.manipulation
 
+import com.fatboyindustrial.gsonjavatime.LocalDateConverter
+import com.fatboyindustrial.gsonjavatime.LocalDateTimeConverter
+import com.fatboyindustrial.gsonjavatime.OffsetDateTimeConverter
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import com.google.inject.Inject
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
 
 /**
  * Serializer for manipulation responses using Gson.
  *
- * @param gson the Gson instance to use for serialization and deserialization.
+ * @param gsonBuilder the GsonBuilder instance with several registered TypeAdapters to create a Gson instance that is
+ * used for serialization and deserialization.
  */
 class GsonManipulationSerializer @Inject constructor(
-    private val gson: Gson
+    private val gsonBuilder: GsonBuilder
 ) : ManipulationSerializer {
+
+    private val gson: Gson = gsonBuilder
+        .registerTypeAdapter(LocalDate::class.java, LocalDateConverter())
+        .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeConverter())
+        .registerTypeAdapter(OffsetDateTime::class.java, OffsetDateTimeConverter())
+        .create()
+
     override fun <M> serialize(manipulationResponse: M): String = gson.toJson(manipulationResponse)
 
     override fun <M> deserialize(manipulationResponse: String, type: Type): M = gson.fromJson(

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/GRpcManipulationsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/GRpcManipulationsTest.java
@@ -7,6 +7,36 @@
 
 package com.draeger.medical.sdccc.manipulation;
 
+import com.draeger.medical.sdccc.messages.ManipulationInfo;
+import com.draeger.medical.sdccc.messages.guice.ManipulationInfoFactory;
+import com.draeger.medical.sdccc.tests.annotations.TestDescription;
+import com.draeger.medical.t2iapi.BasicRequests;
+import com.draeger.medical.t2iapi.BasicResponses;
+import com.draeger.medical.t2iapi.ResponseTypes;
+import com.draeger.medical.t2iapi.context.ContextRequests;
+import com.draeger.medical.t2iapi.context.ContextServiceGrpc;
+import com.draeger.medical.t2iapi.context.ContextTypes;
+import com.draeger.medical.t2iapi.device.DeviceRequests;
+import com.draeger.medical.t2iapi.device.DeviceResponses;
+import com.draeger.medical.t2iapi.device.DeviceServiceGrpc;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.gson.GsonBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.somda.sdc.biceps.model.participant.LocationDetail;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.BiFunction;
+
 import static com.draeger.medical.t2iapi.context.ContextServiceGrpc.getSetLocationDetailMethod;
 import static com.draeger.medical.t2iapi.device.DeviceServiceGrpc.getGetRemovableDescriptorsOfClassMethod;
 import static com.draeger.medical.t2iapi.device.DeviceServiceGrpc.getInsertDescriptorMethod;
@@ -26,35 +56,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-
-import com.draeger.medical.sdccc.messages.ManipulationInfo;
-import com.draeger.medical.sdccc.messages.guice.ManipulationInfoFactory;
-import com.draeger.medical.sdccc.tests.annotations.TestDescription;
-import com.draeger.medical.t2iapi.BasicRequests;
-import com.draeger.medical.t2iapi.BasicResponses;
-import com.draeger.medical.t2iapi.ResponseTypes;
-import com.draeger.medical.t2iapi.context.ContextRequests;
-import com.draeger.medical.t2iapi.context.ContextServiceGrpc;
-import com.draeger.medical.t2iapi.context.ContextTypes;
-import com.draeger.medical.t2iapi.device.DeviceRequests;
-import com.draeger.medical.t2iapi.device.DeviceResponses;
-import com.draeger.medical.t2iapi.device.DeviceServiceGrpc;
-import com.google.common.util.concurrent.SettableFuture;
-import com.google.gson.Gson;
-import io.grpc.Server;
-import io.grpc.ServerBuilder;
-import io.grpc.stub.StreamObserver;
-import java.io.IOException;
-import java.util.List;
-import java.util.function.BiFunction;
-import javax.annotation.Nullable;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
-import org.somda.sdc.biceps.model.participant.LocationDetail;
 
 /**
  * Unit tests for the gRPC {@linkplain Manipulations} implementation.
@@ -89,7 +90,7 @@ public class GRpcManipulationsTest {
         when(manipulationInfoFactory.create(anyLong(), anyLong(), any(), anyString(), anyString(), any()))
                 .thenReturn(manipulationInfo);
         manipulations = new GRpcManipulations(
-                serverAddress, fallback, manipulationInfoFactory, new GsonManipulationSerializer(new Gson()));
+                serverAddress, fallback, manipulationInfoFactory, new GsonManipulationSerializer(new GsonBuilder()));
     }
 
     @AfterEach

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/GRpcManipulationsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/GRpcManipulationsTest.java
@@ -7,36 +7,6 @@
 
 package com.draeger.medical.sdccc.manipulation;
 
-import com.draeger.medical.sdccc.messages.ManipulationInfo;
-import com.draeger.medical.sdccc.messages.guice.ManipulationInfoFactory;
-import com.draeger.medical.sdccc.tests.annotations.TestDescription;
-import com.draeger.medical.t2iapi.BasicRequests;
-import com.draeger.medical.t2iapi.BasicResponses;
-import com.draeger.medical.t2iapi.ResponseTypes;
-import com.draeger.medical.t2iapi.context.ContextRequests;
-import com.draeger.medical.t2iapi.context.ContextServiceGrpc;
-import com.draeger.medical.t2iapi.context.ContextTypes;
-import com.draeger.medical.t2iapi.device.DeviceRequests;
-import com.draeger.medical.t2iapi.device.DeviceResponses;
-import com.draeger.medical.t2iapi.device.DeviceServiceGrpc;
-import com.google.common.util.concurrent.SettableFuture;
-import com.google.gson.GsonBuilder;
-import io.grpc.Server;
-import io.grpc.ServerBuilder;
-import io.grpc.stub.StreamObserver;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
-import org.somda.sdc.biceps.model.participant.LocationDetail;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.function.BiFunction;
-
 import static com.draeger.medical.t2iapi.context.ContextServiceGrpc.getSetLocationDetailMethod;
 import static com.draeger.medical.t2iapi.device.DeviceServiceGrpc.getGetRemovableDescriptorsOfClassMethod;
 import static com.draeger.medical.t2iapi.device.DeviceServiceGrpc.getInsertDescriptorMethod;
@@ -56,6 +26,35 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+
+import com.draeger.medical.sdccc.messages.ManipulationInfo;
+import com.draeger.medical.sdccc.messages.guice.ManipulationInfoFactory;
+import com.draeger.medical.sdccc.tests.annotations.TestDescription;
+import com.draeger.medical.t2iapi.BasicRequests;
+import com.draeger.medical.t2iapi.BasicResponses;
+import com.draeger.medical.t2iapi.ResponseTypes;
+import com.draeger.medical.t2iapi.context.ContextRequests;
+import com.draeger.medical.t2iapi.context.ContextServiceGrpc;
+import com.draeger.medical.t2iapi.context.ContextTypes;
+import com.draeger.medical.t2iapi.device.DeviceRequests;
+import com.draeger.medical.t2iapi.device.DeviceResponses;
+import com.draeger.medical.t2iapi.device.DeviceServiceGrpc;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.gson.GsonBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.BiFunction;
+import javax.annotation.Nullable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.somda.sdc.biceps.model.participant.LocationDetail;
 
 /**
  * Unit tests for the gRPC {@linkplain Manipulations} implementation.


### PR DESCRIPTION
The purpose of the pull request is to enable serialization and deserialization of objects that make use of java time classes. Therefore, the current gson object that is used for that is replaced by a gson builder with registered type adapters.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
