### PR TITLE
fix biceps.c11, biceps.c12, biceps.c13, biceps.c14 and biceps.c15

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
@@ -1449,7 +1449,8 @@ public class MessageStorage implements AutoCloseable {
      * <p>
      * Messages are sorted by MdibVersion on the inner join result.
      *
-     * @param enableSorting switch to turn off or turn on MdibVersion based sorting
+     * @param enableSorting switch to turn off or turn on MdibVersion based sorting, messages with the same MdibVersion
+     *                      are sorted after bodyTypes
      * @param bodyTypes     to match messages against
      * @return container with stream of all matching inbound {@linkplain MessageContent}s
      * @throws IOException if storage is closed
@@ -1510,6 +1511,8 @@ public class MessageStorage implements AutoCloseable {
                         criteriaBuilder.asc(messageContentRoot
                                 .join(MessageContent_.mdibVersionGroups)
                                 .get(MdibVersionGroupEntity_.mdibVersion)),
+                        // also sort by body type to ensure that DescriptionModificationReports are placed
+                        // before EpisodicReports.
                         criteriaBuilder.asc(messageContentRoot
                                 .join(MessageContent_.mdibVersionGroups)
                                 .get(MdibVersionGroupEntity_.bodyElement)));

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
@@ -1447,10 +1447,10 @@ public class MessageStorage implements AutoCloseable {
      * Retrieves all incoming messages which match any of the provided body element QNames.
      *
      * <p>
-     * Messages are sorted by MdibVersion on the inner join result.
+     * Messages are sorted by MdibVersion on the inner join result or, if the MdibVersion is the same,
+     * lexicographically in ascending order according to the name of the bodyType.
      *
-     * @param enableSorting switch to turn off or turn on MdibVersion based sorting, messages with the same MdibVersion
-     *                      are sorted after bodyTypes
+     * @param enableSorting switch to turn off or turn on sorting
      * @param bodyTypes     to match messages against
      * @return container with stream of all matching inbound {@linkplain MessageContent}s
      * @throws IOException if storage is closed

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
@@ -1506,9 +1506,13 @@ public class MessageStorage implements AutoCloseable {
                     criteriaBuilder.exists(mdibVersionGroupSubQuery)));
 
             if (enableSorting) {
-                messageContentQuery.orderBy(criteriaBuilder.asc(messageContentRoot
-                        .join(MessageContent_.mdibVersionGroups)
-                        .get(MdibVersionGroupEntity_.mdibVersion)));
+                messageContentQuery.orderBy(
+                        criteriaBuilder.asc(messageContentRoot
+                                .join(MessageContent_.mdibVersionGroups)
+                                .get(MdibVersionGroupEntity_.mdibVersion)),
+                        criteriaBuilder.asc(messageContentRoot
+                                .join(MessageContent_.mdibVersionGroups)
+                                .get(MdibVersionGroupEntity_.bodyElement)));
             }
         }
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
@@ -1448,7 +1448,7 @@ public class MessageStorage implements AutoCloseable {
      *
      * <p>
      * Messages are sorted by MdibVersion on the inner join result or, if the MdibVersion is the same,
-     * lexicographically in ascending order according to the name of the bodyType.
+     * are sorted in ascending order of the code points of the name of the body types.
      *
      * @param enableSorting switch to turn off or turn on sorting
      * @param bodyTypes     to match messages against

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -822,9 +822,12 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
 
                     if (reportClass.isInstance(report)) {
                         acceptableSequenceSeen.incrementAndGet();
-                        final var priorMdibVersion = report.getMdibVersion().subtract(BigInteger.ONE);
+                        final var priorMdibVersion =
+                                ImpliedValueUtil.getReportMdibVersion(report).subtract(BigInteger.ONE);
                         // fast-forward history to the mdib version before the report
-                        while (mdibAccess.getMdibVersion().getVersion().compareTo(priorMdibVersion) < 0) {
+                        while (ImpliedValueUtil.getMdibVersion(mdibAccess.getMdibVersion())
+                                        .compareTo(priorMdibVersion)
+                                < 0) {
                             mdibAccess = history.next();
                         }
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -50,7 +50,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.somda.sdc.biceps.common.storage.PreprocessingException;
 import org.somda.sdc.biceps.consumer.access.RemoteMdibAccess;
-import org.somda.sdc.biceps.model.message.AbstractAlertReport;
 import org.somda.sdc.biceps.model.message.AbstractReport;
 import org.somda.sdc.biceps.model.message.DescriptionModificationReport;
 import org.somda.sdc.biceps.model.message.DescriptionModificationType;
@@ -698,10 +697,10 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             + " whether at least one child or attribute has changed for each AbstractAlertState contained in an"
             + " EpisodicAlertReport.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerEpisodicAlertReportPrecondition.class})
-    void testRequirementC11() throws NoTestData, IOException {
-        final GetStatesOfReportParts getStatesOfReportParts = report -> ((AbstractAlertReport) report)
+    void testRequirementC11() throws NoTestData {
+        final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicAlertReport) report)
                 .getReportPart().stream()
-                        .map(AbstractAlertReport.ReportPart::getAlertState)
+                        .map(EpisodicAlertReport.ReportPart::getAlertState)
                         .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(EpisodicAlertReport.class, AbstractAlertState.class, getStatesOfReportParts);
@@ -714,7 +713,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             + " EpisodicComponentReport.")
     @RequirePrecondition(
             simplePreconditions = {ConditionalPreconditions.TriggerEpisodicComponentReportPrecondition.class})
-    void testRequirementC12() throws NoTestData, IOException {
+    void testRequirementC12() throws NoTestData {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicComponentReport) report)
                 .getReportPart().stream()
                         .map(EpisodicComponentReport.ReportPart::getComponentState)
@@ -731,7 +730,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             + " EpisodicContextReport.")
     @RequirePrecondition(
             simplePreconditions = {ConditionalPreconditions.TriggerEpisodicContextReportPrecondition.class})
-    void testRequirementC13() throws NoTestData, IOException {
+    void testRequirementC13() throws NoTestData {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicContextReport) report)
                 .getReportPart().stream()
                         .map(EpisodicContextReport.ReportPart::getContextState)
@@ -746,7 +745,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             + " whether at least one child or attribute has changed for each AbstractMetricState contained in an"
             + " EpisodicMetricReport.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerEpisodicMetricReportPrecondition.class})
-    void testRequirementC14() throws NoTestData, IOException {
+    void testRequirementC14() throws NoTestData {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicMetricReport) report)
                 .getReportPart().stream()
                         .map(EpisodicMetricReport.ReportPart::getMetricState)
@@ -762,7 +761,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             + " EpisodicOperationalStateReport.")
     @RequirePrecondition(
             simplePreconditions = {ConditionalPreconditions.TriggerEpisodicOperationalStateReportPrecondition.class})
-    void testRequirementC15() throws NoTestData, IOException {
+    void testRequirementC15() throws NoTestData {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicOperationalStateReport) report)
                 .getReportPart().stream()
                         .map(EpisodicOperationalStateReport.ReportPart::getOperationState)

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -33,21 +33,23 @@ import com.draeger.medical.sdccc.util.TestRunObserver;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.somda.sdc.biceps.common.storage.PreprocessingException;
 import org.somda.sdc.biceps.consumer.access.RemoteMdibAccess;
 import org.somda.sdc.biceps.model.message.AbstractAlertReport;
-import org.somda.sdc.biceps.model.message.AbstractComponentReport;
-import org.somda.sdc.biceps.model.message.AbstractContextReport;
 import org.somda.sdc.biceps.model.message.AbstractReport;
 import org.somda.sdc.biceps.model.message.DescriptionModificationReport;
 import org.somda.sdc.biceps.model.message.DescriptionModificationType;
@@ -61,7 +63,9 @@ import org.somda.sdc.biceps.model.participant.AbstractContextState;
 import org.somda.sdc.biceps.model.participant.AbstractDescriptor;
 import org.somda.sdc.biceps.model.participant.AbstractDeviceComponentState;
 import org.somda.sdc.biceps.model.participant.AbstractMetricState;
+import org.somda.sdc.biceps.model.participant.AbstractMultiState;
 import org.somda.sdc.biceps.model.participant.AbstractOperationState;
+import org.somda.sdc.biceps.model.participant.AbstractState;
 import org.somda.sdc.biceps.model.participant.AlertSystemDescriptor;
 import org.somda.sdc.biceps.model.participant.ChannelDescriptor;
 import org.somda.sdc.biceps.model.participant.MdsDescriptor;
@@ -78,6 +82,7 @@ import org.somda.sdc.glue.consumer.report.ReportProcessingException;
  * Test for the normative Annex Message Model of BICEPS.
  */
 public class InvariantMessageModelAnnexTest extends InjectorTestBase {
+    private static final Logger LOG = LogManager.getLogger();
     private static final String STATE_ABSENT = "The state with handle %s is not present";
     private static final String STATE_UNCHANGED = "The state with the handle %s from the report has not changed";
     private MarshallingService marshalling;
@@ -154,8 +159,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @TestIdentifier(EnabledTestConfig.BICEPS_C5)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
             + " for each AbstractDescriptor contained in a DescriptionModificationReport"
-            + " that it was inserted or deleted or updated by changing"
-            + " at least one child or attribute.")
+            + " that it was inserted or deleted or updated by changing" + " at least one child or attribute.")
     @RequirePrecondition(simplePreconditions = ConditionalPreconditions.DescriptionModificationUptPrecondition.class)
     void testRequirementC5() throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
@@ -694,59 +698,12 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             + " EpisodicAlertReport.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerEpisodicAlertReportPrecondition.class})
     void testRequirementC11() throws NoTestData, IOException {
-        final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
-                messageStorage, getInjector().getInstance(TestRunObserver.class));
+        final GetStatesOfReportParts getStatesOfReportParts = report -> ((AbstractAlertReport) report)
+                .getReportPart().stream()
+                        .map(AbstractAlertReport.ReportPart::getAlertState)
+                        .collect(Collectors.toUnmodifiableList());
 
-        final var acceptableSequenceSeen = new AtomicInteger(0);
-
-        try (final Stream<String> sequenceIds = mdibHistorian.getKnownSequenceIds()) {
-            sequenceIds.forEach(sequenceId -> {
-                RemoteMdibAccess first = null;
-                RemoteMdibAccess second = null;
-                try {
-                    first = mdibHistorian.createNewStorage(sequenceId);
-                    second = mdibHistorian.createNewStorage(sequenceId);
-                } catch (PreprocessingException e) {
-                    fail(e);
-                }
-
-                // get relevant reports
-                final var minimumMdibVersion = ImpliedValueUtil.getMdibVersion(first.getMdibVersion());
-                try (final var reports = mdibHistorian.getAllUniqueReports(sequenceId, minimumMdibVersion)) {
-
-                    for (final Iterator<AbstractReport> iterator = reports.iterator(); iterator.hasNext(); ) {
-                        final AbstractReport report = iterator.next();
-
-                        if (report instanceof EpisodicAlertReport) {
-                            acceptableSequenceSeen.incrementAndGet();
-                            second = mdibHistorian.applyReportOnStorage(second, report);
-                            for (var reportPart : ((AbstractAlertReport) report).getReportPart()) {
-                                for (var alertState : reportPart.getAlertState()) {
-                                    final var stateBeforeReport =
-                                            first.getState(alertState.getDescriptorHandle(), AbstractAlertState.class);
-                                    final var stateAfterReport =
-                                            second.getState(alertState.getDescriptorHandle(), AbstractAlertState.class);
-                                    assertTrue(
-                                            stateBeforeReport.isPresent() && stateAfterReport.isPresent(),
-                                            String.format(STATE_ABSENT, alertState.getDescriptorHandle()));
-                                    assertNotEquals(
-                                            stateAfterReport.orElseThrow(),
-                                            stateBeforeReport.orElseThrow(),
-                                            String.format(STATE_UNCHANGED, alertState.getDescriptorHandle()));
-                                }
-                            }
-                            first = mdibHistorian.applyReportOnStorage(first, report);
-                        } else {
-                            first = mdibHistorian.applyReportOnStorage(first, report);
-                            second = mdibHistorian.applyReportOnStorage(second, report);
-                        }
-                    }
-                } catch (PreprocessingException | ReportProcessingException e) {
-                    fail(e);
-                }
-            });
-        }
-        assertTestData(acceptableSequenceSeen.get(), "No AlertReports seen during test run, test failed.");
+        testEpisodicReportRequirement(EpisodicAlertReport.class, AbstractAlertState.class, getStatesOfReportParts);
     }
 
     @Test
@@ -757,59 +714,13 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @RequirePrecondition(
             simplePreconditions = {ConditionalPreconditions.TriggerEpisodicComponentReportPrecondition.class})
     void testRequirementC12() throws NoTestData, IOException {
-        final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
-                messageStorage, getInjector().getInstance(TestRunObserver.class));
+        final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicComponentReport) report)
+                .getReportPart().stream()
+                        .map(EpisodicComponentReport.ReportPart::getComponentState)
+                        .collect(Collectors.toUnmodifiableList());
 
-        final var acceptableSequenceSeen = new AtomicInteger(0);
-
-        try (final Stream<String> sequenceIds = mdibHistorian.getKnownSequenceIds()) {
-            sequenceIds.forEach(sequenceId -> {
-                RemoteMdibAccess first = null;
-                RemoteMdibAccess second = null;
-                try {
-                    first = mdibHistorian.createNewStorage(sequenceId);
-                    second = mdibHistorian.createNewStorage(sequenceId);
-                } catch (PreprocessingException e) {
-                    fail(e);
-                }
-
-                // get relevant reports
-                final var minimumMdibVersion = ImpliedValueUtil.getMdibVersion(first.getMdibVersion());
-                try (final var reports = mdibHistorian.getAllUniqueReports(sequenceId, minimumMdibVersion)) {
-
-                    for (final Iterator<AbstractReport> iterator = reports.iterator(); iterator.hasNext(); ) {
-                        final AbstractReport report = iterator.next();
-
-                        if (report instanceof EpisodicComponentReport) {
-                            acceptableSequenceSeen.incrementAndGet();
-                            second = mdibHistorian.applyReportOnStorage(second, report);
-                            for (var reportPart : ((AbstractComponentReport) report).getReportPart()) {
-                                for (var componentState : reportPart.getComponentState()) {
-                                    final var stateBeforeReport = first.getState(
-                                            componentState.getDescriptorHandle(), AbstractDeviceComponentState.class);
-                                    final var stateAfterReport = second.getState(
-                                            componentState.getDescriptorHandle(), AbstractDeviceComponentState.class);
-                                    assertTrue(
-                                            stateBeforeReport.isPresent() && stateAfterReport.isPresent(),
-                                            String.format(STATE_ABSENT, componentState.getDescriptorHandle()));
-                                    assertNotEquals(
-                                            stateAfterReport.orElseThrow(),
-                                            stateBeforeReport.orElseThrow(),
-                                            String.format(STATE_UNCHANGED, componentState.getDescriptorHandle()));
-                                }
-                            }
-                            first = mdibHistorian.applyReportOnStorage(first, report);
-                        } else {
-                            first = mdibHistorian.applyReportOnStorage(first, report);
-                            second = mdibHistorian.applyReportOnStorage(second, report);
-                        }
-                    }
-                } catch (PreprocessingException | ReportProcessingException e) {
-                    fail(e);
-                }
-            });
-        }
-        assertTestData(acceptableSequenceSeen.get(), "No ComponentReports seen during test run, test failed.");
+        testEpisodicReportRequirement(
+                EpisodicComponentReport.class, AbstractDeviceComponentState.class, getStatesOfReportParts);
     }
 
     @Test
@@ -820,71 +731,12 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @RequirePrecondition(
             simplePreconditions = {ConditionalPreconditions.TriggerEpisodicContextReportPrecondition.class})
     void testRequirementC13() throws NoTestData, IOException {
-        final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
-                messageStorage, getInjector().getInstance(TestRunObserver.class));
+        final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicContextReport) report)
+                .getReportPart().stream()
+                        .map(EpisodicContextReport.ReportPart::getContextState)
+                        .collect(Collectors.toUnmodifiableList());
 
-        final var acceptableSequenceSeen = new AtomicInteger(0);
-
-        try (final Stream<String> sequenceIds = mdibHistorian.getKnownSequenceIds()) {
-            sequenceIds.forEach(sequenceId -> {
-                RemoteMdibAccess first = null;
-                RemoteMdibAccess second = null;
-                try {
-                    first = mdibHistorian.createNewStorage(sequenceId);
-                    second = mdibHistorian.createNewStorage(sequenceId);
-                } catch (PreprocessingException e) {
-                    fail(e);
-                }
-
-                // get relevant reports
-                final var minimumMdibVersion = ImpliedValueUtil.getMdibVersion(first.getMdibVersion());
-                try (final var reports = mdibHistorian.getAllUniqueReports(sequenceId, minimumMdibVersion)) {
-
-                    for (final Iterator<AbstractReport> iterator = reports.iterator(); iterator.hasNext(); ) {
-                        final AbstractReport report = iterator.next();
-
-                        if (report instanceof EpisodicContextReport) {
-                            acceptableSequenceSeen.incrementAndGet();
-                            second = mdibHistorian.applyReportOnStorage(second, report);
-
-                            for (var reportPart : ((AbstractContextReport) report).getReportPart()) {
-                                for (var contextState : reportPart.getContextState()) {
-                                    final var beforeReport = first.getEntity(contextState.getDescriptorHandle());
-                                    final var afterReport = second.getEntity(contextState.getDescriptorHandle());
-                                    final var stateBeforeReport =
-                                            beforeReport.orElseThrow().getStates(AbstractContextState.class).stream()
-                                                    .filter(state ->
-                                                            state.getHandle().equals(contextState.getHandle()))
-                                                    .findFirst();
-                                    final var stateAfterReport =
-                                            afterReport.orElseThrow().getStates(AbstractContextState.class).stream()
-                                                    .filter(state ->
-                                                            state.getHandle().equals(contextState.getHandle()))
-                                                    .findFirst();
-                                    if (stateBeforeReport.isPresent() && stateAfterReport.isPresent()) {
-                                        assertNotEquals(
-                                                stateAfterReport.orElseThrow(),
-                                                stateBeforeReport.orElseThrow(),
-                                                String.format(STATE_UNCHANGED, contextState.getDescriptorHandle()));
-                                    } else {
-                                        assertTrue(
-                                                stateBeforeReport.isEmpty() && stateAfterReport.isPresent(),
-                                                String.format(STATE_ABSENT, contextState.getDescriptorHandle()));
-                                    }
-                                }
-                            }
-                            first = mdibHistorian.applyReportOnStorage(first, report);
-                        } else {
-                            first = mdibHistorian.applyReportOnStorage(first, report);
-                            second = mdibHistorian.applyReportOnStorage(second, report);
-                        }
-                    }
-                } catch (PreprocessingException | ReportProcessingException e) {
-                    fail(e);
-                }
-            });
-        }
-        assertTestData(acceptableSequenceSeen.get(), "No ContextReports seen during test run, test failed.");
+        testEpisodicReportRequirement(EpisodicContextReport.class, AbstractContextState.class, getStatesOfReportParts);
     }
 
     @Test
@@ -894,60 +746,12 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             + " EpisodicMetricReport.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerEpisodicMetricReportPrecondition.class})
     void testRequirementC14() throws NoTestData, IOException {
-        final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
-                messageStorage, getInjector().getInstance(TestRunObserver.class));
+        final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicMetricReport) report)
+                .getReportPart().stream()
+                        .map(EpisodicMetricReport.ReportPart::getMetricState)
+                        .collect(Collectors.toUnmodifiableList());
 
-        final var acceptableSequenceSeen = new AtomicInteger(0);
-
-        try (final Stream<String> sequenceIds = mdibHistorian.getKnownSequenceIds()) {
-            sequenceIds.forEach(sequenceId -> {
-                RemoteMdibAccess first = null;
-                RemoteMdibAccess second = null;
-                try {
-                    first = mdibHistorian.createNewStorage(sequenceId);
-                    second = mdibHistorian.createNewStorage(sequenceId);
-                } catch (PreprocessingException e) {
-                    fail(e);
-                }
-
-                // get relevant reports
-                final var minimumMdibVersion = ImpliedValueUtil.getMdibVersion(first.getMdibVersion());
-                try (final var reports = mdibHistorian.getAllUniqueReports(sequenceId, minimumMdibVersion)) {
-
-                    for (final Iterator<AbstractReport> iterator = reports.iterator(); iterator.hasNext(); ) {
-                        final AbstractReport report = iterator.next();
-
-                        if (report instanceof EpisodicMetricReport metricReport) {
-                            acceptableSequenceSeen.incrementAndGet();
-                            second = mdibHistorian.applyReportOnStorage(second, report);
-
-                            for (var reportPart : metricReport.getReportPart()) {
-                                for (var metricState : reportPart.getMetricState()) {
-                                    final var stateBeforeReport = first.getState(
-                                            metricState.getDescriptorHandle(), AbstractMetricState.class);
-                                    final var stateAfterReport = second.getState(
-                                            metricState.getDescriptorHandle(), AbstractMetricState.class);
-                                    assertTrue(
-                                            stateBeforeReport.isPresent() && stateAfterReport.isPresent(),
-                                            String.format(STATE_ABSENT, metricState.getDescriptorHandle()));
-                                    assertNotEquals(
-                                            stateAfterReport.orElseThrow(),
-                                            stateBeforeReport.orElseThrow(),
-                                            String.format(STATE_UNCHANGED, metricState.getDescriptorHandle()));
-                                }
-                            }
-                            first = mdibHistorian.applyReportOnStorage(first, report);
-                        } else {
-                            first = mdibHistorian.applyReportOnStorage(first, report);
-                            second = mdibHistorian.applyReportOnStorage(second, report);
-                        }
-                    }
-                } catch (PreprocessingException | ReportProcessingException e) {
-                    fail(e);
-                }
-            });
-        }
-        assertTestData(acceptableSequenceSeen.get(), "No MetricReports seen during test run, test failed.");
+        testEpisodicReportRequirement(EpisodicMetricReport.class, AbstractMetricState.class, getStatesOfReportParts);
     }
 
     @Test
@@ -958,6 +762,20 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @RequirePrecondition(
             simplePreconditions = {ConditionalPreconditions.TriggerEpisodicOperationalStateReportPrecondition.class})
     void testRequirementC15() throws NoTestData, IOException {
+        final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicOperationalStateReport) report)
+                .getReportPart().stream()
+                        .map(EpisodicOperationalStateReport.ReportPart::getOperationState)
+                        .collect(Collectors.toUnmodifiableList());
+
+        testEpisodicReportRequirement(
+                EpisodicOperationalStateReport.class, AbstractOperationState.class, getStatesOfReportParts);
+    }
+
+    private void testEpisodicReportRequirement(
+            final Class<? extends AbstractReport> reportClass,
+            final Class<? extends AbstractState> stateClass,
+            final GetStatesOfReportParts getStatesOfReportParts)
+            throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
                 messageStorage, getInjector().getInstance(TestRunObserver.class));
 
@@ -978,29 +796,89 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                 final var minimumMdibVersion = ImpliedValueUtil.getMdibVersion(first.getMdibVersion());
                 try (final var reports = mdibHistorian.getAllUniqueReports(sequenceId, minimumMdibVersion)) {
 
-                    for (final Iterator<AbstractReport> reportIterator = reports.iterator();
-                            reportIterator.hasNext(); ) {
-                        final AbstractReport report = reportIterator.next();
+                    DescriptionModificationReport previousDescriptionModificationReport = null;
+                    final var statesFromDescriptionModificationReport = new ArrayList<>();
+                    for (final Iterator<AbstractReport> iterator = reports.iterator(); iterator.hasNext(); ) {
+                        final AbstractReport report = iterator.next();
 
-                        if (report instanceof EpisodicOperationalStateReport operationalStateReport) {
+                        if (report instanceof DescriptionModificationReport) {
+                            previousDescriptionModificationReport = (DescriptionModificationReport) report;
+                        }
+
+                        if (reportClass.isInstance(report)) {
                             acceptableSequenceSeen.incrementAndGet();
                             second = mdibHistorian.applyReportOnStorage(second, report);
 
-                            for (var reportPart : operationalStateReport.getReportPart()) {
-                                for (var operationState : reportPart.getOperationState()) {
-                                    final var stateBeforeReport = first.getState(
-                                            operationState.getDescriptorHandle(), AbstractOperationState.class);
-                                    final var stateAfterReport = second.getState(
-                                            operationState.getDescriptorHandle(), AbstractOperationState.class);
-                                    assertTrue(
-                                            stateBeforeReport.isPresent() && stateAfterReport.isPresent(),
-                                            String.format(STATE_ABSENT, operationState.getDescriptorHandle()));
-                                    assertNotEquals(
-                                            stateAfterReport.orElseThrow(),
-                                            stateBeforeReport.orElseThrow(),
-                                            String.format(STATE_UNCHANGED, operationState.getDescriptorHandle()));
+                            // collect all relevant states from the DescriptionModificationReport, one with the same
+                            // MdibVersion exists.
+                            statesFromDescriptionModificationReport.clear();
+                            if (previousDescriptionModificationReport != null
+                                    && ImpliedValueUtil.getReportMdibVersion(previousDescriptionModificationReport)
+                                            .equals(ImpliedValueUtil.getReportMdibVersion(report))) {
+                                statesFromDescriptionModificationReport.addAll(
+                                        previousDescriptionModificationReport.getReportPart().stream()
+                                                .map(DescriptionModificationReport.ReportPart::getState)
+                                                .flatMap(List::stream)
+                                                .filter(stateClass::isInstance)
+                                                .map(stateClass::cast)
+                                                .toList());
+                            }
+
+                            final var reportParts = getStatesOfReportParts.apply(reportClass.cast(report));
+                            for (var reportPart : reportParts) {
+                                for (var state : reportPart) {
+                                    final Optional<? extends AbstractState> stateBeforeReport;
+                                    final Optional<? extends AbstractState> stateAfterReport;
+
+                                    if (state instanceof AbstractMultiState multiState) {
+                                        final var beforeReport = first.getEntity(multiState.getDescriptorHandle());
+                                        final var afterReport = second.getEntity(multiState.getDescriptorHandle());
+                                        stateBeforeReport =
+                                                beforeReport.orElseThrow().getStates(AbstractMultiState.class).stream()
+                                                        .filter(it ->
+                                                                it.getHandle().equals(multiState.getHandle()))
+                                                        .findFirst();
+                                        stateAfterReport =
+                                                afterReport.orElseThrow().getStates(AbstractMultiState.class).stream()
+                                                        .filter(it ->
+                                                                it.getHandle().equals(multiState.getHandle()))
+                                                        .findFirst();
+                                        if (!(stateBeforeReport.isPresent() && stateAfterReport.isPresent())) {
+                                            // when not both AbstractMultiStates are present it must be inserted.
+                                            assertTrue(
+                                                    stateBeforeReport.isEmpty() && stateAfterReport.isPresent(),
+                                                    String.format(STATE_ABSENT, state.getDescriptorHandle()));
+                                            continue;
+                                        }
+                                    } else {
+                                        // no AbstractMultiState so state should be present before and after the report
+                                        stateBeforeReport = first.getState(state.getDescriptorHandle(), stateClass);
+                                        stateAfterReport = second.getState(state.getDescriptorHandle(), stateClass);
+                                        assertTrue(
+                                                stateBeforeReport.isPresent() && stateAfterReport.isPresent(),
+                                                String.format(STATE_ABSENT, state.getDescriptorHandle()));
+                                    }
+
+                                    if (statesFromDescriptionModificationReport.stream()
+                                            .anyMatch(it -> ((AbstractState) it)
+                                                    .getDescriptorHandle()
+                                                    .equals(stateAfterReport
+                                                            .orElseThrow()
+                                                            .getDescriptorHandle()))) {
+                                        LOG.debug(
+                                                "The state with handle {} was already seen in a DescriptionModificationReport in MdibVersion {} and SequenceId {}.",
+                                                stateAfterReport.orElseThrow().getDescriptorHandle(),
+                                                ImpliedValueUtil.getReportMdibVersion(report),
+                                                report.getSequenceId());
+                                    } else {
+                                        assertNotEquals(
+                                                stateAfterReport.orElseThrow(),
+                                                stateBeforeReport.orElseThrow(),
+                                                String.format(STATE_UNCHANGED, state.getDescriptorHandle()));
+                                    }
                                 }
                             }
+                            previousDescriptionModificationReport = null;
                             first = mdibHistorian.applyReportOnStorage(first, report);
                         } else {
                             first = mdibHistorian.applyReportOnStorage(first, report);
@@ -1012,6 +890,13 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                 }
             });
         }
-        assertTestData(acceptableSequenceSeen.get(), "No OperationalStateReports seen during test run, test failed.");
+        assertTestData(
+                acceptableSequenceSeen.get(),
+                String.format("No %s seen during test run, test failed.", reportClass.getSimpleName()));
+    }
+
+    @FunctionalInterface
+    private interface GetStatesOfReportParts {
+        List<List<? extends AbstractState>> apply(AbstractReport report);
     }
 }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -30,10 +30,11 @@ import com.draeger.medical.sdccc.tests.util.NoTestData;
 import com.draeger.medical.sdccc.tests.util.guice.MdibHistorianFactory;
 import com.draeger.medical.sdccc.util.Constants;
 import com.draeger.medical.sdccc.util.TestRunObserver;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -41,6 +42,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -101,27 +103,27 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
 
     @Test
     @DisplayName("A SERVICE PROVIDER SHALL include the parent descriptor handle in "
-            + "msg:DescriptionModificationReport/msg:ReportPart/@ParentDescriptor for any Descriptor that is not a "
-            + "pm:MdsDescriptor, if msg:DescriptionModificationReport/msg:ReportPart/@ModificationType "
-            + "is “Crt” (Created).")
+        + "msg:DescriptionModificationReport/msg:ReportPart/@ParentDescriptor for any Descriptor that is not a "
+        + "pm:MdsDescriptor, if msg:DescriptionModificationReport/msg:ReportPart/@ModificationType "
+        + "is “Crt” (Created).")
     @TestIdentifier(EnabledTestConfig.BICEPS_R0055_0)
     @TestDescription("Retrieves all DescriptionModificationReports seen during the TestRun and checks for each "
-            + "created AbstractDescriptor which is not an MdsDescriptor that the attribute @ParentDescriptor "
-            + "of its ReportPart is set.")
+        + "created AbstractDescriptor which is not an MdsDescriptor that the attribute @ParentDescriptor "
+        + "of its ReportPart is set.")
     @RequirePrecondition(simplePreconditions = ConditionalPreconditions.DescriptionModificationCrtPrecondition.class)
     void testRequirementR00550() throws NoTestData {
         final var acceptableReportPartSeen = new AtomicInteger(0);
 
         // get DescriptionModification reports
         try (final var reports =
-                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             for (final Iterator<MessageContent> iterator = reports.getStream().iterator(); iterator.hasNext(); ) {
 
                 final MessageContent messageContent = iterator.next();
                 final SoapMessage soapMessage = marshalling.unmarshal(
-                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                    new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                 final Optional<DescriptionModificationReport> reportOpt =
-                        soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
+                    soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                 final DescriptionModificationReport descriptionModificationReport = reportOpt.orElseThrow();
 
                 for (var reportPart : descriptionModificationReport.getReportPart()) {
@@ -132,14 +134,14 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                             if (!(createdDescriptor instanceof MdsDescriptor)) {
                                 final String parentDescriptor = reportPart.getParentDescriptor();
                                 assertTrue(
-                                        parentDescriptor != null && !parentDescriptor.isBlank(),
-                                        String.format(
-                                                "msg:DescriptionModificationReport/msg:ReportPart/"
-                                                        + "@ParentDescriptor attribute is not set for a ReportPart "
-                                                        + "with @ModificationType = \"Crt\" that contains "
-                                                        + "AbstractDescriptors that are not MdsDescriptors"
-                                                        + "(for instance: %s).",
-                                                createdDescriptor.getHandle()));
+                                    parentDescriptor != null && !parentDescriptor.isBlank(),
+                                    String.format(
+                                        "msg:DescriptionModificationReport/msg:ReportPart/"
+                                            + "@ParentDescriptor attribute is not set for a ReportPart "
+                                            + "with @ModificationType = \"Crt\" that contains "
+                                            + "AbstractDescriptors that are not MdsDescriptors"
+                                            + "(for instance: %s).",
+                                        createdDescriptor.getHandle()));
                             }
                         }
                     }
@@ -150,20 +152,20 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
         }
 
         assertTestData(
-                acceptableReportPartSeen.get(),
-                "No DescriptionModificationReport with ReportParts with "
-                        + "ModificationType=Crt seen during test run, test failed.");
+            acceptableReportPartSeen.get(),
+            "No DescriptionModificationReport with ReportParts with "
+                + "ModificationType=Crt seen during test run, test failed.");
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C5)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-            + " for each AbstractDescriptor contained in a DescriptionModificationReport"
-            + " that it was inserted or deleted or updated by changing" + " at least one child or attribute.")
+        + " for each AbstractDescriptor contained in a DescriptionModificationReport"
+        + " that it was inserted or deleted or updated by changing" + " at least one child or attribute.")
     @RequirePrecondition(simplePreconditions = ConditionalPreconditions.DescriptionModificationUptPrecondition.class)
     void testRequirementC5() throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
-                messageStorage, getInjector().getInstance(TestRunObserver.class));
+            messageStorage, getInjector().getInstance(TestRunObserver.class));
 
         final var acceptableSequenceSeen = new AtomicInteger(0);
 
@@ -193,48 +195,48 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                                 for (var modifiedDescriptor : reportPart.getDescriptor()) {
 
                                     final var descriptorBeforeReportOpt =
-                                            first.getDescriptor(modifiedDescriptor.getHandle());
+                                        first.getDescriptor(modifiedDescriptor.getHandle());
                                     final var descriptorAfterReportOpt =
-                                            second.getDescriptor(modifiedDescriptor.getHandle());
+                                        second.getDescriptor(modifiedDescriptor.getHandle());
 
                                     final var modificationType = ImpliedValueUtil.getModificationType(reportPart);
                                     if (modificationType.equals(DescriptionModificationType.UPT)) {
                                         assertTrue(
-                                                descriptorBeforeReportOpt.isPresent()
-                                                        && descriptorAfterReportOpt.isPresent(),
-                                                String.format(
-                                                        "The descriptor with handle %s is not present",
-                                                        modifiedDescriptor.getHandle()));
+                                            descriptorBeforeReportOpt.isPresent()
+                                                && descriptorAfterReportOpt.isPresent(),
+                                            String.format(
+                                                "The descriptor with handle %s is not present",
+                                                modifiedDescriptor.getHandle()));
 
                                         assertNotEquals(
-                                                descriptorAfterReportOpt.orElseThrow(),
-                                                descriptorBeforeReportOpt.orElseThrow(),
-                                                String.format(
-                                                        "The descriptor with the handle %s from the report has not changed",
-                                                        modifiedDescriptor.getHandle()));
+                                            descriptorAfterReportOpt.orElseThrow(),
+                                            descriptorBeforeReportOpt.orElseThrow(),
+                                            String.format(
+                                                "The descriptor with the handle %s from the report has not changed",
+                                                modifiedDescriptor.getHandle()));
 
                                     } else if (modificationType.equals(DescriptionModificationType.CRT)) {
                                         assertTrue(
-                                                descriptorBeforeReportOpt.isEmpty()
-                                                        && descriptorAfterReportOpt.isPresent(),
-                                                String.format(
-                                                        "The descriptor with handle %s is missing before applying the report:"
-                                                                + " %s and is present after applying the report: %s,"
-                                                                + " for modification type create",
-                                                        modifiedDescriptor.getHandle(),
-                                                        descriptorBeforeReportOpt.isEmpty(),
-                                                        descriptorAfterReportOpt.isPresent()));
+                                            descriptorBeforeReportOpt.isEmpty()
+                                                && descriptorAfterReportOpt.isPresent(),
+                                            String.format(
+                                                "The descriptor with handle %s is missing before applying the report:"
+                                                    + " %s and is present after applying the report: %s,"
+                                                    + " for modification type create",
+                                                modifiedDescriptor.getHandle(),
+                                                descriptorBeforeReportOpt.isEmpty(),
+                                                descriptorAfterReportOpt.isPresent()));
                                     } else {
                                         assertTrue(
-                                                descriptorBeforeReportOpt.isPresent()
-                                                        && descriptorAfterReportOpt.isEmpty(),
-                                                String.format(
-                                                        "The descriptor with handle %s is present before applying the report:"
-                                                                + " %s and is missing after applying the report: %s,"
-                                                                + " for modification type delete",
-                                                        modifiedDescriptor.getHandle(),
-                                                        descriptorBeforeReportOpt.isPresent(),
-                                                        descriptorAfterReportOpt.isEmpty()));
+                                            descriptorBeforeReportOpt.isPresent()
+                                                && descriptorAfterReportOpt.isEmpty(),
+                                            String.format(
+                                                "The descriptor with handle %s is present before applying the report:"
+                                                    + " %s and is missing after applying the report: %s,"
+                                                    + " for modification type delete",
+                                                modifiedDescriptor.getHandle(),
+                                                descriptorBeforeReportOpt.isPresent(),
+                                                descriptorAfterReportOpt.isEmpty()));
                                     }
                                 }
                             }
@@ -250,65 +252,65 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             });
         }
         assertTestData(
-                acceptableSequenceSeen.get(), "No DescriptionModificationReport seen during test run, test failed.");
+            acceptableSequenceSeen.get(), "No DescriptionModificationReport seen during test run, test failed.");
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C7)
     @TestDescription("Checks all DescriptionModificationReports seen during the TestRun for ReportParts whose "
-            + "./Descriptor references an MdsDescriptor and ensures that these ReportParts do not have the "
-            + "@ParentDescriptor attribute set.")
+        + "./Descriptor references an MdsDescriptor and ensures that these ReportParts do not have the "
+        + "@ParentDescriptor attribute set.")
     @RequirePrecondition(
-            simplePreconditions = ConditionalPreconditions.DescriptionModificationMdsDescriptorPrecondition.class)
+        simplePreconditions = ConditionalPreconditions.DescriptionModificationMdsDescriptorPrecondition.class)
     void testRequirementC7() throws NoTestData, IOException, MarshallingException {
         final var acceptableReportsSeen = new AtomicInteger(0);
 
         try (final MessageStorage.GetterResult<MessageContent> descriptionModificationReports =
-                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             for (MessageContent messageContent :
-                    descriptionModificationReports.getStream().toList()) {
+                descriptionModificationReports.getStream().toList()) {
                 final SoapMessage soapMessage = marshalling.unmarshal(
-                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                    new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                 final DescriptionModificationReport descriptionModificationReport = soapUtil.getBody(
-                                soapMessage, DescriptionModificationReport.class)
-                        .orElseThrow();
+                        soapMessage, DescriptionModificationReport.class)
+                    .orElseThrow();
 
                 for (DescriptionModificationReport.ReportPart reportPart :
-                        descriptionModificationReport.getReportPart()) {
+                    descriptionModificationReport.getReportPart()) {
                     if (reportPart.getDescriptor().stream().anyMatch(MdsDescriptor.class::isInstance)) {
                         acceptableReportsSeen.incrementAndGet();
                         final String parentDescriptor = reportPart.getParentDescriptor();
                         assertTrue(
-                                parentDescriptor == null || parentDescriptor.isBlank(),
-                                String.format(
-                                        "Encountered a DescriptionModificationReport/ReportPart whose Descriptor references an "
-                                                + "MdsDescriptor, but whose @ParentDescriptor is set to '%s'.",
-                                        parentDescriptor));
+                            parentDescriptor == null || parentDescriptor.isBlank(),
+                            String.format(
+                                "Encountered a DescriptionModificationReport/ReportPart whose Descriptor references an "
+                                    + "MdsDescriptor, but whose @ParentDescriptor is set to '%s'.",
+                                parentDescriptor));
                     }
                 }
             }
         }
 
         assertTestData(
-                acceptableReportsSeen.get(),
-                "No DescriptionModificationReport containing MdsDescriptors seen during test run, test failed.");
+            acceptableReportsSeen.get(),
+            "No DescriptionModificationReport containing MdsDescriptors seen during test run, test failed.");
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_R5024)
     @TestDescription("Retrieves each report part from each description modification report seen during the test run and"
-            + " checks that each descriptor does not contain nested descriptors.")
+        + " checks that each descriptor does not contain nested descriptors.")
     @RequirePrecondition(
-            simplePreconditions = {ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.class})
+        simplePreconditions = {ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.class})
     void testRequirementR5024() throws NoTestData, IOException {
         try (final var messages =
-                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             final var descriptorsSeen = new AtomicInteger(0);
 
             messages.getStream().forEach(messageContent -> {
                 try {
                     final var soapMessage = marshalling.unmarshal(
-                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                     final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                     if (reportOpt.isPresent()) {
                         for (var part : reportOpt.orElseThrow().getReportPart()) {
@@ -324,51 +326,51 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             });
 
             assertTestData(
-                    descriptorsSeen.get(),
-                    "No Descriptors in DescriptionModificationReports seen during test run, test failed.");
+                descriptorsSeen.get(),
+                "No Descriptors in DescriptionModificationReports seen during test run, test failed.");
         }
     }
 
     @Test
     @DisplayName("Biceps:R5025_0: A SERVICE PROVIDER shall order msg:DescriptionModificationReport/msg:ReportPart"
-            + " elements in a way the report parts containing parent descriptors appear before report parts containing"
-            + " their child descriptors.")
+        + " elements in a way the report parts containing parent descriptors appear before report parts containing"
+        + " their child descriptors.")
     @TestIdentifier(EnabledTestConfig.BICEPS_R5025_0)
     @TestDescription("For every DescriptionModificationReport received from the DUT, and for all parent-child"
-            + " relationships between the elements contained in the report, checks that the reportPart containing"
-            + " the parent comes before the reportPart containing the child.")
+        + " relationships between the elements contained in the report, checks that the reportPart containing"
+        + " the parent comes before the reportPart containing the child.")
     @RequirePrecondition(
-            manipulationPreconditions =
-                    ManipulationPreconditions.DescriptionModificationAllWithParentChildRelationshipPrecondition.class)
+        manipulationPreconditions =
+            ManipulationPreconditions.DescriptionModificationAllWithParentChildRelationshipPrecondition.class)
     void testRequirementR5025() throws NoTestData, IOException {
         try (final var messages =
-                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             final var descriptorsSeen = new AtomicInteger(0);
 
             messages.getStream().forEach(messageContent -> {
                 try {
                     final var soapMessage = marshalling.unmarshal(
-                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                     final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                     reportOpt.ifPresent(descriptionModificationReport ->
-                            checkOrderOfReportParts(descriptionModificationReport, descriptorsSeen));
+                        checkOrderOfReportParts(descriptionModificationReport, descriptorsSeen));
                 } catch (MarshallingException e) {
                     fail("Error unmarshalling MessageContent " + e);
                 }
             });
 
             assertTestData(
-                    descriptorsSeen.get(),
-                    "No DescriptionModificationReports with Parent-Child Relationships between Descriptors "
-                            + " seen during test run, test failed."
-                            + " Please make sure that the device either supports descriptor updates or that the list"
-                            + " of removable descriptors returned by the getRemovableDescriptors() manipulation"
-                            + " includes at least one descriptor that has child descriptors.");
+                descriptorsSeen.get(),
+                "No DescriptionModificationReports with Parent-Child Relationships between Descriptors "
+                    + " seen during test run, test failed."
+                    + " Please make sure that the device either supports descriptor updates or that the list"
+                    + " of removable descriptors returned by the getRemovableDescriptors() manipulation"
+                    + " includes at least one descriptor that has child descriptors.");
         }
     }
 
     private void checkOrderOfReportParts(
-            final DescriptionModificationReport report, final AtomicInteger descriptorsSeen) {
+        final DescriptionModificationReport report, final AtomicInteger descriptorsSeen) {
         final var modifiedParentHandles = new HashMap<String, Pair<Integer, String>>();
         final List<DescriptionModificationReport.ReportPart> reportParts = report.getReportPart();
         for (var i = 0; i < reportParts.size(); i++) {
@@ -392,11 +394,11 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                     final Integer indexOfFirstChildUpdate = pair.getLeft();
                     final String childHandle = pair.getRight();
                     assertTrue(
-                            indexOfParentUpdate < indexOfFirstChildUpdate,
-                            String.format(
-                                    "reportPart containing child descriptor '%s' is listed before the reportPart"
-                                            + " containing its parent descriptor '%s' in a DescriptionModificationReport.",
-                                    childHandle, key));
+                        indexOfParentUpdate < indexOfFirstChildUpdate,
+                        String.format(
+                            "reportPart containing child descriptor '%s' is listed before the reportPart"
+                                + " containing its parent descriptor '%s' in a DescriptionModificationReport.",
+                            childHandle, key));
                     descriptorsSeen.incrementAndGet();
                 }
             }
@@ -409,62 +411,62 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
         if (descriptor instanceof AlertSystemDescriptor alertSystem) {
             // verify that the alarm system has no alarm signals or alarm conditions
             assertTrue(
-                    alertSystem.getAlertCondition().isEmpty(),
-                    String.format(errorMsg, descriptor.getClass(), handle, alertSystem.getAlertCondition()));
+                alertSystem.getAlertCondition().isEmpty(),
+                String.format(errorMsg, descriptor.getClass(), handle, alertSystem.getAlertCondition()));
             assertTrue(
-                    alertSystem.getAlertSignal().isEmpty(),
-                    String.format(errorMsg, descriptor.getClass(), handle, alertSystem.getAlertSignal()));
+                alertSystem.getAlertSignal().isEmpty(),
+                String.format(errorMsg, descriptor.getClass(), handle, alertSystem.getAlertSignal()));
         } else if (descriptor instanceof ChannelDescriptor channel) {
             // verify that the channel has no metrics
             assertTrue(
-                    channel.getMetric().isEmpty(),
-                    String.format(errorMsg, descriptor.getClass(), handle, channel.getMetric()));
+                channel.getMetric().isEmpty(),
+                String.format(errorMsg, descriptor.getClass(), handle, channel.getMetric()));
         } else if (descriptor instanceof MdsDescriptor mds) {
             // verify that the mds has no alert system, sco, system context, clock, batteries or vmds
             assertNull(
-                    mds.getAlertSystem(), String.format(errorMsg, descriptor.getClass(), handle, mds.getAlertSystem()));
+                mds.getAlertSystem(), String.format(errorMsg, descriptor.getClass(), handle, mds.getAlertSystem()));
             assertNull(mds.getSco(), String.format(errorMsg, descriptor.getClass(), handle, mds.getSco()));
             assertNull(
-                    mds.getSystemContext(),
-                    String.format(errorMsg, descriptor.getClass(), handle, mds.getSystemContext()));
+                mds.getSystemContext(),
+                String.format(errorMsg, descriptor.getClass(), handle, mds.getSystemContext()));
             assertNull(mds.getClock(), String.format(errorMsg, descriptor.getClass(), handle, mds.getClock()));
             assertTrue(
-                    mds.getBattery().isEmpty(),
-                    String.format(errorMsg, descriptor.getClass(), handle, mds.getBattery()));
+                mds.getBattery().isEmpty(),
+                String.format(errorMsg, descriptor.getClass(), handle, mds.getBattery()));
             assertTrue(mds.getVmd().isEmpty(), String.format(errorMsg, descriptor.getClass(), handle, mds.getVmd()));
         } else if (descriptor instanceof ScoDescriptor sco) {
             // verify that the sco has no operations
             assertTrue(
-                    sco.getOperation().isEmpty(),
-                    String.format(errorMsg, descriptor.getClass(), handle, sco.getOperation()));
+                sco.getOperation().isEmpty(),
+                String.format(errorMsg, descriptor.getClass(), handle, sco.getOperation()));
         } else if (descriptor instanceof SystemContextDescriptor systemContext) {
             // verify that the system context has no patient and location context and no ensemble, operator
             // workflow and mean contexts
             assertNull(
-                    systemContext.getPatientContext(),
-                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getPatientContext()));
+                systemContext.getPatientContext(),
+                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getPatientContext()));
             assertNull(
-                    systemContext.getLocationContext(),
-                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getLocationContext()));
+                systemContext.getLocationContext(),
+                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getLocationContext()));
             assertTrue(
-                    systemContext.getEnsembleContext().isEmpty(),
-                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getEnsembleContext()));
+                systemContext.getEnsembleContext().isEmpty(),
+                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getEnsembleContext()));
             assertTrue(
-                    systemContext.getOperatorContext().isEmpty(),
-                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getOperatorContext()));
+                systemContext.getOperatorContext().isEmpty(),
+                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getOperatorContext()));
             assertTrue(
-                    systemContext.getWorkflowContext().isEmpty(),
-                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getWorkflowContext()));
+                systemContext.getWorkflowContext().isEmpty(),
+                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getWorkflowContext()));
             assertTrue(
-                    systemContext.getMeansContext().isEmpty(),
-                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getMeansContext()));
+                systemContext.getMeansContext().isEmpty(),
+                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getMeansContext()));
         } else if (descriptor instanceof VmdDescriptor vmd) {
             // verify that the vmd has no channels, vmd and sco
             assertTrue(
-                    vmd.getChannel().isEmpty(),
-                    String.format(errorMsg, descriptor.getClass(), handle, vmd.getChannel()));
+                vmd.getChannel().isEmpty(),
+                String.format(errorMsg, descriptor.getClass(), handle, vmd.getChannel()));
             assertNull(
-                    vmd.getAlertSystem(), String.format(errorMsg, descriptor.getClass(), handle, vmd.getAlertSystem()));
+                vmd.getAlertSystem(), String.format(errorMsg, descriptor.getClass(), handle, vmd.getAlertSystem()));
             assertNull(vmd.getSco(), String.format(errorMsg, descriptor.getClass(), handle, vmd.getSco()));
         }
     }
@@ -473,12 +475,12 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @DisplayName("A SERVICE PROVIDER shall not delete a parent descriptor when it contains child descriptors.")
     @TestIdentifier(EnabledTestConfig.BICEPS_R5046_0)
     @TestDescription("Starting from the initially retrieved mdib, applies each report to the mdib and checks that each"
-            + " descriptor in each description modification report part with modification type del does not contain any"
-            + " child descriptors.")
+        + " descriptor in each description modification report part with modification type del does not contain any"
+        + " child descriptors.")
     @RequirePrecondition(simplePreconditions = ConditionalPreconditions.DescriptionModificationDelPrecondition.class)
     void testRequirementR50460() throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
-                messageStorage, getInjector().getInstance(TestRunObserver.class));
+            messageStorage, getInjector().getInstance(TestRunObserver.class));
         final var acceptableSequenceSeen = new AtomicInteger(0);
         try (final Stream<String> sequenceIds = mdibHistorian.getKnownSequenceIds()) {
             sequenceIds.forEach(sequenceId -> {
@@ -502,14 +504,14 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                                     for (var descriptor : part.getDescriptor()) {
                                         final var entity = mdib.getEntity(descriptor.getHandle());
                                         assertTrue(
-                                                entity.isPresent()
-                                                        && entity.orElseThrow()
-                                                                .getChildren()
-                                                                .isEmpty(),
-                                                String.format(
-                                                        "The descriptor with the handle %s still has following child descriptors %s.",
-                                                        entity.orElseThrow().getHandle(),
-                                                        entity.orElseThrow().getChildren()));
+                                            entity.isPresent()
+                                                && entity.orElseThrow()
+                                                .getChildren()
+                                                .isEmpty(),
+                                            String.format(
+                                                "The descriptor with the handle %s still has following child descriptors %s.",
+                                                entity.orElseThrow().getHandle(),
+                                                entity.orElseThrow().getChildren()));
                                     }
                                 }
                             }
@@ -527,121 +529,121 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_R5051)
     @TestDescription("Retrieves each report part with modification type crt from each description modification report"
-            + " seen during the test run, and compares the descriptor version from each state to the descriptor version"
-            + " of the respective descriptor.")
+        + " seen during the test run, and compares the descriptor version from each state to the descriptor version"
+        + " of the respective descriptor.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.DescriptionModificationCrtPrecondition.class})
     void testRequirementR5051() throws NoTestData, IOException {
         try (final var messages =
-                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
 
             final var acceptableSequenceSeen = new AtomicInteger(0);
             final var impliedValueMap = new HashMap<String, InitialImpliedValue>();
             messages.getStream().forEach(messageContent -> {
                 try {
                     final var soapMessage = marshalling.unmarshal(
-                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                     final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                     final var crtReportParts = reportOpt.orElseThrow().getReportPart().stream()
-                            .filter(part ->
-                                    ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.CRT))
-                            .toList();
+                        .filter(part ->
+                            ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.CRT))
+                        .toList();
                     for (var part : crtReportParts) {
                         for (var state : part.getState()) {
                             acceptableSequenceSeen.incrementAndGet();
                             final var handle = state.getDescriptorHandle();
                             final var descriptorVersion = ImpliedValueUtil.getStateDescriptorVersion(
-                                    state,
-                                    impliedValueMap.computeIfAbsent(
-                                            reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
+                                state,
+                                impliedValueMap.computeIfAbsent(
+                                    reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
                             final var descriptor = part.getDescriptor().stream()
-                                    .filter(abstractDescriptor ->
-                                            abstractDescriptor.getHandle().equals(handle))
-                                    .findFirst();
+                                .filter(abstractDescriptor ->
+                                    abstractDescriptor.getHandle().equals(handle))
+                                .findFirst();
                             assertTrue(
-                                    descriptor.isPresent(),
-                                    String.format("No matching descriptor for handle %s found.", handle));
+                                descriptor.isPresent(),
+                                String.format("No matching descriptor for handle %s found.", handle));
                             final var descriptorsDescriptorVersion = ImpliedValueUtil.getDescriptorVersion(
-                                    descriptor.orElseThrow(),
-                                    impliedValueMap.computeIfAbsent(
-                                            reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
+                                descriptor.orElseThrow(),
+                                impliedValueMap.computeIfAbsent(
+                                    reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
                             assertEquals(
-                                    descriptorsDescriptorVersion,
-                                    descriptorVersion,
-                                    String.format(
-                                            "The descriptor version of state is %s, but should be %s, for %s.",
-                                            descriptorVersion, descriptorsDescriptorVersion, handle));
+                                descriptorsDescriptorVersion,
+                                descriptorVersion,
+                                String.format(
+                                    "The descriptor version of state is %s, but should be %s, for %s.",
+                                    descriptorVersion, descriptorsDescriptorVersion, handle));
                         }
                     }
                 } catch (MarshallingException e) {
                     fail("Error unmarshalling MessageContent " + e);
                 } catch (InitialImpliedValueException e) {
                     fail(
-                            "The descriptor version was an implied value, but was not allowed to be one."
-                                    + " It occurred previously without an implied value.",
-                            e);
+                        "The descriptor version was an implied value, but was not allowed to be one."
+                            + " It occurred previously without an implied value.",
+                        e);
                 }
             });
 
             assertTestData(
-                    acceptableSequenceSeen.get(),
-                    "No report parts with description modification type crt seen during test run, test failed");
+                acceptableSequenceSeen.get(),
+                "No report parts with description modification type crt seen during test run, test failed");
         }
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_R5052)
     @TestDescription("Retrieves every report part with modification type upt from every description modification report"
-            + " seen during the test run and compares the descriptor version from each state with the descriptor version"
-            + " of their descriptor.")
+        + " seen during the test run and compares the descriptor version from each state with the descriptor version"
+        + " of their descriptor.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.DescriptionModificationUptPrecondition.class})
     void testRequirementR5052() throws NoTestData, IOException {
         try (final var messages =
-                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             final var acceptableSequenceSeen = new AtomicInteger(0);
 
             final var impliedValueMap = new HashMap<Object, InitialImpliedValue>();
             messages.getStream().forEach(messageContent -> {
                 try {
                     final var soapMessage = marshalling.unmarshal(
-                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                     final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                     final var uptReportParts = reportOpt.orElseThrow().getReportPart().stream()
-                            .filter(part ->
-                                    ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.UPT))
-                            .toList();
+                        .filter(part ->
+                            ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.UPT))
+                        .toList();
                     for (var part : uptReportParts) {
                         acceptableSequenceSeen.incrementAndGet();
                         for (var state : part.getState()) {
                             final var handle = state.getDescriptorHandle();
                             final var descriptorVersion = ImpliedValueUtil.getStateDescriptorVersion(
-                                    state,
-                                    impliedValueMap.computeIfAbsent(
-                                            reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
+                                state,
+                                impliedValueMap.computeIfAbsent(
+                                    reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
                             final var descriptor = part.getDescriptor().stream()
-                                    .filter(abstractDescriptor ->
-                                            abstractDescriptor.getHandle().equals(handle))
-                                    .findFirst();
+                                .filter(abstractDescriptor ->
+                                    abstractDescriptor.getHandle().equals(handle))
+                                .findFirst();
                             assertTrue(
-                                    descriptor.isPresent(),
-                                    String.format("No matching descriptor for handle %s found.", handle));
+                                descriptor.isPresent(),
+                                String.format("No matching descriptor for handle %s found.", handle));
                             final var descriptorsDescriptorVersion = ImpliedValueUtil.getDescriptorVersion(
-                                    descriptor.orElseThrow(),
-                                    impliedValueMap.computeIfAbsent(
-                                            reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
+                                descriptor.orElseThrow(),
+                                impliedValueMap.computeIfAbsent(
+                                    reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
                             assertEquals(
-                                    descriptorsDescriptorVersion,
+                                descriptorsDescriptorVersion,
+                                descriptorVersion,
+                                String.format(
+                                    "The descriptor version of state is %s, but should be %s, for %s.",
                                     descriptorVersion,
-                                    String.format(
-                                            "The descriptor version of state is %s, but should be %s, for %s.",
-                                            descriptorVersion,
-                                            ImpliedValueUtil.getDescriptorVersion(
-                                                    descriptor.orElseThrow(),
-                                                    impliedValueMap.computeIfAbsent(
-                                                            reportOpt
-                                                                    .orElseThrow()
-                                                                    .getSequenceId(),
-                                                            k -> new InitialImpliedValue())),
-                                            handle));
+                                    ImpliedValueUtil.getDescriptorVersion(
+                                        descriptor.orElseThrow(),
+                                        impliedValueMap.computeIfAbsent(
+                                            reportOpt
+                                                .orElseThrow()
+                                                .getSequenceId(),
+                                            k -> new InitialImpliedValue())),
+                                    handle));
                         }
                     }
                 } catch (MarshallingException | InitialImpliedValueException e) {
@@ -650,35 +652,35 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             });
 
             assertTestData(
-                    acceptableSequenceSeen.get(),
-                    "No report parts with description modification type upt seen during test run, test failed");
+                acceptableSequenceSeen.get(),
+                "No report parts with description modification type upt seen during test run, test failed");
         }
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_R5053)
     @TestDescription("Retrieves every report part with modification type del from every description modification report"
-            + " seen during the test run and checks if the states are excluded from the message.")
+        + " seen during the test run and checks if the states are excluded from the message.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.DescriptionModificationDelPrecondition.class})
     void testRequirementR5053() throws NoTestData, IOException {
         try (final var messages =
-                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             final var delReportsSeen = new AtomicInteger(0);
 
             messages.getStream().forEach(messageContent -> {
                 try {
                     final var soapMessage = marshalling.unmarshal(
-                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                     final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                     final var delReportParts = reportOpt.orElseThrow().getReportPart().stream()
-                            .filter(part ->
-                                    ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.DEL))
-                            .toList();
+                        .filter(part ->
+                            ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.DEL))
+                        .toList();
                     for (var part : delReportParts) {
                         delReportsSeen.incrementAndGet();
                         assertTrue(
-                                part.getState().isEmpty(),
-                                "State should not be part of the report with modification type delete.");
+                            part.getState().isEmpty(),
+                            "State should not be part of the report with modification type delete.");
                     }
                 } catch (MarshallingException e) {
                     fail("Error unmarshalling MessageContent " + e);
@@ -686,22 +688,22 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             });
 
             assertTestData(
-                    delReportsSeen.get(),
-                    "No report parts with description modification type del seen during test run, test failed");
+                delReportsSeen.get(),
+                "No report parts with description modification type del seen during test run, test failed");
         }
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C11)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-            + " whether at least one child or attribute has changed for each AbstractAlertState contained in an"
-            + " EpisodicAlertReport.")
+        + " whether at least one child or attribute has changed for each AbstractAlertState contained in an"
+        + " EpisodicAlertReport.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerEpisodicAlertReportPrecondition.class})
     void testRequirementC11() throws NoTestData, IOException {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((AbstractAlertReport) report)
-                .getReportPart().stream()
-                        .map(AbstractAlertReport.ReportPart::getAlertState)
-                        .collect(Collectors.toUnmodifiableList());
+            .getReportPart().stream()
+            .map(AbstractAlertReport.ReportPart::getAlertState)
+            .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(EpisodicAlertReport.class, AbstractAlertState.class, getStatesOfReportParts);
     }
@@ -709,32 +711,32 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C12)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-            + " whether at least one child or attribute has changed for each AbstractComponentState contained in an"
-            + " EpisodicComponentReport.")
+        + " whether at least one child or attribute has changed for each AbstractComponentState contained in an"
+        + " EpisodicComponentReport.")
     @RequirePrecondition(
-            simplePreconditions = {ConditionalPreconditions.TriggerEpisodicComponentReportPrecondition.class})
+        simplePreconditions = {ConditionalPreconditions.TriggerEpisodicComponentReportPrecondition.class})
     void testRequirementC12() throws NoTestData, IOException {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicComponentReport) report)
-                .getReportPart().stream()
-                        .map(EpisodicComponentReport.ReportPart::getComponentState)
-                        .collect(Collectors.toUnmodifiableList());
+            .getReportPart().stream()
+            .map(EpisodicComponentReport.ReportPart::getComponentState)
+            .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(
-                EpisodicComponentReport.class, AbstractDeviceComponentState.class, getStatesOfReportParts);
+            EpisodicComponentReport.class, AbstractDeviceComponentState.class, getStatesOfReportParts);
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C13)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-            + " whether at least one child or attribute has changed for each AbstractContextState contained in an"
-            + " EpisodicContextReport.")
+        + " whether at least one child or attribute has changed for each AbstractContextState contained in an"
+        + " EpisodicContextReport.")
     @RequirePrecondition(
-            simplePreconditions = {ConditionalPreconditions.TriggerEpisodicContextReportPrecondition.class})
+        simplePreconditions = {ConditionalPreconditions.TriggerEpisodicContextReportPrecondition.class})
     void testRequirementC13() throws NoTestData, IOException {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicContextReport) report)
-                .getReportPart().stream()
-                        .map(EpisodicContextReport.ReportPart::getContextState)
-                        .collect(Collectors.toUnmodifiableList());
+            .getReportPart().stream()
+            .map(EpisodicContextReport.ReportPart::getContextState)
+            .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(EpisodicContextReport.class, AbstractContextState.class, getStatesOfReportParts);
     }
@@ -742,14 +744,14 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C14)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-            + " whether at least one child or attribute has changed for each AbstractMetricState contained in an"
-            + " EpisodicMetricReport.")
+        + " whether at least one child or attribute has changed for each AbstractMetricState contained in an"
+        + " EpisodicMetricReport.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerEpisodicMetricReportPrecondition.class})
     void testRequirementC14() throws NoTestData, IOException {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicMetricReport) report)
-                .getReportPart().stream()
-                        .map(EpisodicMetricReport.ReportPart::getMetricState)
-                        .collect(Collectors.toUnmodifiableList());
+            .getReportPart().stream()
+            .map(EpisodicMetricReport.ReportPart::getMetricState)
+            .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(EpisodicMetricReport.class, AbstractMetricState.class, getStatesOfReportParts);
     }
@@ -757,142 +759,100 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C15)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-            + " whether at least one child or attribute has changed for each AbstractOperationState contained in an"
-            + " EpisodicOperationalStateReport.")
+        + " whether at least one child or attribute has changed for each AbstractOperationState contained in an"
+        + " EpisodicOperationalStateReport.")
     @RequirePrecondition(
-            simplePreconditions = {ConditionalPreconditions.TriggerEpisodicOperationalStateReportPrecondition.class})
+        simplePreconditions = {ConditionalPreconditions.TriggerEpisodicOperationalStateReportPrecondition.class})
     void testRequirementC15() throws NoTestData, IOException {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicOperationalStateReport) report)
-                .getReportPart().stream()
-                        .map(EpisodicOperationalStateReport.ReportPart::getOperationState)
-                        .collect(Collectors.toUnmodifiableList());
+            .getReportPart().stream()
+            .map(EpisodicOperationalStateReport.ReportPart::getOperationState)
+            .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(
-                EpisodicOperationalStateReport.class, AbstractOperationState.class, getStatesOfReportParts);
+            EpisodicOperationalStateReport.class, AbstractOperationState.class, getStatesOfReportParts);
     }
 
-    private void testEpisodicReportRequirement(
-            final Class<? extends AbstractReport> reportClass,
-            final Class<? extends AbstractState> stateClass,
-            final GetStatesOfReportParts getStatesOfReportParts)
-            throws NoTestData, IOException {
+    private void testEpisodicReportRequirement(final Class<? extends AbstractReport> reportClass,
+                                               final Class<? extends AbstractState> stateClass,
+                                               final GetStatesOfReportParts getStatesOfReportParts) throws NoTestData {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
-                messageStorage, getInjector().getInstance(TestRunObserver.class));
+            messageStorage, getInjector().getInstance(TestRunObserver.class));
 
         final var acceptableSequenceSeen = new AtomicInteger(0);
-
         try (final Stream<String> sequenceIds = mdibHistorian.getKnownSequenceIds()) {
             sequenceIds.forEach(sequenceId -> {
-                RemoteMdibAccess first = null;
-                RemoteMdibAccess second = null;
+                RemoteMdibAccess manualMdibAccess;
+                RemoteMdibAccess mdibAccess;
                 try {
-                    first = mdibHistorian.createNewStorage(sequenceId);
-                    second = mdibHistorian.createNewStorage(sequenceId);
-                } catch (PreprocessingException e) {
-                    fail(e);
-                }
+                    manualMdibAccess = mdibHistorian.createNewStorage(sequenceId);
+                    // get relevant reports
+                    final var minimumMdibVersion = ImpliedValueUtil.getMdibVersion(manualMdibAccess.getMdibVersion());
+                    try (final var reports = mdibHistorian.getAllUniqueReports(sequenceId, minimumMdibVersion)) {
+                        try (final var history = mdibHistorian.episodicReportBasedHistory(sequenceId)) {
+                            mdibAccess = history.next();
 
-                // get relevant reports
-                final var minimumMdibVersion = ImpliedValueUtil.getMdibVersion(first.getMdibVersion());
-                try (final var reports = mdibHistorian.getAllUniqueReports(sequenceId, minimumMdibVersion)) {
+                            for (final Iterator<AbstractReport> iterator = reports.iterator(); iterator.hasNext();) {
+                                final AbstractReport report = iterator.next();
+                                manualMdibAccess = mdibHistorian.applyReportOnStorage(manualMdibAccess, report);
 
-                    DescriptionModificationReport previousDescriptionModificationReport = null;
-                    final var statesFromDescriptionModificationReport = new ArrayList<>();
-                    for (final Iterator<AbstractReport> iterator = reports.iterator(); iterator.hasNext(); ) {
-                        final AbstractReport report = iterator.next();
-
-                        if (report instanceof DescriptionModificationReport) {
-                            previousDescriptionModificationReport = (DescriptionModificationReport) report;
-                        }
-
-                        if (reportClass.isInstance(report)) {
-                            acceptableSequenceSeen.incrementAndGet();
-                            second = mdibHistorian.applyReportOnStorage(second, report);
-
-                            // collect all relevant states from the DescriptionModificationReport, one with the same
-                            // MdibVersion exists.
-                            statesFromDescriptionModificationReport.clear();
-                            if (previousDescriptionModificationReport != null
-                                    && ImpliedValueUtil.getReportMdibVersion(previousDescriptionModificationReport)
-                                            .equals(ImpliedValueUtil.getReportMdibVersion(report))) {
-                                statesFromDescriptionModificationReport.addAll(
-                                        previousDescriptionModificationReport.getReportPart().stream()
-                                                .map(DescriptionModificationReport.ReportPart::getState)
-                                                .flatMap(List::stream)
-                                                .filter(stateClass::isInstance)
-                                                .map(stateClass::cast)
-                                                .toList());
-                            }
-
-                            final var reportParts = getStatesOfReportParts.apply(reportClass.cast(report));
-                            for (var reportPart : reportParts) {
-                                for (var state : reportPart) {
-                                    final Optional<? extends AbstractState> stateBeforeReport;
-                                    final Optional<? extends AbstractState> stateAfterReport;
-
-                                    if (state instanceof AbstractMultiState multiState) {
-                                        final var beforeReport = first.getEntity(multiState.getDescriptorHandle());
-                                        final var afterReport = second.getEntity(multiState.getDescriptorHandle());
-                                        stateBeforeReport =
-                                                beforeReport.orElseThrow().getStates(AbstractMultiState.class).stream()
-                                                        .filter(it ->
-                                                                it.getHandle().equals(multiState.getHandle()))
-                                                        .findFirst();
-                                        stateAfterReport =
-                                                afterReport.orElseThrow().getStates(AbstractMultiState.class).stream()
-                                                        .filter(it ->
-                                                                it.getHandle().equals(multiState.getHandle()))
-                                                        .findFirst();
-                                        if (!(stateBeforeReport.isPresent() && stateAfterReport.isPresent())) {
-                                            // when not both AbstractMultiStates are present it must be inserted.
-                                            assertTrue(
-                                                    stateBeforeReport.isEmpty() && stateAfterReport.isPresent(),
-                                                    String.format(STATE_ABSENT, state.getDescriptorHandle()));
-                                            continue;
-                                        }
-                                    } else {
-                                        // no AbstractMultiState so state should be present before and after the report
-                                        stateBeforeReport = first.getState(state.getDescriptorHandle(), stateClass);
-                                        stateAfterReport = second.getState(state.getDescriptorHandle(), stateClass);
-                                        assertTrue(
-                                                stateBeforeReport.isPresent() && stateAfterReport.isPresent(),
-                                                String.format(STATE_ABSENT, state.getDescriptorHandle()));
+                                if (reportClass.isInstance(report)) {
+                                    acceptableSequenceSeen.incrementAndGet();
+                                    final var priorMdibVersion = report.getMdibVersion().subtract(BigInteger.ONE);
+                                    // fast-forward history to the mdibversion before the report
+                                    while (mdibAccess.getMdibVersion().getVersion().compareTo(priorMdibVersion) < 0) {
+                                        mdibAccess = history.next();
                                     }
 
-                                    if (statesFromDescriptionModificationReport.stream()
-                                            .anyMatch(it -> ((AbstractState) it)
-                                                    .getDescriptorHandle()
-                                                    .equals(stateAfterReport
-                                                            .orElseThrow()
-                                                            .getDescriptorHandle()))) {
-                                        LOG.debug(
-                                                "The state with handle {} was already seen in a DescriptionModificationReport in MdibVersion {} and SequenceId {}.",
-                                                stateAfterReport.orElseThrow().getDescriptorHandle(),
-                                                ImpliedValueUtil.getReportMdibVersion(report),
-                                                report.getSequenceId());
-                                    } else {
-                                        assertNotEquals(
+                                    // get every state of the report
+                                    final var reportParts = getStatesOfReportParts.apply(reportClass.cast(report));
+                                    for (var reportPart : reportParts) {
+                                        for (var state : reportPart) {
+                                            final Optional<? extends AbstractState> stateBeforeReport;
+                                            final Optional<? extends AbstractState> stateAfterReport;
+                                            // multistate need a different handling
+                                            if (state instanceof AbstractMultiState multiState) {
+                                                stateBeforeReport = mdibAccess.getState(multiState.getHandle(), AbstractMultiState.class);
+                                                stateAfterReport = manualMdibAccess.getState(multiState.getHandle(), AbstractMultiState.class);
+
+                                                if (!(stateBeforeReport.isPresent() && stateAfterReport.isPresent())) {
+                                                    // when not both AbstractMultiStates are present it must be inserted.
+                                                    assertTrue(
+                                                        stateBeforeReport.isEmpty() && stateAfterReport.isPresent(),
+                                                        String.format(STATE_ABSENT, state.getDescriptorHandle()));
+                                                    continue;
+                                                }
+                                            } else {
+                                                stateBeforeReport =
+                                                    mdibAccess.getState(state.getDescriptorHandle(), stateClass);
+                                                stateAfterReport =
+                                                    manualMdibAccess.getState(state.getDescriptorHandle(), stateClass);
+                                                assertTrue(
+                                                    stateBeforeReport.isPresent() && stateAfterReport.isPresent(),
+                                                    String.format(STATE_ABSENT, state.getDescriptorHandle()));
+                                            }
+                                            assertNotEquals(
                                                 stateAfterReport.orElseThrow(),
                                                 stateBeforeReport.orElseThrow(),
                                                 String.format(STATE_UNCHANGED, state.getDescriptorHandle()));
+                                        }
                                     }
                                 }
                             }
-                            previousDescriptionModificationReport = null;
-                            first = mdibHistorian.applyReportOnStorage(first, report);
-                        } else {
-                            first = mdibHistorian.applyReportOnStorage(first, report);
-                            second = mdibHistorian.applyReportOnStorage(second, report);
+                        } catch (ReportProcessingException e) {
+                            fail(e);
                         }
                     }
-                } catch (PreprocessingException | ReportProcessingException e) {
+                } catch (PreprocessingException e) {
                     fail(e);
                 }
             });
+        } catch (IOException e) {
+            fail(e);
         }
         assertTestData(
-                acceptableSequenceSeen.get(),
-                String.format("No %s seen during test run, test failed.", reportClass.getSimpleName()));
+            acceptableSequenceSeen.get(),
+            String.format("No %s seen during test run, test failed.", reportClass.getSimpleName()));
     }
 
     @FunctionalInterface

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -62,7 +62,6 @@ import org.somda.sdc.biceps.model.participant.AbstractContextState;
 import org.somda.sdc.biceps.model.participant.AbstractDescriptor;
 import org.somda.sdc.biceps.model.participant.AbstractDeviceComponentState;
 import org.somda.sdc.biceps.model.participant.AbstractMetricState;
-import org.somda.sdc.biceps.model.participant.AbstractMultiState;
 import org.somda.sdc.biceps.model.participant.AbstractOperationState;
 import org.somda.sdc.biceps.model.participant.AbstractState;
 import org.somda.sdc.biceps.model.participant.AlertSystemDescriptor;
@@ -866,17 +865,12 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                         for (var state : reportPart) {
                             final Optional<? extends AbstractState> stateBeforeReport;
 
-                            if (state instanceof AbstractMultiState multiState) {
-                                stateBeforeReport =
-                                        mdibAccess.getState(multiState.getHandle(), AbstractMultiState.class);
-
-                                if (stateBeforeReport.isEmpty()) {
-                                    // when stateBeforeReport is not present, the AbstractMultiState was
-                                    // inserted.
-                                    continue;
-                                }
-                            } else {
-                                stateBeforeReport = mdibAccess.getState(state.getDescriptorHandle(), stateClass);
+                            stateBeforeReport = mdibAccess.getState(state.getDescriptorHandle(), stateClass);
+                            if (stateBeforeReport.isEmpty()) {
+                                // If stateBeforeReport is not present, it has either been inserted as a multi-state or
+                                // with a description change report within the same mdib version. In both cases,
+                                // the state has definitely changed.
+                                continue;
                             }
                             assertNotEquals(
                                     state,

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -26,11 +26,11 @@ import com.draeger.medical.sdccc.tests.annotations.TestIdentifier;
 import com.draeger.medical.sdccc.tests.util.ImpliedValueUtil;
 import com.draeger.medical.sdccc.tests.util.InitialImpliedValue;
 import com.draeger.medical.sdccc.tests.util.InitialImpliedValueException;
+import com.draeger.medical.sdccc.tests.util.MdibHistorian;
 import com.draeger.medical.sdccc.tests.util.NoTestData;
 import com.draeger.medical.sdccc.tests.util.guice.MdibHistorianFactory;
 import com.draeger.medical.sdccc.util.Constants;
 import com.draeger.medical.sdccc.util.TestRunObserver;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -42,7 +42,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -103,27 +102,27 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
 
     @Test
     @DisplayName("A SERVICE PROVIDER SHALL include the parent descriptor handle in "
-        + "msg:DescriptionModificationReport/msg:ReportPart/@ParentDescriptor for any Descriptor that is not a "
-        + "pm:MdsDescriptor, if msg:DescriptionModificationReport/msg:ReportPart/@ModificationType "
-        + "is “Crt” (Created).")
+            + "msg:DescriptionModificationReport/msg:ReportPart/@ParentDescriptor for any Descriptor that is not a "
+            + "pm:MdsDescriptor, if msg:DescriptionModificationReport/msg:ReportPart/@ModificationType "
+            + "is “Crt” (Created).")
     @TestIdentifier(EnabledTestConfig.BICEPS_R0055_0)
     @TestDescription("Retrieves all DescriptionModificationReports seen during the TestRun and checks for each "
-        + "created AbstractDescriptor which is not an MdsDescriptor that the attribute @ParentDescriptor "
-        + "of its ReportPart is set.")
+            + "created AbstractDescriptor which is not an MdsDescriptor that the attribute @ParentDescriptor "
+            + "of its ReportPart is set.")
     @RequirePrecondition(simplePreconditions = ConditionalPreconditions.DescriptionModificationCrtPrecondition.class)
     void testRequirementR00550() throws NoTestData {
         final var acceptableReportPartSeen = new AtomicInteger(0);
 
         // get DescriptionModification reports
         try (final var reports =
-                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             for (final Iterator<MessageContent> iterator = reports.getStream().iterator(); iterator.hasNext(); ) {
 
                 final MessageContent messageContent = iterator.next();
                 final SoapMessage soapMessage = marshalling.unmarshal(
-                    new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                 final Optional<DescriptionModificationReport> reportOpt =
-                    soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
+                        soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                 final DescriptionModificationReport descriptionModificationReport = reportOpt.orElseThrow();
 
                 for (var reportPart : descriptionModificationReport.getReportPart()) {
@@ -134,14 +133,14 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                             if (!(createdDescriptor instanceof MdsDescriptor)) {
                                 final String parentDescriptor = reportPart.getParentDescriptor();
                                 assertTrue(
-                                    parentDescriptor != null && !parentDescriptor.isBlank(),
-                                    String.format(
-                                        "msg:DescriptionModificationReport/msg:ReportPart/"
-                                            + "@ParentDescriptor attribute is not set for a ReportPart "
-                                            + "with @ModificationType = \"Crt\" that contains "
-                                            + "AbstractDescriptors that are not MdsDescriptors"
-                                            + "(for instance: %s).",
-                                        createdDescriptor.getHandle()));
+                                        parentDescriptor != null && !parentDescriptor.isBlank(),
+                                        String.format(
+                                                "msg:DescriptionModificationReport/msg:ReportPart/"
+                                                        + "@ParentDescriptor attribute is not set for a ReportPart "
+                                                        + "with @ModificationType = \"Crt\" that contains "
+                                                        + "AbstractDescriptors that are not MdsDescriptors"
+                                                        + "(for instance: %s).",
+                                                createdDescriptor.getHandle()));
                             }
                         }
                     }
@@ -152,20 +151,20 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
         }
 
         assertTestData(
-            acceptableReportPartSeen.get(),
-            "No DescriptionModificationReport with ReportParts with "
-                + "ModificationType=Crt seen during test run, test failed.");
+                acceptableReportPartSeen.get(),
+                "No DescriptionModificationReport with ReportParts with "
+                        + "ModificationType=Crt seen during test run, test failed.");
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C5)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-        + " for each AbstractDescriptor contained in a DescriptionModificationReport"
-        + " that it was inserted or deleted or updated by changing" + " at least one child or attribute.")
+            + " for each AbstractDescriptor contained in a DescriptionModificationReport"
+            + " that it was inserted or deleted or updated by changing" + " at least one child or attribute.")
     @RequirePrecondition(simplePreconditions = ConditionalPreconditions.DescriptionModificationUptPrecondition.class)
     void testRequirementC5() throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
-            messageStorage, getInjector().getInstance(TestRunObserver.class));
+                messageStorage, getInjector().getInstance(TestRunObserver.class));
 
         final var acceptableSequenceSeen = new AtomicInteger(0);
 
@@ -195,48 +194,48 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                                 for (var modifiedDescriptor : reportPart.getDescriptor()) {
 
                                     final var descriptorBeforeReportOpt =
-                                        first.getDescriptor(modifiedDescriptor.getHandle());
+                                            first.getDescriptor(modifiedDescriptor.getHandle());
                                     final var descriptorAfterReportOpt =
-                                        second.getDescriptor(modifiedDescriptor.getHandle());
+                                            second.getDescriptor(modifiedDescriptor.getHandle());
 
                                     final var modificationType = ImpliedValueUtil.getModificationType(reportPart);
                                     if (modificationType.equals(DescriptionModificationType.UPT)) {
                                         assertTrue(
-                                            descriptorBeforeReportOpt.isPresent()
-                                                && descriptorAfterReportOpt.isPresent(),
-                                            String.format(
-                                                "The descriptor with handle %s is not present",
-                                                modifiedDescriptor.getHandle()));
+                                                descriptorBeforeReportOpt.isPresent()
+                                                        && descriptorAfterReportOpt.isPresent(),
+                                                String.format(
+                                                        "The descriptor with handle %s is not present",
+                                                        modifiedDescriptor.getHandle()));
 
                                         assertNotEquals(
-                                            descriptorAfterReportOpt.orElseThrow(),
-                                            descriptorBeforeReportOpt.orElseThrow(),
-                                            String.format(
-                                                "The descriptor with the handle %s from the report has not changed",
-                                                modifiedDescriptor.getHandle()));
+                                                descriptorAfterReportOpt.orElseThrow(),
+                                                descriptorBeforeReportOpt.orElseThrow(),
+                                                String.format(
+                                                        "The descriptor with the handle %s from the report has not changed",
+                                                        modifiedDescriptor.getHandle()));
 
                                     } else if (modificationType.equals(DescriptionModificationType.CRT)) {
                                         assertTrue(
-                                            descriptorBeforeReportOpt.isEmpty()
-                                                && descriptorAfterReportOpt.isPresent(),
-                                            String.format(
-                                                "The descriptor with handle %s is missing before applying the report:"
-                                                    + " %s and is present after applying the report: %s,"
-                                                    + " for modification type create",
-                                                modifiedDescriptor.getHandle(),
-                                                descriptorBeforeReportOpt.isEmpty(),
-                                                descriptorAfterReportOpt.isPresent()));
+                                                descriptorBeforeReportOpt.isEmpty()
+                                                        && descriptorAfterReportOpt.isPresent(),
+                                                String.format(
+                                                        "The descriptor with handle %s is missing before applying the report:"
+                                                                + " %s and is present after applying the report: %s,"
+                                                                + " for modification type create",
+                                                        modifiedDescriptor.getHandle(),
+                                                        descriptorBeforeReportOpt.isEmpty(),
+                                                        descriptorAfterReportOpt.isPresent()));
                                     } else {
                                         assertTrue(
-                                            descriptorBeforeReportOpt.isPresent()
-                                                && descriptorAfterReportOpt.isEmpty(),
-                                            String.format(
-                                                "The descriptor with handle %s is present before applying the report:"
-                                                    + " %s and is missing after applying the report: %s,"
-                                                    + " for modification type delete",
-                                                modifiedDescriptor.getHandle(),
-                                                descriptorBeforeReportOpt.isPresent(),
-                                                descriptorAfterReportOpt.isEmpty()));
+                                                descriptorBeforeReportOpt.isPresent()
+                                                        && descriptorAfterReportOpt.isEmpty(),
+                                                String.format(
+                                                        "The descriptor with handle %s is present before applying the report:"
+                                                                + " %s and is missing after applying the report: %s,"
+                                                                + " for modification type delete",
+                                                        modifiedDescriptor.getHandle(),
+                                                        descriptorBeforeReportOpt.isPresent(),
+                                                        descriptorAfterReportOpt.isEmpty()));
                                     }
                                 }
                             }
@@ -252,65 +251,65 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             });
         }
         assertTestData(
-            acceptableSequenceSeen.get(), "No DescriptionModificationReport seen during test run, test failed.");
+                acceptableSequenceSeen.get(), "No DescriptionModificationReport seen during test run, test failed.");
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C7)
     @TestDescription("Checks all DescriptionModificationReports seen during the TestRun for ReportParts whose "
-        + "./Descriptor references an MdsDescriptor and ensures that these ReportParts do not have the "
-        + "@ParentDescriptor attribute set.")
+            + "./Descriptor references an MdsDescriptor and ensures that these ReportParts do not have the "
+            + "@ParentDescriptor attribute set.")
     @RequirePrecondition(
-        simplePreconditions = ConditionalPreconditions.DescriptionModificationMdsDescriptorPrecondition.class)
+            simplePreconditions = ConditionalPreconditions.DescriptionModificationMdsDescriptorPrecondition.class)
     void testRequirementC7() throws NoTestData, IOException, MarshallingException {
         final var acceptableReportsSeen = new AtomicInteger(0);
 
         try (final MessageStorage.GetterResult<MessageContent> descriptionModificationReports =
-                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             for (MessageContent messageContent :
-                descriptionModificationReports.getStream().toList()) {
+                    descriptionModificationReports.getStream().toList()) {
                 final SoapMessage soapMessage = marshalling.unmarshal(
-                    new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                 final DescriptionModificationReport descriptionModificationReport = soapUtil.getBody(
-                        soapMessage, DescriptionModificationReport.class)
-                    .orElseThrow();
+                                soapMessage, DescriptionModificationReport.class)
+                        .orElseThrow();
 
                 for (DescriptionModificationReport.ReportPart reportPart :
-                    descriptionModificationReport.getReportPart()) {
+                        descriptionModificationReport.getReportPart()) {
                     if (reportPart.getDescriptor().stream().anyMatch(MdsDescriptor.class::isInstance)) {
                         acceptableReportsSeen.incrementAndGet();
                         final String parentDescriptor = reportPart.getParentDescriptor();
                         assertTrue(
-                            parentDescriptor == null || parentDescriptor.isBlank(),
-                            String.format(
-                                "Encountered a DescriptionModificationReport/ReportPart whose Descriptor references an "
-                                    + "MdsDescriptor, but whose @ParentDescriptor is set to '%s'.",
-                                parentDescriptor));
+                                parentDescriptor == null || parentDescriptor.isBlank(),
+                                String.format(
+                                        "Encountered a DescriptionModificationReport/ReportPart whose Descriptor references an "
+                                                + "MdsDescriptor, but whose @ParentDescriptor is set to '%s'.",
+                                        parentDescriptor));
                     }
                 }
             }
         }
 
         assertTestData(
-            acceptableReportsSeen.get(),
-            "No DescriptionModificationReport containing MdsDescriptors seen during test run, test failed.");
+                acceptableReportsSeen.get(),
+                "No DescriptionModificationReport containing MdsDescriptors seen during test run, test failed.");
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_R5024)
     @TestDescription("Retrieves each report part from each description modification report seen during the test run and"
-        + " checks that each descriptor does not contain nested descriptors.")
+            + " checks that each descriptor does not contain nested descriptors.")
     @RequirePrecondition(
-        simplePreconditions = {ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.class})
+            simplePreconditions = {ConditionalPreconditions.TriggerDescriptionModificationReportPrecondition.class})
     void testRequirementR5024() throws NoTestData, IOException {
         try (final var messages =
-                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             final var descriptorsSeen = new AtomicInteger(0);
 
             messages.getStream().forEach(messageContent -> {
                 try {
                     final var soapMessage = marshalling.unmarshal(
-                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                     final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                     if (reportOpt.isPresent()) {
                         for (var part : reportOpt.orElseThrow().getReportPart()) {
@@ -326,51 +325,51 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             });
 
             assertTestData(
-                descriptorsSeen.get(),
-                "No Descriptors in DescriptionModificationReports seen during test run, test failed.");
+                    descriptorsSeen.get(),
+                    "No Descriptors in DescriptionModificationReports seen during test run, test failed.");
         }
     }
 
     @Test
     @DisplayName("Biceps:R5025_0: A SERVICE PROVIDER shall order msg:DescriptionModificationReport/msg:ReportPart"
-        + " elements in a way the report parts containing parent descriptors appear before report parts containing"
-        + " their child descriptors.")
+            + " elements in a way the report parts containing parent descriptors appear before report parts containing"
+            + " their child descriptors.")
     @TestIdentifier(EnabledTestConfig.BICEPS_R5025_0)
     @TestDescription("For every DescriptionModificationReport received from the DUT, and for all parent-child"
-        + " relationships between the elements contained in the report, checks that the reportPart containing"
-        + " the parent comes before the reportPart containing the child.")
+            + " relationships between the elements contained in the report, checks that the reportPart containing"
+            + " the parent comes before the reportPart containing the child.")
     @RequirePrecondition(
-        manipulationPreconditions =
-            ManipulationPreconditions.DescriptionModificationAllWithParentChildRelationshipPrecondition.class)
+            manipulationPreconditions =
+                    ManipulationPreconditions.DescriptionModificationAllWithParentChildRelationshipPrecondition.class)
     void testRequirementR5025() throws NoTestData, IOException {
         try (final var messages =
-                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             final var descriptorsSeen = new AtomicInteger(0);
 
             messages.getStream().forEach(messageContent -> {
                 try {
                     final var soapMessage = marshalling.unmarshal(
-                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                     final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                     reportOpt.ifPresent(descriptionModificationReport ->
-                        checkOrderOfReportParts(descriptionModificationReport, descriptorsSeen));
+                            checkOrderOfReportParts(descriptionModificationReport, descriptorsSeen));
                 } catch (MarshallingException e) {
                     fail("Error unmarshalling MessageContent " + e);
                 }
             });
 
             assertTestData(
-                descriptorsSeen.get(),
-                "No DescriptionModificationReports with Parent-Child Relationships between Descriptors "
-                    + " seen during test run, test failed."
-                    + " Please make sure that the device either supports descriptor updates or that the list"
-                    + " of removable descriptors returned by the getRemovableDescriptors() manipulation"
-                    + " includes at least one descriptor that has child descriptors.");
+                    descriptorsSeen.get(),
+                    "No DescriptionModificationReports with Parent-Child Relationships between Descriptors "
+                            + " seen during test run, test failed."
+                            + " Please make sure that the device either supports descriptor updates or that the list"
+                            + " of removable descriptors returned by the getRemovableDescriptors() manipulation"
+                            + " includes at least one descriptor that has child descriptors.");
         }
     }
 
     private void checkOrderOfReportParts(
-        final DescriptionModificationReport report, final AtomicInteger descriptorsSeen) {
+            final DescriptionModificationReport report, final AtomicInteger descriptorsSeen) {
         final var modifiedParentHandles = new HashMap<String, Pair<Integer, String>>();
         final List<DescriptionModificationReport.ReportPart> reportParts = report.getReportPart();
         for (var i = 0; i < reportParts.size(); i++) {
@@ -394,11 +393,11 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                     final Integer indexOfFirstChildUpdate = pair.getLeft();
                     final String childHandle = pair.getRight();
                     assertTrue(
-                        indexOfParentUpdate < indexOfFirstChildUpdate,
-                        String.format(
-                            "reportPart containing child descriptor '%s' is listed before the reportPart"
-                                + " containing its parent descriptor '%s' in a DescriptionModificationReport.",
-                            childHandle, key));
+                            indexOfParentUpdate < indexOfFirstChildUpdate,
+                            String.format(
+                                    "reportPart containing child descriptor '%s' is listed before the reportPart"
+                                            + " containing its parent descriptor '%s' in a DescriptionModificationReport.",
+                                    childHandle, key));
                     descriptorsSeen.incrementAndGet();
                 }
             }
@@ -411,62 +410,62 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
         if (descriptor instanceof AlertSystemDescriptor alertSystem) {
             // verify that the alarm system has no alarm signals or alarm conditions
             assertTrue(
-                alertSystem.getAlertCondition().isEmpty(),
-                String.format(errorMsg, descriptor.getClass(), handle, alertSystem.getAlertCondition()));
+                    alertSystem.getAlertCondition().isEmpty(),
+                    String.format(errorMsg, descriptor.getClass(), handle, alertSystem.getAlertCondition()));
             assertTrue(
-                alertSystem.getAlertSignal().isEmpty(),
-                String.format(errorMsg, descriptor.getClass(), handle, alertSystem.getAlertSignal()));
+                    alertSystem.getAlertSignal().isEmpty(),
+                    String.format(errorMsg, descriptor.getClass(), handle, alertSystem.getAlertSignal()));
         } else if (descriptor instanceof ChannelDescriptor channel) {
             // verify that the channel has no metrics
             assertTrue(
-                channel.getMetric().isEmpty(),
-                String.format(errorMsg, descriptor.getClass(), handle, channel.getMetric()));
+                    channel.getMetric().isEmpty(),
+                    String.format(errorMsg, descriptor.getClass(), handle, channel.getMetric()));
         } else if (descriptor instanceof MdsDescriptor mds) {
             // verify that the mds has no alert system, sco, system context, clock, batteries or vmds
             assertNull(
-                mds.getAlertSystem(), String.format(errorMsg, descriptor.getClass(), handle, mds.getAlertSystem()));
+                    mds.getAlertSystem(), String.format(errorMsg, descriptor.getClass(), handle, mds.getAlertSystem()));
             assertNull(mds.getSco(), String.format(errorMsg, descriptor.getClass(), handle, mds.getSco()));
             assertNull(
-                mds.getSystemContext(),
-                String.format(errorMsg, descriptor.getClass(), handle, mds.getSystemContext()));
+                    mds.getSystemContext(),
+                    String.format(errorMsg, descriptor.getClass(), handle, mds.getSystemContext()));
             assertNull(mds.getClock(), String.format(errorMsg, descriptor.getClass(), handle, mds.getClock()));
             assertTrue(
-                mds.getBattery().isEmpty(),
-                String.format(errorMsg, descriptor.getClass(), handle, mds.getBattery()));
+                    mds.getBattery().isEmpty(),
+                    String.format(errorMsg, descriptor.getClass(), handle, mds.getBattery()));
             assertTrue(mds.getVmd().isEmpty(), String.format(errorMsg, descriptor.getClass(), handle, mds.getVmd()));
         } else if (descriptor instanceof ScoDescriptor sco) {
             // verify that the sco has no operations
             assertTrue(
-                sco.getOperation().isEmpty(),
-                String.format(errorMsg, descriptor.getClass(), handle, sco.getOperation()));
+                    sco.getOperation().isEmpty(),
+                    String.format(errorMsg, descriptor.getClass(), handle, sco.getOperation()));
         } else if (descriptor instanceof SystemContextDescriptor systemContext) {
             // verify that the system context has no patient and location context and no ensemble, operator
             // workflow and mean contexts
             assertNull(
-                systemContext.getPatientContext(),
-                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getPatientContext()));
+                    systemContext.getPatientContext(),
+                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getPatientContext()));
             assertNull(
-                systemContext.getLocationContext(),
-                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getLocationContext()));
+                    systemContext.getLocationContext(),
+                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getLocationContext()));
             assertTrue(
-                systemContext.getEnsembleContext().isEmpty(),
-                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getEnsembleContext()));
+                    systemContext.getEnsembleContext().isEmpty(),
+                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getEnsembleContext()));
             assertTrue(
-                systemContext.getOperatorContext().isEmpty(),
-                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getOperatorContext()));
+                    systemContext.getOperatorContext().isEmpty(),
+                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getOperatorContext()));
             assertTrue(
-                systemContext.getWorkflowContext().isEmpty(),
-                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getWorkflowContext()));
+                    systemContext.getWorkflowContext().isEmpty(),
+                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getWorkflowContext()));
             assertTrue(
-                systemContext.getMeansContext().isEmpty(),
-                String.format(errorMsg, descriptor.getClass(), handle, systemContext.getMeansContext()));
+                    systemContext.getMeansContext().isEmpty(),
+                    String.format(errorMsg, descriptor.getClass(), handle, systemContext.getMeansContext()));
         } else if (descriptor instanceof VmdDescriptor vmd) {
             // verify that the vmd has no channels, vmd and sco
             assertTrue(
-                vmd.getChannel().isEmpty(),
-                String.format(errorMsg, descriptor.getClass(), handle, vmd.getChannel()));
+                    vmd.getChannel().isEmpty(),
+                    String.format(errorMsg, descriptor.getClass(), handle, vmd.getChannel()));
             assertNull(
-                vmd.getAlertSystem(), String.format(errorMsg, descriptor.getClass(), handle, vmd.getAlertSystem()));
+                    vmd.getAlertSystem(), String.format(errorMsg, descriptor.getClass(), handle, vmd.getAlertSystem()));
             assertNull(vmd.getSco(), String.format(errorMsg, descriptor.getClass(), handle, vmd.getSco()));
         }
     }
@@ -475,12 +474,12 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @DisplayName("A SERVICE PROVIDER shall not delete a parent descriptor when it contains child descriptors.")
     @TestIdentifier(EnabledTestConfig.BICEPS_R5046_0)
     @TestDescription("Starting from the initially retrieved mdib, applies each report to the mdib and checks that each"
-        + " descriptor in each description modification report part with modification type del does not contain any"
-        + " child descriptors.")
+            + " descriptor in each description modification report part with modification type del does not contain any"
+            + " child descriptors.")
     @RequirePrecondition(simplePreconditions = ConditionalPreconditions.DescriptionModificationDelPrecondition.class)
     void testRequirementR50460() throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
-            messageStorage, getInjector().getInstance(TestRunObserver.class));
+                messageStorage, getInjector().getInstance(TestRunObserver.class));
         final var acceptableSequenceSeen = new AtomicInteger(0);
         try (final Stream<String> sequenceIds = mdibHistorian.getKnownSequenceIds()) {
             sequenceIds.forEach(sequenceId -> {
@@ -504,14 +503,14 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                                     for (var descriptor : part.getDescriptor()) {
                                         final var entity = mdib.getEntity(descriptor.getHandle());
                                         assertTrue(
-                                            entity.isPresent()
-                                                && entity.orElseThrow()
-                                                .getChildren()
-                                                .isEmpty(),
-                                            String.format(
-                                                "The descriptor with the handle %s still has following child descriptors %s.",
-                                                entity.orElseThrow().getHandle(),
-                                                entity.orElseThrow().getChildren()));
+                                                entity.isPresent()
+                                                        && entity.orElseThrow()
+                                                                .getChildren()
+                                                                .isEmpty(),
+                                                String.format(
+                                                        "The descriptor with the handle %s still has following child descriptors %s.",
+                                                        entity.orElseThrow().getHandle(),
+                                                        entity.orElseThrow().getChildren()));
                                     }
                                 }
                             }
@@ -529,121 +528,121 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_R5051)
     @TestDescription("Retrieves each report part with modification type crt from each description modification report"
-        + " seen during the test run, and compares the descriptor version from each state to the descriptor version"
-        + " of the respective descriptor.")
+            + " seen during the test run, and compares the descriptor version from each state to the descriptor version"
+            + " of the respective descriptor.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.DescriptionModificationCrtPrecondition.class})
     void testRequirementR5051() throws NoTestData, IOException {
         try (final var messages =
-                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
 
             final var acceptableSequenceSeen = new AtomicInteger(0);
             final var impliedValueMap = new HashMap<String, InitialImpliedValue>();
             messages.getStream().forEach(messageContent -> {
                 try {
                     final var soapMessage = marshalling.unmarshal(
-                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                     final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                     final var crtReportParts = reportOpt.orElseThrow().getReportPart().stream()
-                        .filter(part ->
-                            ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.CRT))
-                        .toList();
+                            .filter(part ->
+                                    ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.CRT))
+                            .toList();
                     for (var part : crtReportParts) {
                         for (var state : part.getState()) {
                             acceptableSequenceSeen.incrementAndGet();
                             final var handle = state.getDescriptorHandle();
                             final var descriptorVersion = ImpliedValueUtil.getStateDescriptorVersion(
-                                state,
-                                impliedValueMap.computeIfAbsent(
-                                    reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
+                                    state,
+                                    impliedValueMap.computeIfAbsent(
+                                            reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
                             final var descriptor = part.getDescriptor().stream()
-                                .filter(abstractDescriptor ->
-                                    abstractDescriptor.getHandle().equals(handle))
-                                .findFirst();
+                                    .filter(abstractDescriptor ->
+                                            abstractDescriptor.getHandle().equals(handle))
+                                    .findFirst();
                             assertTrue(
-                                descriptor.isPresent(),
-                                String.format("No matching descriptor for handle %s found.", handle));
+                                    descriptor.isPresent(),
+                                    String.format("No matching descriptor for handle %s found.", handle));
                             final var descriptorsDescriptorVersion = ImpliedValueUtil.getDescriptorVersion(
-                                descriptor.orElseThrow(),
-                                impliedValueMap.computeIfAbsent(
-                                    reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
+                                    descriptor.orElseThrow(),
+                                    impliedValueMap.computeIfAbsent(
+                                            reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
                             assertEquals(
-                                descriptorsDescriptorVersion,
-                                descriptorVersion,
-                                String.format(
-                                    "The descriptor version of state is %s, but should be %s, for %s.",
-                                    descriptorVersion, descriptorsDescriptorVersion, handle));
+                                    descriptorsDescriptorVersion,
+                                    descriptorVersion,
+                                    String.format(
+                                            "The descriptor version of state is %s, but should be %s, for %s.",
+                                            descriptorVersion, descriptorsDescriptorVersion, handle));
                         }
                     }
                 } catch (MarshallingException e) {
                     fail("Error unmarshalling MessageContent " + e);
                 } catch (InitialImpliedValueException e) {
                     fail(
-                        "The descriptor version was an implied value, but was not allowed to be one."
-                            + " It occurred previously without an implied value.",
-                        e);
+                            "The descriptor version was an implied value, but was not allowed to be one."
+                                    + " It occurred previously without an implied value.",
+                            e);
                 }
             });
 
             assertTestData(
-                acceptableSequenceSeen.get(),
-                "No report parts with description modification type crt seen during test run, test failed");
+                    acceptableSequenceSeen.get(),
+                    "No report parts with description modification type crt seen during test run, test failed");
         }
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_R5052)
     @TestDescription("Retrieves every report part with modification type upt from every description modification report"
-        + " seen during the test run and compares the descriptor version from each state with the descriptor version"
-        + " of their descriptor.")
+            + " seen during the test run and compares the descriptor version from each state with the descriptor version"
+            + " of their descriptor.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.DescriptionModificationUptPrecondition.class})
     void testRequirementR5052() throws NoTestData, IOException {
         try (final var messages =
-                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             final var acceptableSequenceSeen = new AtomicInteger(0);
 
             final var impliedValueMap = new HashMap<Object, InitialImpliedValue>();
             messages.getStream().forEach(messageContent -> {
                 try {
                     final var soapMessage = marshalling.unmarshal(
-                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                     final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                     final var uptReportParts = reportOpt.orElseThrow().getReportPart().stream()
-                        .filter(part ->
-                            ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.UPT))
-                        .toList();
+                            .filter(part ->
+                                    ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.UPT))
+                            .toList();
                     for (var part : uptReportParts) {
                         acceptableSequenceSeen.incrementAndGet();
                         for (var state : part.getState()) {
                             final var handle = state.getDescriptorHandle();
                             final var descriptorVersion = ImpliedValueUtil.getStateDescriptorVersion(
-                                state,
-                                impliedValueMap.computeIfAbsent(
-                                    reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
+                                    state,
+                                    impliedValueMap.computeIfAbsent(
+                                            reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
                             final var descriptor = part.getDescriptor().stream()
-                                .filter(abstractDescriptor ->
-                                    abstractDescriptor.getHandle().equals(handle))
-                                .findFirst();
+                                    .filter(abstractDescriptor ->
+                                            abstractDescriptor.getHandle().equals(handle))
+                                    .findFirst();
                             assertTrue(
-                                descriptor.isPresent(),
-                                String.format("No matching descriptor for handle %s found.", handle));
+                                    descriptor.isPresent(),
+                                    String.format("No matching descriptor for handle %s found.", handle));
                             final var descriptorsDescriptorVersion = ImpliedValueUtil.getDescriptorVersion(
-                                descriptor.orElseThrow(),
-                                impliedValueMap.computeIfAbsent(
-                                    reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
+                                    descriptor.orElseThrow(),
+                                    impliedValueMap.computeIfAbsent(
+                                            reportOpt.orElseThrow().getSequenceId(), k -> new InitialImpliedValue()));
                             assertEquals(
-                                descriptorsDescriptorVersion,
-                                descriptorVersion,
-                                String.format(
-                                    "The descriptor version of state is %s, but should be %s, for %s.",
+                                    descriptorsDescriptorVersion,
                                     descriptorVersion,
-                                    ImpliedValueUtil.getDescriptorVersion(
-                                        descriptor.orElseThrow(),
-                                        impliedValueMap.computeIfAbsent(
-                                            reportOpt
-                                                .orElseThrow()
-                                                .getSequenceId(),
-                                            k -> new InitialImpliedValue())),
-                                    handle));
+                                    String.format(
+                                            "The descriptor version of state is %s, but should be %s, for %s.",
+                                            descriptorVersion,
+                                            ImpliedValueUtil.getDescriptorVersion(
+                                                    descriptor.orElseThrow(),
+                                                    impliedValueMap.computeIfAbsent(
+                                                            reportOpt
+                                                                    .orElseThrow()
+                                                                    .getSequenceId(),
+                                                            k -> new InitialImpliedValue())),
+                                            handle));
                         }
                     }
                 } catch (MarshallingException | InitialImpliedValueException e) {
@@ -652,35 +651,35 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             });
 
             assertTestData(
-                acceptableSequenceSeen.get(),
-                "No report parts with description modification type upt seen during test run, test failed");
+                    acceptableSequenceSeen.get(),
+                    "No report parts with description modification type upt seen during test run, test failed");
         }
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_R5053)
     @TestDescription("Retrieves every report part with modification type del from every description modification report"
-        + " seen during the test run and checks if the states are excluded from the message.")
+            + " seen during the test run and checks if the states are excluded from the message.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.DescriptionModificationDelPrecondition.class})
     void testRequirementR5053() throws NoTestData, IOException {
         try (final var messages =
-                 messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
+                messageStorage.getInboundMessagesByBodyType(Constants.MSG_DESCRIPTION_MODIFICATION_REPORT)) {
             final var delReportsSeen = new AtomicInteger(0);
 
             messages.getStream().forEach(messageContent -> {
                 try {
                     final var soapMessage = marshalling.unmarshal(
-                        new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
+                            new ByteArrayInputStream(messageContent.getBody().getBytes(StandardCharsets.UTF_8)));
                     final var reportOpt = soapUtil.getBody(soapMessage, DescriptionModificationReport.class);
                     final var delReportParts = reportOpt.orElseThrow().getReportPart().stream()
-                        .filter(part ->
-                            ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.DEL))
-                        .toList();
+                            .filter(part ->
+                                    ImpliedValueUtil.getModificationType(part).equals(DescriptionModificationType.DEL))
+                            .toList();
                     for (var part : delReportParts) {
                         delReportsSeen.incrementAndGet();
                         assertTrue(
-                            part.getState().isEmpty(),
-                            "State should not be part of the report with modification type delete.");
+                                part.getState().isEmpty(),
+                                "State should not be part of the report with modification type delete.");
                     }
                 } catch (MarshallingException e) {
                     fail("Error unmarshalling MessageContent " + e);
@@ -688,22 +687,22 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
             });
 
             assertTestData(
-                delReportsSeen.get(),
-                "No report parts with description modification type del seen during test run, test failed");
+                    delReportsSeen.get(),
+                    "No report parts with description modification type del seen during test run, test failed");
         }
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C11)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-        + " whether at least one child or attribute has changed for each AbstractAlertState contained in an"
-        + " EpisodicAlertReport.")
+            + " whether at least one child or attribute has changed for each AbstractAlertState contained in an"
+            + " EpisodicAlertReport.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerEpisodicAlertReportPrecondition.class})
     void testRequirementC11() throws NoTestData, IOException {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((AbstractAlertReport) report)
-            .getReportPart().stream()
-            .map(AbstractAlertReport.ReportPart::getAlertState)
-            .collect(Collectors.toUnmodifiableList());
+                .getReportPart().stream()
+                        .map(AbstractAlertReport.ReportPart::getAlertState)
+                        .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(EpisodicAlertReport.class, AbstractAlertState.class, getStatesOfReportParts);
     }
@@ -711,32 +710,32 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C12)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-        + " whether at least one child or attribute has changed for each AbstractComponentState contained in an"
-        + " EpisodicComponentReport.")
+            + " whether at least one child or attribute has changed for each AbstractComponentState contained in an"
+            + " EpisodicComponentReport.")
     @RequirePrecondition(
-        simplePreconditions = {ConditionalPreconditions.TriggerEpisodicComponentReportPrecondition.class})
+            simplePreconditions = {ConditionalPreconditions.TriggerEpisodicComponentReportPrecondition.class})
     void testRequirementC12() throws NoTestData, IOException {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicComponentReport) report)
-            .getReportPart().stream()
-            .map(EpisodicComponentReport.ReportPart::getComponentState)
-            .collect(Collectors.toUnmodifiableList());
+                .getReportPart().stream()
+                        .map(EpisodicComponentReport.ReportPart::getComponentState)
+                        .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(
-            EpisodicComponentReport.class, AbstractDeviceComponentState.class, getStatesOfReportParts);
+                EpisodicComponentReport.class, AbstractDeviceComponentState.class, getStatesOfReportParts);
     }
 
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C13)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-        + " whether at least one child or attribute has changed for each AbstractContextState contained in an"
-        + " EpisodicContextReport.")
+            + " whether at least one child or attribute has changed for each AbstractContextState contained in an"
+            + " EpisodicContextReport.")
     @RequirePrecondition(
-        simplePreconditions = {ConditionalPreconditions.TriggerEpisodicContextReportPrecondition.class})
+            simplePreconditions = {ConditionalPreconditions.TriggerEpisodicContextReportPrecondition.class})
     void testRequirementC13() throws NoTestData, IOException {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicContextReport) report)
-            .getReportPart().stream()
-            .map(EpisodicContextReport.ReportPart::getContextState)
-            .collect(Collectors.toUnmodifiableList());
+                .getReportPart().stream()
+                        .map(EpisodicContextReport.ReportPart::getContextState)
+                        .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(EpisodicContextReport.class, AbstractContextState.class, getStatesOfReportParts);
     }
@@ -744,14 +743,14 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C14)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-        + " whether at least one child or attribute has changed for each AbstractMetricState contained in an"
-        + " EpisodicMetricReport.")
+            + " whether at least one child or attribute has changed for each AbstractMetricState contained in an"
+            + " EpisodicMetricReport.")
     @RequirePrecondition(simplePreconditions = {ConditionalPreconditions.TriggerEpisodicMetricReportPrecondition.class})
     void testRequirementC14() throws NoTestData, IOException {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicMetricReport) report)
-            .getReportPart().stream()
-            .map(EpisodicMetricReport.ReportPart::getMetricState)
-            .collect(Collectors.toUnmodifiableList());
+                .getReportPart().stream()
+                        .map(EpisodicMetricReport.ReportPart::getMetricState)
+                        .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(EpisodicMetricReport.class, AbstractMetricState.class, getStatesOfReportParts);
     }
@@ -759,100 +758,121 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @Test
     @TestIdentifier(EnabledTestConfig.BICEPS_C15)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
-        + " whether at least one child or attribute has changed for each AbstractOperationState contained in an"
-        + " EpisodicOperationalStateReport.")
+            + " whether at least one child or attribute has changed for each AbstractOperationState contained in an"
+            + " EpisodicOperationalStateReport.")
     @RequirePrecondition(
-        simplePreconditions = {ConditionalPreconditions.TriggerEpisodicOperationalStateReportPrecondition.class})
+            simplePreconditions = {ConditionalPreconditions.TriggerEpisodicOperationalStateReportPrecondition.class})
     void testRequirementC15() throws NoTestData, IOException {
         final GetStatesOfReportParts getStatesOfReportParts = report -> ((EpisodicOperationalStateReport) report)
-            .getReportPart().stream()
-            .map(EpisodicOperationalStateReport.ReportPart::getOperationState)
-            .collect(Collectors.toUnmodifiableList());
+                .getReportPart().stream()
+                        .map(EpisodicOperationalStateReport.ReportPart::getOperationState)
+                        .collect(Collectors.toUnmodifiableList());
 
         testEpisodicReportRequirement(
-            EpisodicOperationalStateReport.class, AbstractOperationState.class, getStatesOfReportParts);
+                EpisodicOperationalStateReport.class, AbstractOperationState.class, getStatesOfReportParts);
     }
 
-    private void testEpisodicReportRequirement(final Class<? extends AbstractReport> reportClass,
-                                               final Class<? extends AbstractState> stateClass,
-                                               final GetStatesOfReportParts getStatesOfReportParts) throws NoTestData {
+    private void testEpisodicReportRequirement(
+            final Class<? extends AbstractReport> reportClass,
+            final Class<? extends AbstractState> stateClass,
+            final GetStatesOfReportParts getStatesOfReportParts)
+            throws NoTestData {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
-            messageStorage, getInjector().getInstance(TestRunObserver.class));
+                messageStorage, getInjector().getInstance(TestRunObserver.class));
 
         final var acceptableSequenceSeen = new AtomicInteger(0);
         try (final Stream<String> sequenceIds = mdibHistorian.getKnownSequenceIds()) {
             sequenceIds.forEach(sequenceId -> {
-                RemoteMdibAccess manualMdibAccess;
-                RemoteMdibAccess mdibAccess;
                 try {
-                    manualMdibAccess = mdibHistorian.createNewStorage(sequenceId);
-                    // get relevant reports
-                    final var minimumMdibVersion = ImpliedValueUtil.getMdibVersion(manualMdibAccess.getMdibVersion());
-                    try (final var reports = mdibHistorian.getAllUniqueReports(sequenceId, minimumMdibVersion)) {
-                        try (final var history = mdibHistorian.episodicReportBasedHistory(sequenceId)) {
-                            mdibAccess = history.next();
-
-                            for (final Iterator<AbstractReport> iterator = reports.iterator(); iterator.hasNext();) {
-                                final AbstractReport report = iterator.next();
-                                manualMdibAccess = mdibHistorian.applyReportOnStorage(manualMdibAccess, report);
-
-                                if (reportClass.isInstance(report)) {
-                                    acceptableSequenceSeen.incrementAndGet();
-                                    final var priorMdibVersion = report.getMdibVersion().subtract(BigInteger.ONE);
-                                    // fast-forward history to the mdibversion before the report
-                                    while (mdibAccess.getMdibVersion().getVersion().compareTo(priorMdibVersion) < 0) {
-                                        mdibAccess = history.next();
-                                    }
-
-                                    // get every state of the report
-                                    final var reportParts = getStatesOfReportParts.apply(reportClass.cast(report));
-                                    for (var reportPart : reportParts) {
-                                        for (var state : reportPart) {
-                                            final Optional<? extends AbstractState> stateBeforeReport;
-                                            final Optional<? extends AbstractState> stateAfterReport;
-                                            // multistate need a different handling
-                                            if (state instanceof AbstractMultiState multiState) {
-                                                stateBeforeReport = mdibAccess.getState(multiState.getHandle(), AbstractMultiState.class);
-                                                stateAfterReport = manualMdibAccess.getState(multiState.getHandle(), AbstractMultiState.class);
-
-                                                if (!(stateBeforeReport.isPresent() && stateAfterReport.isPresent())) {
-                                                    // when not both AbstractMultiStates are present it must be inserted.
-                                                    assertTrue(
-                                                        stateBeforeReport.isEmpty() && stateAfterReport.isPresent(),
-                                                        String.format(STATE_ABSENT, state.getDescriptorHandle()));
-                                                    continue;
-                                                }
-                                            } else {
-                                                stateBeforeReport =
-                                                    mdibAccess.getState(state.getDescriptorHandle(), stateClass);
-                                                stateAfterReport =
-                                                    manualMdibAccess.getState(state.getDescriptorHandle(), stateClass);
-                                                assertTrue(
-                                                    stateBeforeReport.isPresent() && stateAfterReport.isPresent(),
-                                                    String.format(STATE_ABSENT, state.getDescriptorHandle()));
-                                            }
-                                            assertNotEquals(
-                                                stateAfterReport.orElseThrow(),
-                                                stateBeforeReport.orElseThrow(),
-                                                String.format(STATE_UNCHANGED, state.getDescriptorHandle()));
-                                        }
-                                    }
-                                }
-                            }
-                        } catch (ReportProcessingException e) {
-                            fail(e);
-                        }
-                    }
+                    checkReportsForSequenceId(
+                            reportClass,
+                            stateClass,
+                            getStatesOfReportParts,
+                            sequenceId,
+                            mdibHistorian,
+                            acceptableSequenceSeen);
                 } catch (PreprocessingException e) {
-                    fail(e);
+                    throw new RuntimeException(e);
                 }
             });
         } catch (IOException e) {
             fail(e);
         }
         assertTestData(
-            acceptableSequenceSeen.get(),
-            String.format("No %s seen during test run, test failed.", reportClass.getSimpleName()));
+                acceptableSequenceSeen.get(),
+                String.format("No %s seen during test run, test failed.", reportClass.getSimpleName()));
+    }
+
+    private static void checkReportsForSequenceId(
+            final Class<? extends AbstractReport> reportClass,
+            final Class<? extends AbstractState> stateClass,
+            final GetStatesOfReportParts getStatesOfReportParts,
+            final String sequenceId,
+            final MdibHistorian mdibHistorian,
+            final AtomicInteger acceptableSequenceSeen)
+            throws PreprocessingException {
+
+        RemoteMdibAccess manualMdibAccess = mdibHistorian.createNewStorage(sequenceId);
+        RemoteMdibAccess mdibAccess;
+
+        // get relevant reports
+        final var minimumMdibVersion = ImpliedValueUtil.getMdibVersion(manualMdibAccess.getMdibVersion());
+        try (final var reports = mdibHistorian.getAllUniqueReports(sequenceId, minimumMdibVersion)) {
+            try (final var history = mdibHistorian.episodicReportBasedHistory(sequenceId)) {
+                mdibAccess = history.next();
+
+                for (final Iterator<AbstractReport> iterator = reports.iterator(); iterator.hasNext(); ) {
+                    final AbstractReport report = iterator.next();
+                    manualMdibAccess = mdibHistorian.applyReportOnStorage(manualMdibAccess, report);
+
+                    if (reportClass.isInstance(report)) {
+                        acceptableSequenceSeen.incrementAndGet();
+                        final var priorMdibVersion = report.getMdibVersion().subtract(BigInteger.ONE);
+                        // fast-forward history to the mdib version before the report
+                        while (mdibAccess.getMdibVersion().getVersion().compareTo(priorMdibVersion) < 0) {
+                            mdibAccess = history.next();
+                        }
+
+                        // get every state of the report
+                        final var reportParts = getStatesOfReportParts.apply(reportClass.cast(report));
+                        for (var reportPart : reportParts) {
+                            for (var state : reportPart) {
+                                final Optional<? extends AbstractState> stateBeforeReport;
+                                final Optional<? extends AbstractState> stateAfterReport;
+                                // multi state need a different handling
+                                if (state instanceof AbstractMultiState multiState) {
+                                    stateBeforeReport =
+                                            mdibAccess.getState(multiState.getHandle(), AbstractMultiState.class);
+                                    stateAfterReport =
+                                            manualMdibAccess.getState(multiState.getHandle(), AbstractMultiState.class);
+
+                                    if (!(stateBeforeReport.isPresent() && stateAfterReport.isPresent())) {
+                                        // when not both AbstractMultiStates are present it must be inserted.
+                                        assertTrue(
+                                                stateBeforeReport.isEmpty() && stateAfterReport.isPresent(),
+                                                String.format(STATE_ABSENT, state.getDescriptorHandle()));
+                                        continue;
+                                    }
+                                } else {
+                                    stateBeforeReport = mdibAccess.getState(state.getDescriptorHandle(), stateClass);
+                                    stateAfterReport =
+                                            manualMdibAccess.getState(state.getDescriptorHandle(), stateClass);
+                                    assertTrue(
+                                            stateBeforeReport.isPresent() && stateAfterReport.isPresent(),
+                                            String.format(STATE_ABSENT, state.getDescriptorHandle()));
+                                }
+                                assertNotEquals(
+                                        stateAfterReport.orElseThrow(),
+                                        stateBeforeReport.orElseThrow(),
+                                        String.format(STATE_UNCHANGED, state.getDescriptorHandle()));
+                            }
+                        }
+                    }
+                }
+            } catch (ReportProcessingException e) {
+                fail(e);
+            }
+        }
     }
 
     @FunctionalInterface

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTest.java
@@ -62,6 +62,7 @@ import org.somda.sdc.biceps.model.participant.AbstractContextState;
 import org.somda.sdc.biceps.model.participant.AbstractDescriptor;
 import org.somda.sdc.biceps.model.participant.AbstractDeviceComponentState;
 import org.somda.sdc.biceps.model.participant.AbstractMetricState;
+import org.somda.sdc.biceps.model.participant.AbstractMultiState;
 import org.somda.sdc.biceps.model.participant.AbstractOperationState;
 import org.somda.sdc.biceps.model.participant.AbstractState;
 import org.somda.sdc.biceps.model.participant.AlertSystemDescriptor;
@@ -157,7 +158,7 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
     @TestIdentifier(EnabledTestConfig.BICEPS_C5)
     @TestDescription("Starting from the initially retrieved mdib, applies each episodic report to the mdib and checks"
             + " for each AbstractDescriptor contained in a DescriptionModificationReport"
-            + " that it was inserted or deleted or updated by changing" + " at least one child or attribute.")
+            + " that it was inserted or deleted or updated by changing at least one child or attribute.")
     @RequirePrecondition(simplePreconditions = ConditionalPreconditions.DescriptionModificationUptPrecondition.class)
     void testRequirementC5() throws NoTestData, IOException {
         final var mdibHistorian = mdibHistorianFactory.createMdibHistorian(
@@ -865,7 +866,11 @@ public class InvariantMessageModelAnnexTest extends InjectorTestBase {
                         for (var state : reportPart) {
                             final Optional<? extends AbstractState> stateBeforeReport;
 
-                            stateBeforeReport = mdibAccess.getState(state.getDescriptorHandle(), stateClass);
+                            if (state instanceof AbstractMultiState multiState) {
+                                stateBeforeReport = mdibAccess.getState(multiState.getHandle(), stateClass);
+                            } else {
+                                stateBeforeReport = mdibAccess.getState(state.getDescriptorHandle(), stateClass);
+                            }
                             if (stateBeforeReport.isEmpty()) {
                                 // If stateBeforeReport is not present, it has either been inserted as a multi-state or
                                 // with a description change report within the same mdib version. In both cases,

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTestTest.java
@@ -1663,7 +1663,7 @@ public class InvariantMessageModelAnnexTestTest {
                 buildAlertConditionState(MDS_ALERT_CONDITION_HANDLE, AlertActivation.PSD, false),
                 buildAlertConditionState(MDS_SECOND_ALERT_CONDITION_HANDLE, AlertActivation.PSD, false));
 
-        final var secondDescrptionModification = buildDescriptionModificationReport(
+        final var secondDescriptionModification = buildDescriptionModificationReport(
                 SEQUENCE_ID,
                 BigInteger.TWO,
                 buildDescriptionModificationReportPart(
@@ -1682,7 +1682,7 @@ public class InvariantMessageModelAnnexTestTest {
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
         messageStorageUtil.addInboundSecureHttpMessage(storage, first);
-        messageStorageUtil.addInboundSecureHttpMessage(storage, secondDescrptionModification);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, secondDescriptionModification);
         messageStorageUtil.addInboundSecureHttpMessage(storage, second);
 
         testClass.testRequirementC11();

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTestTest.java
@@ -1650,6 +1650,48 @@ public class InvariantMessageModelAnnexTestTest {
     }
 
     /**
+     * Tests whether a DescriptionModificationReport with the same MdibVersion that already contains
+     * the changed state does not fail the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementC11GoodDescriptionModificationDoesNotFailTheTest() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
+
+        final var first = buildEpisodicAlertReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildAlertConditionState(VMD_ALERT_CONDITION_HANDLE, AlertActivation.PSD, false),
+                buildAlertConditionState(MDS_ALERT_CONDITION_HANDLE, AlertActivation.PSD, false),
+                buildAlertConditionState(MDS_SECOND_ALERT_CONDITION_HANDLE, AlertActivation.PSD, false));
+
+        final var secondDescrptionModification = buildDescriptionModificationReport(
+                SEQUENCE_ID,
+                BigInteger.TWO,
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.UPT,
+                        Pair.of(
+                                mdibBuilder.buildAlertConditionDescriptor(
+                                        VMD_ALERT_CONDITION_HANDLE, AlertConditionKind.OTH, AlertConditionPriority.ME),
+                                buildAlertConditionState(VMD_ALERT_CONDITION_HANDLE, AlertActivation.ON, true))));
+
+        final var second = buildEpisodicAlertReport(
+                SEQUENCE_ID,
+                BigInteger.TWO,
+                buildAlertConditionState(VMD_ALERT_CONDITION_HANDLE, AlertActivation.ON, true),
+                buildAlertConditionState(MDS_ALERT_CONDITION_HANDLE, AlertActivation.ON, true),
+                buildAlertConditionState(MDS_SECOND_ALERT_CONDITION_HANDLE, AlertActivation.ON, true));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, first);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, secondDescrptionModification);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, second);
+
+        testClass.testRequirementC11();
+    }
+
+    /**
      * Tests whether duplicated EpisodicAlertReports pass the test.
      *
      * @throws Exception on any exception
@@ -1832,6 +1874,35 @@ public class InvariantMessageModelAnnexTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, first);
         messageStorageUtil.addInboundSecureHttpMessage(storage, second);
         messageStorageUtil.addInboundSecureHttpMessage(storage, third);
+
+        testClass.testRequirementC12();
+    }
+
+    /**
+     * Tests whether a DescriptionModificationReport with the same MdibVersion that already contains
+     * the changed state does not fail the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementC12GoodDescriptionModificationDoesNotFailTheTest() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
+
+        final var descriptionModificationReportWithComponentChanges = buildDescriptionModificationReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.UPT,
+                        Pair.of(
+                                mdibBuilder.buildBatteryDescriptor(BATTERY_HANDLE),
+                                buildBatteryState(BATTERY_HANDLE, ComponentActivation.STND_BY, 10L))));
+
+        final var componentReport = buildEpisodicComponentReport(
+                SEQUENCE_ID, BigInteger.ONE, buildBatteryState(BATTERY_HANDLE, ComponentActivation.STND_BY, 10L));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithComponentChanges);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, componentReport);
 
         testClass.testRequirementC12();
     }
@@ -2033,6 +2104,45 @@ public class InvariantMessageModelAnnexTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, first);
         messageStorageUtil.addInboundSecureHttpMessage(storage, second);
         messageStorageUtil.addInboundSecureHttpMessage(storage, third);
+
+        testClass.testRequirementC13();
+    }
+
+    /**
+     * Tests whether a DescriptionModificationReport with the same MdibVersion that already contains
+     * the changed state does not fail the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementC13GoodDescriptionModificationDoesNotFailTheTest() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
+
+        final var descriptionModificationReportWithContextChanges = buildDescriptionModificationReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.UPT,
+                        Pair.of(
+                                mdibBuilder.buildPatientContextDescriptor(PATIENT_CONTEXT_DESCRIPTOR_HANDLE),
+                                buildPatientContextState(
+                                        PATIENT_CONTEXT_DESCRIPTOR_HANDLE,
+                                        PATIENT_CONTEXT_STATE_HANDLE,
+                                        ContextAssociation.ASSOC,
+                                        mdibBuilder.buildCodedValue("newCodedValue")))));
+
+        final var contextReport = buildEpisodicContextReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildPatientContextState(
+                        PATIENT_CONTEXT_DESCRIPTOR_HANDLE,
+                        PATIENT_CONTEXT_STATE_HANDLE,
+                        ContextAssociation.ASSOC,
+                        mdibBuilder.buildCodedValue("newCodedValue")));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithContextChanges);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, contextReport);
 
         testClass.testRequirementC13();
     }
@@ -2285,6 +2395,48 @@ public class InvariantMessageModelAnnexTestTest {
     }
 
     /**
+     * Tests whether a DescriptionModificationReport with the same MdibVersion that already contains
+     * the changed state does not fail the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementC14GoodDescriptionModificationDoesNotFailTheTest() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
+
+        final var descriptionModificationReportWithMetricChanges = buildDescriptionModificationReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.UPT,
+                        Pair.of(
+                                mdibBuilder.buildNumericMetricDescriptor(
+                                        NUMERIC_METRIC_HANDLE,
+                                        MetricCategory.RCMM,
+                                        MetricAvailability.CONT,
+                                        mdibBuilder.buildCodedValue("abc"),
+                                        BigDecimal.ONE),
+                                buildNumericMetricState(
+                                        NUMERIC_METRIC_HANDLE,
+                                        mdibBuilder.buildNumericMetricValue(BigDecimal.TEN),
+                                        ComponentActivation.NOT_RDY))));
+
+        final var metricReport = buildEpisodicMetricReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildNumericMetricState(
+                        NUMERIC_METRIC_HANDLE,
+                        mdibBuilder.buildNumericMetricValue(BigDecimal.TEN),
+                        ComponentActivation.NOT_RDY));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithMetricChanges);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, metricReport);
+
+        testClass.testRequirementC14();
+    }
+
+    /**
      * Tests whether duplicated EpisodicMetricReports pass the test.
      *
      * @throws Exception on any exception
@@ -2469,6 +2621,38 @@ public class InvariantMessageModelAnnexTestTest {
         messageStorageUtil.addInboundSecureHttpMessage(storage, first);
         messageStorageUtil.addInboundSecureHttpMessage(storage, second);
         messageStorageUtil.addInboundSecureHttpMessage(storage, third);
+
+        testClass.testRequirementC15();
+    }
+
+    /**
+     * Tests whether a DescriptionModificationReport with the same MdibVersion that already contains
+     * the changed state does not fail the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementC15GoodDescriptionModificationDoesNotFailTheTest() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
+
+        final var descriptionModificationReportWithOperationStateChanges = buildDescriptionModificationReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.UPT,
+                        Pair.of(
+                                mdibBuilder.buildSetStringOperationDescriptor(
+                                        SET_STRING_OPERATION_HANDLE, "someTarget"),
+                                buildSetStringOperationState(SET_STRING_OPERATION_HANDLE, OperatingMode.DIS))));
+
+        final var operationalStateReport = buildEpisodicOperationalStateReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildSetStringOperationState(SET_STRING_OPERATION_HANDLE, OperatingMode.DIS));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithOperationStateChanges);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, operationalStateReport);
 
         testClass.testRequirementC15();
     }

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantMessageModelAnnexTestTest.java
@@ -7,6 +7,7 @@
 
 package com.draeger.medical.sdccc.tests.biceps.invariant;
 
+import static com.draeger.medical.sdccc.util.MdibBuilder.DEFAULT_MDS_HANDLE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -184,9 +185,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final String parentDescriptor = "parentDescriptor";
         final Envelope first = buildDescriptionModificationReport(
@@ -234,9 +235,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final String parentDescriptor = "parentDescriptor";
         final Envelope first = buildDescriptionModificationReport(
@@ -282,9 +283,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final String parentDescriptor = "parentDescriptor";
         final Envelope first = buildDescriptionModificationReport(
@@ -334,9 +335,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final String parentDescriptor = "parentDescriptor";
         final Envelope first = buildDescriptionModificationReport(
@@ -382,7 +383,7 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final Pair<MdsDescriptor, MdsState> mdsDescriptor = mdibBuilder.buildMds(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final Pair<MdsDescriptor, MdsState> mdsDescriptor = mdibBuilder.buildMds(DEFAULT_MDS_HANDLE);
 
         final String parentDescriptor = "parentDescriptor";
         final Envelope first = buildDescriptionModificationReport(
@@ -427,9 +428,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final String parentDescriptor = "parentDescriptor";
         final Envelope first = buildDescriptionModificationReport(
@@ -472,9 +473,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final String parentDescriptor = "parentDescriptor";
         final Envelope first = buildDescriptionModificationReport(
@@ -525,9 +526,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO, BigInteger.ONE);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final Envelope first = buildDescriptionModificationReport(
                 SEQUENCE_ID,
@@ -560,9 +561,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final Envelope first = buildDescriptionModificationReport(
                 SEQUENCE_ID,
@@ -576,9 +577,7 @@ public class InvariantMessageModelAnnexTestTest {
                 SEQUENCE_ID,
                 BigInteger.TWO,
                 buildDescriptionModificationReportPart(
-                        DescriptionModificationType.CRT,
-                        MdibBuilder.DEFAULT_MDS_HANDLE,
-                        mdibBuilder.buildVmd(crtPart1Handle)),
+                        DescriptionModificationType.CRT, DEFAULT_MDS_HANDLE, mdibBuilder.buildVmd(crtPart1Handle)),
                 buildDescriptionModificationReportPart(
                         DescriptionModificationType.CRT, crtPart1Handle, mdibBuilder.buildChannel("second channel")));
         messageStorageUtil.addInboundSecureHttpMessage(storage, second);
@@ -605,9 +604,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final Envelope first = buildDescriptionModificationReport(
                 SEQUENCE_ID,
@@ -621,9 +620,7 @@ public class InvariantMessageModelAnnexTestTest {
                 SEQUENCE_ID,
                 BigInteger.TWO,
                 buildDescriptionModificationReportPart(
-                        DescriptionModificationType.CRT,
-                        MdibBuilder.DEFAULT_MDS_HANDLE,
-                        mdibBuilder.buildVmd(crtPart1Handle)),
+                        DescriptionModificationType.CRT, DEFAULT_MDS_HANDLE, mdibBuilder.buildVmd(crtPart1Handle)),
                 buildDescriptionModificationReportPart(
                         DescriptionModificationType.CRT, crtPart1Handle, mdibBuilder.buildChannel("second channel")));
         messageStorageUtil.addInboundSecureHttpMessage(storage, second);
@@ -653,9 +650,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.ZERO);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final Envelope first = buildDescriptionModificationReport(
                 SEQUENCE_ID,
@@ -729,9 +726,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final Envelope first = buildDescriptionModificationReport(
                 SEQUENCE_ID,
@@ -769,9 +766,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final Envelope first = buildDescriptionModificationReport(
                 SEQUENCE_ID,
@@ -795,9 +792,9 @@ public class InvariantMessageModelAnnexTestTest {
         final Envelope initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
 
-        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsDescriptor mdsDescriptor = mdibBuilder.buildMdsDescriptor(DEFAULT_MDS_HANDLE);
         mdsDescriptor.setDescriptorVersion(BigInteger.TEN);
-        final MdsState mdsState = mdibBuilder.buildMdsState(MdibBuilder.DEFAULT_MDS_HANDLE);
+        final MdsState mdsState = mdibBuilder.buildMdsState(DEFAULT_MDS_HANDLE);
 
         final Envelope first = buildDescriptionModificationReport(
                 SEQUENCE_ID,
@@ -834,7 +831,7 @@ public class InvariantMessageModelAnnexTestTest {
                 BigInteger.ONE,
                 buildDescriptionModificationReportPart(
                         DescriptionModificationType.UPT,
-                        mdibBuilder.buildMds(MdibBuilder.DEFAULT_MDS_HANDLE),
+                        mdibBuilder.buildMds(DEFAULT_MDS_HANDLE),
                         mdibBuilder.buildAlertSystem(MDS_ALERT_SYSTEM_HANDLE, AlertActivation.ON)));
         messageStorageUtil.addInboundSecureHttpMessage(storage, first);
 
@@ -1692,6 +1689,39 @@ public class InvariantMessageModelAnnexTestTest {
     }
 
     /**
+     * Tests whether a DescriptionModificationReport with the same MdibVersion that already contains
+     * the changed state does not fail the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementC11GoodDescriptionModificationInsertDoesNotFailTheTest() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
+
+        final var handle = VMD_ALERT_CONDITION_HANDLE + "other";
+
+        final var descriptionModificationReportWithAlertChanges = buildDescriptionModificationReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.CRT,
+                        DEFAULT_MDS_HANDLE,
+                        Pair.of(
+                                mdibBuilder.buildAlertConditionDescriptor(
+                                        handle, AlertConditionKind.OTH, AlertConditionPriority.ME),
+                                buildAlertConditionState(handle, AlertActivation.ON, true))));
+
+        final var alertReport = buildEpisodicAlertReport(
+                SEQUENCE_ID, BigInteger.ONE, buildAlertConditionState(handle, AlertActivation.ON, true));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithAlertChanges);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, alertReport);
+
+        testClass.testRequirementC11();
+    }
+
+    /**
      * Tests whether duplicated EpisodicAlertReports pass the test.
      *
      * @throws Exception on any exception
@@ -1899,6 +1929,38 @@ public class InvariantMessageModelAnnexTestTest {
 
         final var componentReport = buildEpisodicComponentReport(
                 SEQUENCE_ID, BigInteger.ONE, buildBatteryState(BATTERY_HANDLE, ComponentActivation.STND_BY, 10L));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithComponentChanges);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, componentReport);
+
+        testClass.testRequirementC12();
+    }
+
+    /**
+     * Tests whether a DescriptionModificationReport with the same MdibVersion that already contains
+     * the changed state does not fail the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementC12GoodDescriptionModificationInsertDoesNotFailTheTest() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
+
+        final var handle = BATTERY_HANDLE + "other";
+
+        final var descriptionModificationReportWithComponentChanges = buildDescriptionModificationReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.CRT,
+                        DEFAULT_MDS_HANDLE,
+                        Pair.of(
+                                mdibBuilder.buildBatteryDescriptor(handle),
+                                buildBatteryState(handle, ComponentActivation.STND_BY, 10L))));
+
+        final var componentReport = buildEpisodicComponentReport(
+                SEQUENCE_ID, BigInteger.ONE, buildBatteryState(handle, ComponentActivation.STND_BY, 10L));
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
         messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithComponentChanges);
@@ -2139,6 +2201,46 @@ public class InvariantMessageModelAnnexTestTest {
                         PATIENT_CONTEXT_STATE_HANDLE,
                         ContextAssociation.ASSOC,
                         mdibBuilder.buildCodedValue("newCodedValue")));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithContextChanges);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, contextReport);
+
+        testClass.testRequirementC13();
+    }
+
+    /**
+     * Tests whether a DescriptionModificationReport with the same MdibVersion that already contains
+     * the changed state does not fail the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementC13GoodDescriptionModificationInsertDoesNotFailTheTest() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
+
+        final var handle = OPERATOR_CONTEXT_DESCRIPTOR_HANDLE + "other";
+        final var stateHandle = OPERATOR_CONTEXT_STATE_HANDLE + "other";
+
+        final var descriptionModificationReportWithContextChanges = buildDescriptionModificationReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.CRT,
+                        SYSTEM_CONTEXT_HANDLE,
+                        Pair.of(
+                                mdibBuilder.buildOperatorContextDescriptor(handle),
+                                buildOperatorContextState(
+                                        handle,
+                                        stateHandle,
+                                        ContextAssociation.ASSOC,
+                                        mdibBuilder.buildCodedValue("newCodedValue")))));
+
+        final var contextReport = buildEpisodicContextReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildOperatorContextState(
+                        handle, stateHandle, ContextAssociation.ASSOC, mdibBuilder.buildCodedValue("newCodedValue")));
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
         messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithContextChanges);
@@ -2437,6 +2539,49 @@ public class InvariantMessageModelAnnexTestTest {
     }
 
     /**
+     * Tests whether a DescriptionModificationReport with the same MdibVersion that already contains
+     * the changed state does not fail the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementC14GoodDescriptionModificationInsertDoesNotFailTheTest() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
+
+        final var handle = NUMERIC_METRIC_HANDLE + "other";
+
+        final var descriptionModificationReportWithMetricChanges = buildDescriptionModificationReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.CRT,
+                        CHANNEL_HANDLE,
+                        Pair.of(
+                                mdibBuilder.buildNumericMetricDescriptor(
+                                        handle,
+                                        MetricCategory.RCMM,
+                                        MetricAvailability.CONT,
+                                        mdibBuilder.buildCodedValue("abc"),
+                                        BigDecimal.ONE),
+                                buildNumericMetricState(
+                                        handle,
+                                        mdibBuilder.buildNumericMetricValue(BigDecimal.TEN),
+                                        ComponentActivation.NOT_RDY))));
+
+        final var metricReport = buildEpisodicMetricReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildNumericMetricState(
+                        handle, mdibBuilder.buildNumericMetricValue(BigDecimal.TEN), ComponentActivation.NOT_RDY));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithMetricChanges);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, metricReport);
+
+        testClass.testRequirementC14();
+    }
+
+    /**
      * Tests whether duplicated EpisodicMetricReports pass the test.
      *
      * @throws Exception on any exception
@@ -2649,6 +2794,38 @@ public class InvariantMessageModelAnnexTestTest {
                 SEQUENCE_ID,
                 BigInteger.ONE,
                 buildSetStringOperationState(SET_STRING_OPERATION_HANDLE, OperatingMode.DIS));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithOperationStateChanges);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, operationalStateReport);
+
+        testClass.testRequirementC15();
+    }
+
+    /**
+     * Tests whether a DescriptionModificationReport with the same MdibVersion that already contains
+     * the changed state does not fail the test.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementC15GoodDescriptionModificationInsertDoesNotFailTheTest() throws Exception {
+        final var initial = buildMdib(SEQUENCE_ID, BigInteger.ZERO);
+
+        final var handle = SET_STRING_OPERATION_HANDLE + "other";
+
+        final var descriptionModificationReportWithOperationStateChanges = buildDescriptionModificationReport(
+                SEQUENCE_ID,
+                BigInteger.ONE,
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.CRT,
+                        SCO_HANDLE,
+                        Pair.of(
+                                mdibBuilder.buildSetStringOperationDescriptor(handle, "someTarget"),
+                                buildSetStringOperationState(handle, OperatingMode.DIS))));
+
+        final var operationalStateReport = buildEpisodicOperationalStateReport(
+                SEQUENCE_ID, BigInteger.ONE, buildSetStringOperationState(handle, OperatingMode.DIS));
 
         messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
         messageStorageUtil.addInboundSecureHttpMessage(storage, descriptionModificationReportWithOperationStateChanges);
@@ -3027,6 +3204,7 @@ public class InvariantMessageModelAnnexTestTest {
         for (var reportPart : reportParts) {
             report.getReportPart().add(reportPart);
         }
+
         return messageBuilder.createSoapMessageWithBody(ActionConstants.ACTION_EPISODIC_ALERT_REPORT, report);
     }
 


### PR DESCRIPTION
the requirement tests biceps.c11 - biceps.c15 no longer fail when a description modification report with the same state and mdib version is seen. Unit tests added for that scenario.


# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
