### PR TITLE
Unit test for TriggerOnErrorOrWorseLogAppender

### DIFF
--- a/sdccc/src/test/java/com/draeger/medical/sdccc/util/TriggerOnErrorOrWorseLogAppenderTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/util/TriggerOnErrorOrWorseLogAppenderTest.java
@@ -1,0 +1,78 @@
+/*
+ * This Source Code Form is subject to the terms of the MIT License.
+ * Copyright (c) 2023 Draegerwerk AG & Co. KGaA.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.draeger.medical.sdccc.util;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@linkplain TriggerOnErrorOrWorseLogAppender}
+ */
+public class TriggerOnErrorOrWorseLogAppenderTest {
+
+    @Test
+    public void testAppendWithDifferentLogLevels() {
+        testAppend(Level.ALL, false);
+        testAppend(Level.TRACE, false);
+        testAppend(Level.DEBUG, false);
+        testAppend(Level.INFO, false);
+        testAppend(Level.WARN, false);
+        testAppend(Level.ERROR, true);
+        testAppend(Level.FATAL, true);
+        testAppend(Level.OFF, true);
+    }
+
+    public void testAppend(Level level, boolean expectHandlerCall) {
+
+        AtomicBoolean flag = new AtomicBoolean(false);
+
+        // given
+        TriggerOnErrorOrWorseLogAppender classUnderTest = new TriggerOnErrorOrWorseLogAppender("log", null);
+        classUnderTest.setOnErrorOrWorseHandler(new TriggerOnErrorOrWorseLogAppender.OnErrorOrWorseHandler() {
+            @Override
+            public void onErrorOrWorse(LogEvent event) {
+                flag.set(true);
+            }
+        });
+        LogEvent event = mock(LogEvent.class);
+        when(event.getLevel()).thenReturn(level);
+
+        // when
+        classUnderTest.append(event);
+
+        // then
+        if (expectHandlerCall) {
+            assertTrue(flag.get());
+        } else {
+            assertFalse(flag.get());
+        }
+    }
+
+}

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/util/TriggerOnErrorOrWorseLogAppenderTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/util/TriggerOnErrorOrWorseLogAppenderTest.java
@@ -8,28 +8,15 @@
 package com.draeger.medical.sdccc.util;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -54,7 +41,9 @@ public class TriggerOnErrorOrWorseLogAppenderTest {
         AtomicBoolean flag = new AtomicBoolean(false);
 
         // given
-        TriggerOnErrorOrWorseLogAppender classUnderTest = new TriggerOnErrorOrWorseLogAppender("log", null);
+        Filter filter = mock(Filter.class);
+        TriggerOnErrorOrWorseLogAppender classUnderTest = new TriggerOnErrorOrWorseLogAppender("log",
+                filter);
         classUnderTest.setOnErrorOrWorseHandler(new TriggerOnErrorOrWorseLogAppender.OnErrorOrWorseHandler() {
             @Override
             public void onErrorOrWorse(LogEvent event) {

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/util/TriggerOnErrorOrWorseLogAppenderTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/util/TriggerOnErrorOrWorseLogAppenderTest.java
@@ -44,12 +44,7 @@ public class TriggerOnErrorOrWorseLogAppenderTest {
         Filter filter = mock(Filter.class);
         TriggerOnErrorOrWorseLogAppender classUnderTest = new TriggerOnErrorOrWorseLogAppender("log",
                 filter);
-        classUnderTest.setOnErrorOrWorseHandler(new TriggerOnErrorOrWorseLogAppender.OnErrorOrWorseHandler() {
-            @Override
-            public void onErrorOrWorse(LogEvent event) {
-                flag.set(true);
-            }
-        });
+        classUnderTest.setOnErrorOrWorseHandler((LogEvent event) -> flag.set(true));
         LogEvent event = mock(LogEvent.class);
         when(event.getLevel()).thenReturn(level);
 


### PR DESCRIPTION
Added a Unit Test for the TriggerOnErrorOrWorseLogAppender.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
