### PR TITLE
increase the response column length

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/mapping/ManipulationData.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/mapping/ManipulationData.java
@@ -11,11 +11,13 @@ import com.draeger.medical.t2iapi.ResponseTypes;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.annotations.GenericGenerator;
 
@@ -26,6 +28,9 @@ import org.hibernate.annotations.GenericGenerator;
 @Table(name = "manipulation_data")
 public class ManipulationData {
 
+    @Transient
+    private static final int MAXIMUM_LENGTH = 2147483647;
+
     @Id
     @GenericGenerator(name = "ManipulationDataIDGen", strategy = "increment")
     @GeneratedValue(generator = "ManipulationDataIDGen")
@@ -33,7 +38,10 @@ public class ManipulationData {
 
     private long startTimestamp;
     private long finishTimestamp;
+
+    @Column(columnDefinition = "clob", length = MAXIMUM_LENGTH)
     private String response;
+
     private ResponseTypes.Result result;
     private String methodName;
 


### PR DESCRIPTION
Increase the manipulation data response column length and fix the issue https://github.com/Draegerwerk/SDCcc/issues/187

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [x] Reviewer
