### PR TITLE
Use thread join before verifying the invalidation in BufferedObservingPreconditionTest

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/BufferedObservingPrecondition.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/BufferedObservingPrecondition.kt
@@ -28,10 +28,14 @@ abstract class BufferedObservingPrecondition(
     // as the queue will fill up (quite quickly with waveforms)
     private val updateQueue = LinkedBlockingQueue<MdibChange>()
 
-    // internal visibility to allow unit tests to inspect the thread. do not use for anything else
-    internal val processingThread: Thread
     private val processDied = AtomicBoolean(false)
     private val testRunObserver = injector.getInstance(TestRunObserver::class.java)
+
+    /**
+     * The thread that processes the incoming changes and provides them to
+     * the concrete observing precondition.
+     */
+    val processingThread: Thread
 
     init {
         processingThread = thread(start = true, isDaemon = true) {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/BufferedObservingPrecondition.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/BufferedObservingPrecondition.kt
@@ -27,7 +27,9 @@ abstract class BufferedObservingPrecondition(
     // this is going to be a problem when the manipulation is very long-running,
     // as the queue will fill up (quite quickly with waveforms)
     private val updateQueue = LinkedBlockingQueue<MdibChange>()
-    private val processingThread: Thread
+
+    // internal visibility to allow unit tests to inspect the thread. do not use for anything else
+    internal val processingThread: Thread
     private val processDied = AtomicBoolean(false)
     private val testRunObserver = injector.getInstance(TestRunObserver::class.java)
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/BufferedObservingPreconditionTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/BufferedObservingPreconditionTest.kt
@@ -134,7 +134,7 @@ internal class BufferedObservingPreconditionTest {
 
         exampleObserving
             .processingThread
-            .join(TIME_TO_WAIT_FOR_CHANGE.inWholeMilliseconds)
+            .join(TIME_TO_WAIT_FOR_CHANGE_MILLIS)
 
         verify(
             testRunObserver,
@@ -146,6 +146,6 @@ internal class BufferedObservingPreconditionTest {
     }
 
     companion object {
-        private val TIME_TO_WAIT_FOR_CHANGE = 100.milliseconds
+        private const val TIME_TO_WAIT_FOR_CHANGE_MILLIS = 60_000L
     }
 }

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/BufferedObservingPreconditionTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/BufferedObservingPreconditionTest.kt
@@ -139,7 +139,8 @@ internal class BufferedObservingPreconditionTest {
             times(1)
         ).invalidateTestRun(anyString(), any())
 
-        // passing more changes is still possible
+        // passing more changes is still possible and does not block,
+        // but will trigger no processing
         exampleObserving.observeChange(mock<MdibChange.Metric>())
     }
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/BufferedObservingPreconditionTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/BufferedObservingPreconditionTest.kt
@@ -23,7 +23,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 
@@ -116,7 +115,6 @@ internal class BufferedObservingPreconditionTest {
     @Test
     internal fun `test processing thread dying invalidates test`() {
         val testRunObserver = mock<TestRunObserver>()
-        whenever(testRunObserver.isInvalid).thenReturn(false)
         val mockInjector = mock<Injector>()
         whenever(mockInjector.getInstance(TestRunObserver::class.java)).thenReturn(testRunObserver)
 


### PR DESCRIPTION
Use thread join before verifying the invalidation in BufferedObservingPreconditionTest
This ensures we wait for the call instead of randomly failing.

Closes #202.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [X] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [X] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [X] Pull Request Assignee
  * [x] Reviewer
