### PR TITLE
Fixed problem with Unit Tests invalidating the TestRun

### DIFF
--- a/sdccc/src/test/java/com/draeger/medical/sdccc/util/MessageStorageUtil.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/util/MessageStorageUtil.java
@@ -39,6 +39,7 @@ import org.somda.sdc.dpws.soap.TransportInfo;
 public class MessageStorageUtil {
     private static final String SECURE_HTTP_SCHEME = "https";
     private static final String INSECURE_HTTP_SCHEME = "http";
+    private static final String TEST_REMOTE_ADDR = "1.2.3.4";
 
     private final SoapMarshalling marshalling;
     private final MessageBuilder messageBuilder;
@@ -224,7 +225,7 @@ public class MessageStorageUtil {
 
         final CommunicationContext messageContext = new CommunicationContext(
                 new HttpApplicationInfo(httpHeaders, "", ""),
-                new TransportInfo(SECURE_HTTP_SCHEME, null, null, null, null, certificates),
+                new TransportInfo(SECURE_HTTP_SCHEME, null, null, TEST_REMOTE_ADDR, null, certificates),
                 null);
         addMessage(
                 storage,
@@ -259,7 +260,7 @@ public class MessageStorageUtil {
 
         final CommunicationContext messageContext = new CommunicationContext(
                 new HttpApplicationInfo(httpHeaders, "", ""),
-                new TransportInfo(SECURE_HTTP_SCHEME, null, null, null, null, certificates),
+                new TransportInfo(SECURE_HTTP_SCHEME, null, null, TEST_REMOTE_ADDR, null, certificates),
                 null);
         addMessage(
                 storage,
@@ -323,7 +324,12 @@ public class MessageStorageUtil {
         final CommunicationContext messageContext = new CommunicationContext(
                 new ApplicationInfo(),
                 new TransportInfo(
-                        DpwsConstants.URI_SCHEME_SOAP_OVER_UDP, null, null, null, null, Collections.emptyList()),
+                        DpwsConstants.URI_SCHEME_SOAP_OVER_UDP,
+                        null,
+                        null,
+                        TEST_REMOTE_ADDR,
+                        null,
+                        Collections.emptyList()),
                 null);
         addMessage(
                 storage,


### PR DESCRIPTION
Fixed problem with Unit Tests invalidating the Test Run because they violated the assumption that inbound message always have a sender address.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
