### PR TITLE
add parameter MinCollectDataTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preconditions which observe mdib changes during the test run
 - storing of IP addresses of inbound messages in the database
 - a command line parameter to not create subdirectories in the test run directory
+- add config parameter to set the minimum amount of time the test tool is supposed to collect data
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ in high numbers. When this option is set to true, then the errors will not be di
 at the end. When the option is set to false, then the individual errors are displayed, which is useful for fixing
 these problems.
 
+```
+[SDCcc] 
+MinCollectDataTime=10
+```
+
+MinCollectDataTime defaults to 10 seconds and allows the user to control minimum amount of time in seconds the 
+test tool is supposed to collect data.
+
 ### Test parameter configuration
 
 Some test cases require individual parameters that can be overwritten in the *test_parameter.toml* file.

--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -4,6 +4,7 @@ GraphicalPopups=true
 TestExecutionLogging=true
 EnableMessageEncodingCheck=true
 SummarizeMessageEncodingErrors=true
+MinCollectDataTime=20
 
 [SDCcc.TLS]
 FileDirectory="./configuration"

--- a/configuration/config.toml
+++ b/configuration/config.toml
@@ -4,7 +4,7 @@ GraphicalPopups=true
 TestExecutionLogging=true
 EnableMessageEncodingCheck=true
 SummarizeMessageEncodingErrors=true
-MinCollectDataTime=20
+MinCollectDataTime=10
 
 [SDCcc.TLS]
 FileDirectory="./configuration"

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/TestSuite.java
@@ -104,6 +104,7 @@ public class TestSuite {
 
     private final Injector injector;
     private final String[] sdcTestDirectories;
+    private final Duration minCollectDataTime;
     private final File testRunDir;
     private final TestRunObserver testRunObserver;
     private final MessageGeneratingUtil messageGenerator;
@@ -118,6 +119,7 @@ public class TestSuite {
      * @param injector             a reference to the injector injecting here
      * @param testRunObserver      observer for invalidating test runs
      * @param sdcTestDirectories   directories to search for test cases
+     * @param minCollectDataTime   minimum amount of time to collect data
      * @param testRunDir           directory to run the tests in and store artifacts
      * @param testExecutionLogging whether logging of test case starts etc. shall be done
      * @param messageGenerator     utility for generating messages to send
@@ -129,6 +131,7 @@ public class TestSuite {
             final Injector injector,
             final TestRunObserver testRunObserver,
             @Named(TestSuiteConfig.SDC_TEST_DIRECTORIES) final String[] sdcTestDirectories,
+            @Named(TestSuiteConfig.MIN_COLLECT_DATA_TIME) final long minCollectDataTime,
             @Named(TestRunConfig.TEST_RUN_DIR) final File testRunDir,
             @Named(TestSuiteConfig.TEST_EXECUTION_LOGGING) final boolean testExecutionLogging,
             final MessageGeneratingUtil messageGenerator,
@@ -137,6 +140,7 @@ public class TestSuite {
         this.injector = injector;
         this.sdcTestDirectories = sdcTestDirectories;
         this.testRunObserver = testRunObserver;
+        this.minCollectDataTime = Duration.ofSeconds(minCollectDataTime);
         this.testRunDir = testRunDir;
         this.messageGenerator = messageGenerator;
         this.testRunInformation = testRunInformation;
@@ -284,8 +288,9 @@ public class TestSuite {
     private void phase1() {
         performBasicMessagingCheck();
 
+        LOG.info("Waiting for {} to collect data.", this.minCollectDataTime);
         try {
-            Thread.sleep(TIME_BETWEEN_PHASES);
+            Thread.sleep(this.minCollectDataTime.toMillis());
         } catch (final InterruptedException e) {
             LOG.error("", e);
         }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/DefaultTestSuiteConfig.java
@@ -50,6 +50,7 @@ public class DefaultTestSuiteConfig extends AbstractConfigurationModule {
 
         bind(TestSuiteConfig.ENABLE_MESSAGE_ENCODING_CHECK, Boolean.class, true);
         bind(TestSuiteConfig.SUMMARIZE_MESSAGE_ENCODING_ERRORS, Boolean.class, true);
+        bind(TestSuiteConfig.MIN_COLLECT_DATA_TIME, long.class, 10L);
         bind(Constants.CONFIGURATION_MODULE, AbstractConfigurationModule.class, new AbstractConfigurationModule() {
             @Override
             protected void defaultConfigure() {}

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/configuration/TestSuiteConfig.java
@@ -25,7 +25,7 @@ public final class TestSuiteConfig {
     public static final String TEST_EXECUTION_LOGGING = SDCCC + "TestExecutionLogging";
     public static final String SUMMARIZE_MESSAGE_ENCODING_ERRORS = SDCCC + "SummarizeMessageEncodingErrors";
     public static final String ENABLE_MESSAGE_ENCODING_CHECK = SDCCC + "EnableMessageEncodingCheck";
-
+    public static final String MIN_COLLECT_DATA_TIME = SDCCC + "MinCollectDataTime";
     /*
      * TLS configuration
      */


### PR DESCRIPTION
Add config parameter to set the minimum amount of time the test tool is supposed to collect data.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
