### PR TITLE
fix: changed biceps:R5003 test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - inconsistent messaging in SDCcc logs ("No problems were found" and "Test run was invalid" one after another.)
 - incorrect behavior of the configuration option SDCcc.SummarizeMessageEncodingErrors
 - SequenceIds are now ordered by the timestamp of the first message that used them
-- test for BICEPS.R5003 does not check MdDescription and MdStateVersion anymore
+- test for BICEPS.R5003 does not check MdDescriptionVersion and MdStateVersion anymore (see [PR 232](https://github.com/Draegerwerk/SDCcc/pull/232))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - inconsistent messaging in SDCcc logs ("No problems were found" and "Test run was invalid" one after another.)
 - incorrect behavior of the configuration option SDCcc.SummarizeMessageEncodingErrors
 - SequenceIds are now ordered by the timestamp of the first message that used them
+- test for BICEPS.R5003 does not check MdDescription and MdStateVersion anymore
 
 ### Removed
 

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTest.java
@@ -337,8 +337,6 @@ public class InvariantParticipantModelVersioningTest extends InjectorTestBase {
                 final var impliedValueMap = new InitialImpliedValue();
                 final var previousDescriptorVersionMap = new HashMap<String, BigInteger>();
                 final var previousStateVersionMap = new HashMap<String, BigInteger>();
-                var previousMdDescriptionVersion = BigInteger.valueOf(-1);
-                var previousMdStateVersion = BigInteger.valueOf(-1);
                 var previousMdibVersion = BigInteger.valueOf(-1);
 
                 try (final MdibHistorian.HistorianResult history =
@@ -388,32 +386,11 @@ public class InvariantParticipantModelVersioningTest extends InjectorTestBase {
                             previousStateVersionMap.put(stateHandle, currentStateVersion);
                             stateVersionsSeen.incrementAndGet();
                         }
-                        final var currentMdDescriptionVersion =
-                                ImpliedValueUtil.getMdibAccessDescriptionVersion(current);
-                        final var currentMdStateVersion = ImpliedValueUtil.getMdibAccessMdStateVersion(current);
-                        assertTrue(
-                                isNotDecrementedVersion(previousMdDescriptionVersion, currentMdDescriptionVersion),
-                                String.format(
-                                        DECREMENTED_VERSION_ERROR_MESSAGE,
-                                        "MdDescription",
-                                        currentMdibVersion,
-                                        previousMdDescriptionVersion,
-                                        currentMdDescriptionVersion));
-                        assertTrue(
-                                isNotDecrementedVersion(previousMdStateVersion, currentMdStateVersion),
-                                String.format(
-                                        DECREMENTED_VERSION_ERROR_MESSAGE,
-                                        "MdState",
-                                        currentMdibVersion,
-                                        previousMdStateVersion,
-                                        currentMdStateVersion));
                         assertTrue(
                                 isNotDecrementedVersion(previousMdibVersion, currentMdibVersion),
                                 String.format(
                                         "The mdib version has been decremented. It was %s and is now %s.",
                                         previousMdibVersion, currentMdibVersion));
-                        previousMdDescriptionVersion = currentMdDescriptionVersion;
-                        previousMdStateVersion = currentMdStateVersion;
                         previousMdibVersion = currentMdibVersion;
                         current = history.next();
                     }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ImpliedValueUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ImpliedValueUtil.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
 import javax.annotation.Nullable;
-import org.somda.sdc.biceps.common.access.MdibAccess;
 import org.somda.sdc.biceps.model.message.AbstractReport;
 import org.somda.sdc.biceps.model.message.DescriptionModificationReport;
 import org.somda.sdc.biceps.model.message.DescriptionModificationType;

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ImpliedValueUtil.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/ImpliedValueUtil.java
@@ -374,17 +374,6 @@ public final class ImpliedValueUtil {
     }
 
     /**
-     * Retrieves the description version of mdib access or the implied value.
-     *
-     * @param mdibAccess to retrieve the description version from
-     * @return the description version
-     */
-    public static BigInteger getMdibAccessDescriptionVersion(final MdibAccess mdibAccess) {
-        final var descriptionVersion = mdibAccess.getMdDescriptionVersion();
-        return descriptionVersion != null ? descriptionVersion : BigInteger.ZERO;
-    }
-
-    /**
      * Retrieves the language of an mds state or the implied value.
      *
      * @param mdsState to retrieve the language from
@@ -418,17 +407,6 @@ public final class ImpliedValueUtil {
             return stateVersion != null ? stateVersion : BigInteger.ZERO;
         }
         return BigInteger.ZERO;
-    }
-
-    /**
-     * Retrieves the md state version of mdib access or the implied value.
-     *
-     * @param mdibAccess to retrieve the state version from
-     * @return the state version
-     */
-    public static BigInteger getMdibAccessMdStateVersion(final MdibAccess mdibAccess) {
-        final var stateVersion = mdibAccess.getMdStateVersion();
-        return stateVersion != null ? stateVersion : BigInteger.ZERO;
     }
 
     /**

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTestTest.java
@@ -1194,6 +1194,29 @@ public class InvariantParticipantModelVersioningTestTest {
     }
 
     /**
+     * The old implementation of the test also checked the MdDescriptionVersion and MdStateVersion, although changes to
+     * these values are not visible via reports. The check for these versions were removed and this test is intended
+     * to ensure, that MdDescriptionVersion and MdStateVersion does not affect the test result.
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void testRequirementR5003TestMdDescriptionVersionAndMdStateVersion() throws Exception {
+        final var initial = buildMdib(null, BigInteger.valueOf(8));
+        final var firstUpdate = buildDescriptionModificationReportWithParts(
+                SEQUENCE_ID,
+                BigInteger.valueOf(74),
+                buildDescriptionModificationReportPart(
+                        DescriptionModificationType.UPT,
+                        buildVmd(VMD_HANDLE, BigInteger.ONE, BigInteger.ONE),
+                        buildChannel(CHANNEL_HANDLE, BigInteger.ONE, BigInteger.ONE)));
+
+        messageStorageUtil.addInboundSecureHttpMessage(storage, initial);
+        messageStorageUtil.addInboundSecureHttpMessage(storage, firstUpdate);
+        assertDoesNotThrow(testClass::testRequirementR5003);
+    }
+
+    /**
      * Tests whether versions which are only incremented causes the test to pass.
      *
      * @throws Exception on any exception

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/invariant/InvariantParticipantModelVersioningTestTest.java
@@ -1211,8 +1211,7 @@ public class InvariantParticipantModelVersioningTestTest {
      * </p>
      *
      * @param mdDescriptionVersion the MdDescriptionVersion to set
-     * @param mdStateVersion the MdStateVersion to set
-     *
+     * @param mdStateVersion       the MdStateVersion to set
      * @throws Exception on any exception
      */
     @ParameterizedTest
@@ -1220,8 +1219,8 @@ public class InvariantParticipantModelVersioningTestTest {
     public void testRequirementR5003TestMdDescriptionVersionAndMdStateVersion(
             final @Nullable BigInteger mdDescriptionVersion, final @Nullable BigInteger mdStateVersion)
             throws Exception {
-        final var initial = buildMdibWithMdDescriptionAndStateVersion(
-                MdibBuilder.DEFAULT_SEQUENCE_ID, mdDescriptionVersion, mdStateVersion);
+        final var initial =
+                buildMdibWithMdDescriptionAndStateVersion(SEQUENCE_ID, mdDescriptionVersion, mdStateVersion);
         final var firstUpdate = buildDescriptionModificationReportWithParts(
                 SEQUENCE_ID,
                 BigInteger.valueOf(74),
@@ -1633,7 +1632,7 @@ public class InvariantParticipantModelVersioningTestTest {
     }
 
     Envelope buildMdib(final @Nullable BigInteger vmdVersion, final @Nullable BigInteger mdsVersion) {
-        return buildMdib(MdibBuilder.DEFAULT_SEQUENCE_ID, vmdVersion, mdsVersion);
+        return buildMdib(SEQUENCE_ID, vmdVersion, mdsVersion);
     }
 
     /*


### PR DESCRIPTION
In the mdib representation on the consumer side in sdc-ri, when processing description modifications, the values
for the MdDescriptionVersion and MdStateVersion are set to the implied value if the description modification
does not contain any values for them. This is the case if the versions are missing in the GetMdibResponse,
or generally for DescriptionModificationReports. If the MdDescriptionVersion or MdStateVersion in the
GetMdibResponse is set to a value other than the implied value, they would be set to the implied value again in the next
DescriptionModificationReport, which would cause the test to fail. As the actual values are not communicated via
reports, the check of the MdDescriptionVersion and MdStateVersion has been removed from the test implementation.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
