### PR TITLE
manipulation locking

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -96,6 +96,12 @@ import org.somda.sdc.glue.common.WsdlConstants;
  * SDCcc main class.
  */
 public class TestSuite {
+
+    /**
+     * The name used to hold the manipulation lock during the phase 4 disconnect.
+     */
+    public static final String LOCK_NAME = "TestSuite.phase4";
+
     private static final Logger LOG = LogManager.getLogger(TestSuite.class);
     private static final Duration MAX_WAIT = Duration.ofSeconds(10);
     private static final int TIME_BETWEEN_PHASES = 10000;
@@ -233,7 +239,7 @@ public class TestSuite {
             final SummaryGeneratingListener invariantSummary) {
         // acquire ManipulationLocker lock to ensure we don't lose any calls
         final var manipulationLocker = injector.getInstance(ManipulationLocker.class);
-        manipulationLocker.lock("TestSuite.phase4", () -> {
+        manipulationLocker.lock(LOCK_NAME, () -> {
             LOG.info("Disconnecting TestSuite Client");
             try {
                 injector.getInstance(TestClient.class).disconnect();

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteModule.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteModule.java
@@ -9,6 +9,7 @@ package com.draeger.medical.sdccc.configuration;
 
 import com.draeger.medical.sdccc.manipulation.GRpcManipulations;
 import com.draeger.medical.sdccc.manipulation.GsonManipulationSerializer;
+import com.draeger.medical.sdccc.manipulation.ManipulationLocker;
 import com.draeger.medical.sdccc.manipulation.ManipulationSerializer;
 import com.draeger.medical.sdccc.manipulation.Manipulations;
 import com.draeger.medical.sdccc.manipulation.guice.InteractionFactory;
@@ -50,5 +51,6 @@ public class DefaultTestSuiteModule extends AbstractModule {
         bind(Manipulations.class).to(GRpcManipulations.class).in(Singleton.class);
         bind(LocalAddressResolver.class).to(LocalAddressResolverImpl.class).in(Singleton.class);
         bind(ManipulationSerializer.class).to(GsonManipulationSerializer.class).in(Singleton.class);
+        bind(ManipulationLocker.class).asEagerSingleton();
     }
 }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
@@ -4,6 +4,8 @@ import com.google.inject.Inject
 import com.google.inject.Injector
 import com.google.inject.Singleton
 import org.apache.logging.log4j.kotlin.Logging
+import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.locks.ReentrantLock
 
 /**
@@ -24,11 +26,15 @@ class ManipulationLocker @Inject constructor(
         callerName: String,
         supplier: () -> T
     ): T {
+        val start = Instant.now()
         try {
             internalLock.lock()
             logger.debug { "Lock was granted for $callerName, executing lambda" }
             return supplier()
         } finally {
+            val finish = Instant.now()
+            val elapsed = Duration.between(start, finish)
+            logger.debug { "Releasing lock for $callerName after $elapsed" }
             internalLock.unlock()
         }
     }
@@ -48,6 +54,7 @@ class ManipulationLocker @Inject constructor(
             logger.debug { "Lock was granted for $callerName, executing lambda" }
             return supplier(requestedManipulations)
         } finally {
+            logger.debug { "Lock was released for $callerName" }
             internalLock.unlock()
         }
     }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.kotlin.Logging
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.properties.Delegates
 
 /**
  * Locker for manipulations. This locker is used to prevent multiple
@@ -25,6 +26,13 @@ class ManipulationLocker @Inject constructor(
     private val injector: Injector
 ) {
     private val internalLock = ReentrantLock(true)
+    private val subscribers = mutableListOf<(String?) -> Unit>()
+    private var lockedBy: String? by Delegates.observable(null) { _, _, newValue ->
+        subscribers.toList()
+            .forEach {
+                it(newValue)
+            }
+    }
 
     /**
      * Locks the manipulation and executes the lambda. Returns the result of the lambda.
@@ -33,25 +41,11 @@ class ManipulationLocker @Inject constructor(
         callerName: String,
         supplier: () -> T
     ): T {
-        val start = Instant.now()
-        try {
-            internalLock.lock()
-            logger.debug { "Lock was granted for $callerName, executing lambda" }
-            return supplier()
-        } finally {
-            val finish = Instant.now()
-            val elapsed = Duration.between(start, finish)
-            logger.debug { "Releasing lock for $callerName after $elapsed" }
-            internalLock.unlock()
+        // use the reified call without passing in the argument
+        return this.lockManipulations(callerName, Manipulations::class.java) {
+            supplier()
         }
     }
-
-    /**
-     * Returns whether the manipulation is currently locked.
-     *
-     * This is mostly useful for unit testing.
-     */
-    fun isLocked() = internalLock.isLocked
 
     // TODO: Do we want his? Implication: internalLock and injector must be internal
     /**
@@ -63,14 +57,44 @@ class ManipulationLocker @Inject constructor(
         supplier: (M) -> T
     ): T {
         val requestedManipulations = injector.getInstance(manipulationsClass)
+        val start = Instant.now()
         try {
             internalLock.lock()
+            lockedBy = callerName
             logger.debug { "Lock was granted for $callerName, executing lambda" }
             return supplier(requestedManipulations)
         } finally {
-            logger.debug { "Lock was released for $callerName" }
+            val finish = Instant.now()
+            val elapsed = Duration.between(start, finish)
+            logger.debug { "Releasing lock for $callerName after $elapsed" }
+            lockedBy = null
             internalLock.unlock()
         }
+    }
+
+    /**
+     * Returns whether the manipulation is currently locked.
+     *
+     * This is mostly useful for unit testing.
+     */
+    fun isLocked() = internalLock.isLocked
+
+    /**
+     * Returns the self-declared name of the locking code.
+     *
+     * This is mostly useful for unit testing.
+     */
+    fun lockedBy() = lockedBy
+
+    // for testing purposes, this implementation allows observing the names of the lockers
+    internal fun subscribe(subscriber: (String?) -> Unit) {
+        logger.debug { "Subscribing to lock events" }
+        subscribers.add(subscriber)
+    }
+
+    internal fun unsubscribe(subscriber: (String?) -> Unit) {
+        logger.debug { "Unsubscribing from lock events" }
+        subscribers.remove(subscriber)
     }
 
     companion object : Logging

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
@@ -36,20 +36,29 @@ class ManipulationLocker @Inject constructor(
 
     /**
      * Locks the manipulation and executes the lambda. Returns the result of the lambda.
+     *
+     * @param T the return type of the lambda
+     * @param callerName the name of the caller
+     * @param supplier the lambda to execute
      */
     fun <T> lock(
         callerName: String,
         supplier: () -> T
     ): T {
-        // use the reified call without passing in the argument
+        // use the other call without passing in the argument
         return this.lockManipulations(callerName, Manipulations::class.java) {
             supplier()
         }
     }
 
-    // TODO: Do we want his? Implication: internalLock and injector must be internal
     /**
      * Locks the manipulation and executes the lambda. Returns the result of the lambda.
+     *
+     * @param M the type of the manipulations to provide to the lambda
+     * @param T the return type of the lambda
+     * @param callerName the name of the caller
+     * @param manipulationsClass the class of the manipulations to provide to the lambda
+     * @param supplier the lambda to execute
      */
     fun <M : Manipulations, T> lockManipulations(
         callerName: String,

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
@@ -1,0 +1,56 @@
+package com.draeger.medical.sdccc.manipulation
+
+import com.google.inject.Inject
+import com.google.inject.Injector
+import com.google.inject.Singleton
+import org.apache.logging.log4j.kotlin.Logging
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * Locker for manipulations. This locker is used to prevent multiple
+ * manipulations from running at the same time. This is necessary
+ * as observing manipulations can trigger manipulations at arbitrary times.
+ */
+@Singleton
+class ManipulationLocker @Inject constructor(
+    private val injector: Injector
+) {
+    private val internalLock = ReentrantLock(true)
+
+    /**
+     * Locks the manipulation and executes the lambda. Returns the result of the lambda.
+     */
+    fun <T> lock(
+        callerName: String,
+        supplier: () -> T
+    ): T {
+        try {
+            internalLock.lock()
+            logger.debug { "Lock was granted for $callerName, executing lambda" }
+            return supplier()
+        } finally {
+            internalLock.unlock()
+        }
+    }
+
+    // TODO: Do we want his? Implication: internalLock and injector must be internal
+    /**
+     * Locks the manipulation and executes the lambda. Returns the result of the lambda.
+     */
+    fun <M : Manipulations, T> lockManipulations(
+        callerName: String,
+        manipulationsClass: Class<M>,
+        supplier: (M) -> T
+    ): T {
+        val requestedManipulations = injector.getInstance(manipulationsClass)
+        try {
+            internalLock.lock()
+            logger.debug { "Lock was granted for $callerName, executing lambda" }
+            return supplier(requestedManipulations)
+        } finally {
+            internalLock.unlock()
+        }
+    }
+
+    companion object : Logging
+}

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
@@ -1,3 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the MIT License.
+ * Copyright (c) 2024 Draegerwerk AG & Co. KGaA.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 package com.draeger.medical.sdccc.manipulation
 
 import com.google.inject.Inject

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationLocker.kt
@@ -46,6 +46,13 @@ class ManipulationLocker @Inject constructor(
         }
     }
 
+    /**
+     * Returns whether the manipulation is currently locked.
+     *
+     * This is mostly useful for unit testing.
+     */
+    fun isLocked() = internalLock.isLocked
+
     // TODO: Do we want his? Implication: internalLock and injector must be internal
     /**
      * Locks the manipulation and executes the lambda. Returns the result of the lambda.

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/LockingPrecondition.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/LockingPrecondition.kt
@@ -1,0 +1,7 @@
+package com.draeger.medical.sdccc.manipulation.precondition
+
+/**
+ * Marker interface to indicate the precondition is taking over the responsibility
+ * of locking the manipulations on its own.
+ */
+interface LockingPrecondition

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/LockingPrecondition.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/LockingPrecondition.kt
@@ -1,3 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the MIT License.
+ * Copyright (c) 2024 Draegerwerk AG & Co. KGaA.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 package com.draeger.medical.sdccc.manipulation.precondition
 
 /**

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/PreconditionRegistry.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/PreconditionRegistry.kt
@@ -110,7 +110,7 @@ class PreconditionRegistry @Inject internal constructor(private val injector: In
                 // so we unconditionally lock during their execution
                 logger.info {
                     "Precondition ${precondition.javaClass.simpleName} does not implement" +
-                        " ${LockingPrecondition::class.java.simpleName}, locking ManipulationLocker"
+                        " ${LockingPrecondition::class.java.simpleName}, locking ManipulationLocker."
                 }
                 injector.getInstance(ManipulationLocker::class.java).lock(
                     "PreconditionRegistry.runPreconditions - ${precondition.javaClass.simpleName}"

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.draeger.medical.sdccc.configuration.EnabledTestConfig;
+import com.draeger.medical.sdccc.manipulation.ManipulationLocker;
 import com.draeger.medical.sdccc.manipulation.Manipulations;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClient;
 import com.draeger.medical.sdccc.tests.InjectorTestBase;
@@ -40,7 +41,7 @@ import org.somda.sdc.biceps.model.participant.MdsDescriptor;
 public class DirectParticipantModelContextStateTest extends InjectorTestBase {
 
     private MessageGeneratingUtil messageGeneratingUtil;
-    private Manipulations manipulations;
+    private ManipulationLocker manipulationLocker;
     private TestClient testClient;
 
     @BeforeEach
@@ -48,7 +49,7 @@ public class DirectParticipantModelContextStateTest extends InjectorTestBase {
         testClient = getInjector().getInstance(TestClient.class);
         assertTrue(testClient.isClientRunning());
         this.messageGeneratingUtil = getInjector().getInstance(MessageGeneratingUtil.class);
-        this.manipulations = getInjector().getInstance(Manipulations.class);
+        this.manipulationLocker = getInjector().getInstance(ManipulationLocker.class);
     }
 
     @Test
@@ -89,9 +90,10 @@ public class DirectParticipantModelContextStateTest extends InjectorTestBase {
         if (contextDescriptor == null) {
             return 0;
         }
-        final var newHandle = manipulations
-                .createContextStateWithAssociation(contextDescriptor.getHandle(), ContextAssociation.ASSOC)
-                .getResponse();
+        final var newHandle = manipulationLocker.lockManipulations(
+                "testRequirement0125", Manipulations.class, manipulations -> manipulations
+                        .createContextStateWithAssociation(contextDescriptor.getHandle(), ContextAssociation.ASSOC)
+                        .getResponse());
         assertTrue(
                 newHandle.isPresent(),
                 String.format("Manipulation was unsuccessful for handle %s", contextDescriptor.getHandle()));

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/direct/DirectSubscriptionHandlingTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/direct/DirectSubscriptionHandlingTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.draeger.medical.sdccc.configuration.EnabledTestConfig;
 import com.draeger.medical.sdccc.configuration.TestSuiteConfig;
+import com.draeger.medical.sdccc.manipulation.ManipulationLocker;
 import com.draeger.medical.sdccc.manipulation.Manipulations;
 import com.draeger.medical.sdccc.sdcri.testclient.TestClient;
 import com.draeger.medical.sdccc.tests.InjectorTestBase;
@@ -100,7 +101,7 @@ public class DirectSubscriptionHandlingTest extends InjectorTestBase {
     private TestClient testClient;
     private HostedServiceVerifier hostedServiceVerifier;
     private MessageGeneratingUtil messageGeneratingUtil;
-    private Manipulations manipulations;
+    private ManipulationLocker manipulationLocker;
     private WsEventingEventSinkFactory eventSinkFactory;
     private String adapterAddress;
     private NotificationSinkFactory notificationSinkFactory;
@@ -114,7 +115,7 @@ public class DirectSubscriptionHandlingTest extends InjectorTestBase {
         final Injector riInjector = this.testClient.getInjector();
         this.hostedServiceVerifier = getInjector().getInstance(HostedServiceVerifier.class);
         this.messageGeneratingUtil = getInjector().getInstance(MessageGeneratingUtil.class);
-        this.manipulations = getInjector().getInstance(Manipulations.class);
+        this.manipulationLocker = getInjector().getInstance(ManipulationLocker.class);
         this.eventSinkFactory = riInjector.getInstance(WsEventingEventSinkFactory.class);
         this.adapterAddress = getInjector()
                 .getInstance(Key.get(String.class, Names.named(TestSuiteConfig.NETWORK_INTERFACE_ADDRESS)));
@@ -214,7 +215,10 @@ public class DirectSubscriptionHandlingTest extends InjectorTestBase {
                             } else {
                                 locationDetail.setRoom(ROOM1);
                             }
-                            manipulations.setLocationDetail(locationDetail);
+                            manipulationLocker.lockManipulations(
+                                    "testRequirementR00360",
+                                    Manipulations.class,
+                                    manipulations -> manipulations.setLocationDetail(locationDetail));
                         }) {
                     @Override
                     public boolean doesNotificationBodyBelongToThisReport(final Object notificationBody) {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/ManipulationLockerTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/ManipulationLockerTest.kt
@@ -1,0 +1,91 @@
+package com.draeger.medical.sdccc.manipulation
+
+import com.google.inject.Injector
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import java.util.concurrent.CompletableFuture
+import kotlin.concurrent.thread
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
+
+class ManipulationLockerTest {
+
+    private val mockInjector = mock<Injector>()
+
+    @Test
+    internal fun `test lock`() {
+        val locker = ManipulationLocker(mockInjector)
+        val timeToBlock = 1.seconds
+        val timeTolerance = 100.milliseconds
+        // lock and block
+        val blockingLock = startThreadWithFuture(locker) {
+            Thread.sleep(timeToBlock.inWholeMilliseconds)
+        }
+
+        // wait for the thread to lock
+        blockingLock.future.join()
+        val elapsedBlocked = measureTime {
+            locker.lock("blockedResult") {
+                println("blockedResult")
+            }
+        }
+
+        val elapsed = timeToBlock - elapsedBlocked
+        assertTrue(
+            "Elapsed time $elapsedBlocked is not within $timeTolerance of $timeToBlock "
+        ) { elapsed.absoluteValue <= timeTolerance }
+    }
+
+    // this is obviously not a proper test for fairness, functions as a sanity check for fairness
+    @Test
+    internal fun `test lock fairness`() {
+        val locker = ManipulationLocker(mockInjector)
+        val timeToBlock = 1.seconds
+        val locksToAcquire = 10000
+        // lock and block
+        val hasLock = startThreadWithFuture(locker) {
+            Thread.sleep(timeToBlock.inWholeMilliseconds)
+        }
+
+        // wait for the thread to lock
+        hasLock.future.join()
+        val resultList = mutableListOf<Int>()
+        // start tasks that should remain in order
+
+        val threads = (0 ..< locksToAcquire).map {
+            val res = startThreadWithFuture(locker) {
+                resultList.add(it)
+            }
+            res.future.join()
+            res
+        }
+
+        threads.forEach { it.thread.join() }
+
+        locker.lock("blockedResult") {
+            println("blockedResult")
+        }
+
+        assertEquals(locksToAcquire, resultList.size)
+        assertEquals(resultList.sorted(), resultList)
+    }
+
+    private fun startThreadWithFuture(
+        locker: ManipulationLocker,
+        supplier: () -> Unit
+    ): ThreadAndFuture {
+        val hasLock = CompletableFuture<Unit>()
+        val t = thread (isDaemon = true) {
+            locker.lock("result") {
+                hasLock.complete(null)
+                supplier()
+            }
+        }
+        return ThreadAndFuture(t, hasLock)
+    }
+
+    private data class ThreadAndFuture(val thread: Thread, val future: CompletableFuture<Unit>)
+}

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/ManipulationLockerTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/ManipulationLockerTest.kt
@@ -1,3 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the MIT License.
+ * Copyright (c) 2024 Draegerwerk AG & Co. KGaA.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 package com.draeger.medical.sdccc.manipulation
 
 import com.google.inject.Injector

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/PreconditionRegistryTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/PreconditionRegistryTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.draeger.medical.sdccc.manipulation.ManipulationLocker;
+import com.draeger.medical.sdccc.manipulation.Manipulations;
 import com.google.inject.Injector;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -46,6 +47,8 @@ public class PreconditionRegistryTest {
         mockInjector = mock(Injector.class);
         locker = new ManipulationLocker(mockInjector);
         when(mockInjector.getInstance(ManipulationLocker.class)).thenReturn(locker);
+        final var mockManipulations = mock(Manipulations.class);
+        when(mockInjector.getInstance(Manipulations.class)).thenReturn(mockManipulations);
     }
 
     /**

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/PreconditionRegistryTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/PreconditionRegistryTest.java
@@ -15,7 +15,9 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.draeger.medical.sdccc.manipulation.ManipulationLocker;
 import com.google.inject.Injector;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,10 +31,15 @@ import org.junit.jupiter.api.Test;
  */
 public class PreconditionRegistryTest {
 
+    private Injector mockInjector;
+
     @BeforeEach
     void setUp() {
         PreconditionUtil.MockPrecondition.reset();
         PreconditionUtil.MockManipulation.reset();
+        mockInjector = mock(Injector.class);
+        final ManipulationLocker locker = new ManipulationLocker(mockInjector);
+        when(mockInjector.getInstance(ManipulationLocker.class)).thenReturn(locker);
     }
 
     /**
@@ -43,7 +50,6 @@ public class PreconditionRegistryTest {
     @Test
     @DisplayName("Tests registering a complex interaction and whether it's prompted for")
     public void testPreconditionInteractionRegistrationAndPrompt() throws Exception {
-        final var mockInjector = mock(Injector.class);
         final var registry = new PreconditionRegistry(mockInjector);
 
         final var preconditionWasCalled = new AtomicBoolean(false);
@@ -74,7 +80,6 @@ public class PreconditionRegistryTest {
     @Test
     @DisplayName("Tests whether registering the same complex interaction thrice only prompts for it once")
     public void testPreconditionInteractionRegisteredOnlyOnce() throws Exception {
-        final var mockInjector = mock(Injector.class);
         final var registry = new PreconditionRegistry(mockInjector);
 
         final var preconditionWasCalled = new AtomicInteger(0);
@@ -98,7 +103,6 @@ public class PreconditionRegistryTest {
     @Test
     @DisplayName("Tests whether an exception during registration causes a RuntimeException and stops the test run")
     public void testPreconditionInteractionRegistrationException() {
-        final var mockInjector = mock(Injector.class);
         final var registry = new PreconditionRegistry(mockInjector);
 
         final var mockInteractionWasCalled = new AtomicInteger(0);
@@ -121,7 +125,6 @@ public class PreconditionRegistryTest {
     @Test
     @DisplayName("Tests registering a manipulation and whether it's prompted for")
     public void testManipulationInteractionRegistrationAndPrompt() throws Exception {
-        final var mockInjector = mock(Injector.class);
         final var registry = new PreconditionRegistry(mockInjector);
 
         final var manipulationWasCalled = new AtomicBoolean(false);
@@ -144,7 +147,6 @@ public class PreconditionRegistryTest {
     @Test
     @DisplayName("Tests whether registering the same manipulation thrice only prompts for it once")
     public void testManipulationInteractionRegisteredOnlyOnce() throws Exception {
-        final var mockInjector = mock(Injector.class);
         final var registry = new PreconditionRegistry(mockInjector);
 
         final var manipulationWasCalled = new AtomicInteger(0);
@@ -167,7 +169,6 @@ public class PreconditionRegistryTest {
     @Test
     @DisplayName("Tests whether an exception during registration causes a RuntimeException and stops the test run")
     public void testManipulationInteractionRegistrationException() {
-        final var mockInjector = mock(Injector.class);
         final var registry = new PreconditionRegistry(mockInjector);
 
         final var mockInteractionWasCalled = new AtomicInteger(0);
@@ -184,7 +185,6 @@ public class PreconditionRegistryTest {
 
     @Test
     void testRegisteringObservingPreconditions() throws Exception {
-        final var mockInjector = mock(Injector.class);
         final var registry = new PreconditionRegistry(mockInjector);
 
         final KClass<? extends ObservingPreconditionFactory<?>> mockPreconditionFactory = mock(KClass.class);
@@ -211,7 +211,6 @@ public class PreconditionRegistryTest {
 
     @Test
     void testRegisteringObservingPreconditionsFailsWhenNoObjectInstanceAvailable() {
-        final var mockInjector = mock(Injector.class);
         final var registry = new PreconditionRegistry(mockInjector);
 
         final KClass<? extends ObservingPreconditionFactory<?>> mockPreconditionFactory = mock(KClass.class);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/PreconditionUtil.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/PreconditionUtil.java
@@ -112,4 +112,12 @@ public class PreconditionUtil {
             MockManipulation.afterConstructorCall = afterConstructorCall;
         }
     }
+
+    /**
+     * An extension of {@linkplain MockManipulation} which implements the {@linkplain LockingPrecondition} interface.
+     */
+    public static class MockLockingManipulation extends MockManipulation implements LockingPrecondition {
+
+        MockLockingManipulation() throws Exception {}
+    }
 }


### PR DESCRIPTION
Introduce a "Manipulation Locker" to limit access to manipulations, specifically to avoid side effects of concurrently running manipulations that are not intended to be run together with others.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
