### PR TITLE
add rules disallowing direct calls to getDescriptor and getStates

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -217,7 +217,7 @@ public class ManipulationPreconditions {
 
         final Collection<MdibEntity> entities = mdibAccess.findEntitiesByType(AbstractDescriptor.class);
         for (MdibEntity entity : entities) {
-            if (entity.getDescriptor() instanceof MdsDescriptor) {
+            if (entity.getDescriptor(MdsDescriptor.class).isPresent()) {
                 continue; // we are not interested in MdsDescriptors as many Devices do not support modifying them.
             }
             final List<String> children = entity.getChildren();

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelContextStateTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelContextStateTest.java
@@ -86,11 +86,11 @@ public class InvariantParticipantModelContextStateTest extends InjectorTestBase 
 
                         for (MdibEntity patientContextEntity : patientContextEntities) {
 
-                            final var associatedPatients = patientContextEntity.getStates().stream()
-                                    .map(state -> (PatientContextState) state)
-                                    .filter(state -> ContextAssociation.ASSOC.equals(
-                                            ImpliedValueUtil.getContextAssociation(state)))
-                                    .toList();
+                            final var associatedPatients =
+                                    patientContextEntity.getStates(PatientContextState.class).stream()
+                                            .filter(state -> ContextAssociation.ASSOC.equals(
+                                                    ImpliedValueUtil.getContextAssociation(state)))
+                                            .toList();
 
                             if (!associatedPatients.isEmpty()) {
                                 final var associatedStateHandles = associatedPatients.stream()
@@ -171,11 +171,11 @@ public class InvariantParticipantModelContextStateTest extends InjectorTestBase 
 
                         for (MdibEntity locationContextEntity : locationContextEntities) {
 
-                            final var associatedLocations = locationContextEntity.getStates().stream()
-                                    .map(state -> (LocationContextState) state)
-                                    .filter(state -> ContextAssociation.ASSOC.equals(
-                                            ImpliedValueUtil.getContextAssociation(state)))
-                                    .toList();
+                            final var associatedLocations =
+                                    locationContextEntity.getStates(LocationContextState.class).stream()
+                                            .filter(state -> ContextAssociation.ASSOC.equals(
+                                                    ImpliedValueUtil.getContextAssociation(state)))
+                                            .toList();
 
                             if (!associatedLocations.isEmpty()) {
                                 final var associatedStateHandles = associatedLocations.stream()

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/invariant/InvariantNonFunctionalQualityAttributesTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/glue/invariant/InvariantNonFunctionalQualityAttributesTest.java
@@ -139,7 +139,8 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
 
                         for (var entity : entities) {
 
-                            if (entity.getDescriptor() instanceof RealTimeSampleArrayMetricDescriptor) {
+                            if (entity.getDescriptor(RealTimeSampleArrayMetricDescriptor.class)
+                                    .isPresent()) {
                                 final var metricValue = entity.getFirstState(RealTimeSampleArrayMetricState.class)
                                         .orElseThrow()
                                         .getMetricValue();
@@ -155,7 +156,8 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
                                                             + "even though it has a non-empty sample attribute.",
                                                     entity.getHandle()));
                                 }
-                            } else if (entity.getDescriptor() instanceof DistributionSampleArrayMetricDescriptor) {
+                            } else if (entity.getDescriptor(DistributionSampleArrayMetricDescriptor.class)
+                                    .isPresent()) {
                                 final var metricValue = entity.getFirstState(DistributionSampleArrayMetricState.class)
                                         .orElseThrow()
                                         .getMetricValue();
@@ -171,7 +173,8 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
                                                             + "even though it has a non-empty sample attribute.",
                                                     entity.getHandle()));
                                 }
-                            } else if (entity.getDescriptor() instanceof NumericMetricDescriptor) {
+                            } else if (entity.getDescriptor(NumericMetricDescriptor.class)
+                                    .isPresent()) {
                                 final var metricValue = entity.getFirstState(NumericMetricState.class)
                                         .orElseThrow()
                                         .getMetricValue();
@@ -186,7 +189,8 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
                                                             + "even though it has a non-empty value attribute.",
                                                     entity.getHandle()));
                                 }
-                            } else if (entity.getDescriptor() instanceof EnumStringMetricDescriptor) {
+                            } else if (entity.getDescriptor(EnumStringMetricDescriptor.class)
+                                    .isPresent()) {
                                 final var metricValue = entity.getFirstState(EnumStringMetricState.class)
                                         .orElseThrow()
                                         .getMetricValue();
@@ -201,7 +205,8 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
                                                             + "even though it has a non-empty value attribute.",
                                                     entity.getHandle()));
                                 }
-                            } else if (entity.getDescriptor() instanceof StringMetricDescriptor) {
+                            } else if (entity.getDescriptor(StringMetricDescriptor.class)
+                                    .isPresent()) {
                                 final var metricValue = entity.getFirstState(StringMetricState.class)
                                         .orElseThrow()
                                         .getMetricValue();
@@ -219,7 +224,7 @@ public class InvariantNonFunctionalQualityAttributesTest extends InjectorTestBas
                             } else {
                                 fail(String.format(
                                         "Object of type %s is not supported by the test.",
-                                        entity.getDescriptor().getClass()));
+                                        entity.getDescriptorClass()));
                             }
                         }
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/architecture/ArchitecturalRulesTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/architecture/ArchitecturalRulesTest.java
@@ -29,6 +29,7 @@ import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.somda.sdc.biceps.common.MdibEntity;
 import org.somda.sdc.biceps.model.message.AbstractReport;
 import org.somda.sdc.biceps.model.message.DescriptionModificationReport;
 import org.somda.sdc.biceps.model.message.ObservedValueStream;
@@ -292,6 +293,18 @@ public class ArchitecturalRulesTest {
             .accessTargetWhere(
                     target(owner(assignableTo(ImpliedValueUtil.class))).and(nameMatching("getStateDescriptorVersion")))
             .because("Initial implied value can not be reliable checked in direct tests");
+
+    @ArchTest
+    private static final ArchRule NO_CALLS_TO_GET_DESCRIPTOR = noClasses()
+            .should()
+            .callMethod(MdibEntity.class, "getDescriptor")
+            .because("Direct calls to getDescriptor are disallowed use getDescriptor(Class<T> var1).");
+
+    @ArchTest
+    private static final ArchRule NO_CALLS_TO_GET_STATES = noClasses()
+            .should()
+            .callMethod(MdibEntity.class, "getStates")
+            .because("Direct calls to getStates are disallowed use getStates(Class<T> var1) instead.");
 
     private static ArchRule checkImpliedValue(
             final String methodName, final Class<?> targetClass, final String reason) {


### PR DESCRIPTION
Add archunit rules that disallow calling getDescriptor and getStates directly. Replaces calls to these methods by their class-specific calls

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
