### PR TITLE
fix: update guice to 7.0.0

### DIFF
--- a/sdccc/pom.xml
+++ b/sdccc/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>5.0.1</version>
+            <version>7.0.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.tomlj/tomlj -->


### PR DESCRIPTION
sdc-ri has been using guice 7 for a while, now our outdated version stopped working with ri.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [X] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [X] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [X] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [X] Pull Request Assignee
  * [x] Reviewer
