### PR TITLE
Fix for the SequenceId ordering problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - support multiple mds for test case for BICEPS.R5042
 - inconsistent messaging in SDCcc logs ("No problems were found" and "Test run was invalid" one after another.)
 - incorrect behavior of the configuration option SDCcc.SummarizeMessageEncodingErrors
+- SequenceIds are now ordered by the timestamp of the first message that used them
 
 ### Removed
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/MessageStorage.java
@@ -1927,7 +1927,7 @@ public class MessageStorage implements AutoCloseable {
     private <T> Stream<T> getStreamForQuery(final Session session, final CriteriaQuery<T> criteriaQuery) {
         // The stream provided by Hibernate does not have the ORDERED characteristic.
         // We hence build our own.
-        ScrollableResultsImplementor scrollableResults =
+        final ScrollableResultsImplementor scrollableResults =
                 (ScrollableResultsImplementor) session.createQuery(criteriaQuery)
                         .setReadOnly(true)
                         .setCacheable(false)

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/ScrollableResultsIterator.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/ScrollableResultsIterator.java
@@ -13,7 +13,7 @@ import org.hibernate.query.spi.ScrollableResultsImplementor;
 class ScrollableResultsIterator<T> implements CloseableIterator<T> {
     private final ScrollableResultsImplementor scrollableResults;
 
-    ScrollableResultsIterator(ScrollableResultsImplementor scrollableResults) {
+    ScrollableResultsIterator(final ScrollableResultsImplementor scrollableResults) {
         this.scrollableResults = scrollableResults;
     }
 
@@ -30,7 +30,7 @@ class ScrollableResultsIterator<T> implements CloseableIterator<T> {
     @Override
     @SuppressWarnings("unchecked")
     public T next() {
-        Object[] next = scrollableResults.get();
+        final Object[] next = scrollableResults.get();
         if (next.length == 1) {
             return (T) next[0];
         } else {

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/ScrollableResultsIterator.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/ScrollableResultsIterator.java
@@ -1,0 +1,33 @@
+package com.draeger.medical.sdccc.messages;
+
+import org.hibernate.query.spi.CloseableIterator;
+import org.hibernate.query.spi.ScrollableResultsImplementor;
+
+class ScrollableResultsIterator<T> implements CloseableIterator<T> {
+    private final ScrollableResultsImplementor scrollableResults;
+
+    ScrollableResultsIterator(ScrollableResultsImplementor scrollableResults) {
+        this.scrollableResults = scrollableResults;
+    }
+
+    @Override
+    public void close() {
+        scrollableResults.close();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return !scrollableResults.isClosed() && scrollableResults.next();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T next() {
+        Object[] next = scrollableResults.get();
+        if (next.length == 1) {
+            return (T) next[0];
+        } else {
+            return (T) next;
+        }
+    }
+}

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/messages/ScrollableResultsIterator.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/messages/ScrollableResultsIterator.java
@@ -1,3 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the MIT License.
+ * Copyright (c) 2023-2024 Draegerwerk AG & Co. KGaA.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 package com.draeger.medical.sdccc.messages;
 
 import org.hibernate.query.spi.CloseableIterator;

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
@@ -340,17 +340,22 @@ public class TestMessageStorage {
         }
     }
 
-    private static @NotNull CommunicationContext getCommunicationContext(ListMultimap<String, String> multimap) throws CertificateException, IOException {
+    private static @NotNull CommunicationContext getCommunicationContext(final ListMultimap<String, String> multimap)
+            throws CertificateException, IOException {
         final String transactionId = "transactionId";
         final String requestUri = "requestUri";
 
         final X509Certificate certificate = CertificateUtil.getDummyCert();
-        final CommunicationContext headerContext = new CommunicationContext(
+        return new CommunicationContext(
                 new HttpApplicationInfo(multimap, transactionId, requestUri),
                 new TransportInfo(
-                        Constants.HTTPS_SCHEME, null, null, null, null, Collections.singletonList(certificate)),
+                        Constants.HTTPS_SCHEME,
+                        null,
+                        null,
+                        null,
+                        null,
+                        Collections.singletonList(certificate)),
                 null);
-        return headerContext;
     }
 
     /**

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/messages/TestMessageStorage.java
@@ -328,13 +328,11 @@ public class TestMessageStorage {
             messageStorage.flush();
 
             try (final Stream<String> sequenceIdStream = messageStorage.getUniqueSequenceIds()) {
-                assertEquals(
-                        List.of("urn:uuid:3", "urn:uuid:2", "urn:uuid:1"),
-                        sequenceIdStream.toList());
+                assertEquals(List.of("urn:uuid:3", "urn:uuid:2", "urn:uuid:1"), sequenceIdStream.toList());
             }
 
             try (final MessageStorage.GetterResult<MessageContent> inboundMessages =
-                         messageStorage.getInboundMessages()) {
+                    messageStorage.getInboundMessages()) {
                 assertEquals(3, inboundMessages.getStream().count());
             }
         }
@@ -349,12 +347,7 @@ public class TestMessageStorage {
         return new CommunicationContext(
                 new HttpApplicationInfo(multimap, transactionId, requestUri),
                 new TransportInfo(
-                        Constants.HTTPS_SCHEME,
-                        null,
-                        null,
-                        null,
-                        null,
-                        Collections.singletonList(certificate)),
+                        Constants.HTTPS_SCHEME, null, null, null, null, Collections.singletonList(certificate)),
                 null);
     }
 


### PR DESCRIPTION
Currently the Database orders SequenceIds lexicographically, which
- is questionable as the SDC standards do not define any ordering upon SequenceIds, and
- may cause the behaviour of certain invariant test cases to change depending on which SequenceIds are used.

This Fix ensures that the SequenceIds retrieved from the Database are ordered by the timestamp of the first message that they were used in, making the order (and hence the behaviour of the invariant test cases) independent of the used SequenceIds.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [ ] Reviewer (maximilianpilz)
  * [ ] Reviewer (midttuna)
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [ ] Reviewer (maximilianpilz)
  * [ ] Reviewer (midttuna)
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer (maximilianpilz)
  * [ ] Reviewer (midttuna)
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer (maximilianpilz)
  * [ ] Reviewer (midttuna)
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer (maximilianpilz)
  * [ ] Reviewer (midttuna)
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [ ] Reviewer (maximilianpilz)
  * [ ] Reviewer (midttuna)
