### PR TITLE
detekt dependson testclasses

### DIFF
--- a/build-logic/src/main/kotlin/com.draeger.medical.kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/com.draeger.medical.kotlin-conventions.gradle.kts
@@ -27,7 +27,7 @@ data class LazyToStringFileCollection(private val fileCollection: FileCollection
 }
 
 val detektTask = tasks.register<JavaExec>("detekt") {
-    dependsOn("testClasses")
+    dependsOn("testClasses", "assemble")
     mainClass.set("io.gitlab.arturbosch.detekt.cli.Main")
     classpath = detekt
 

--- a/build-logic/src/main/kotlin/com.draeger.medical.kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/com.draeger.medical.kotlin-conventions.gradle.kts
@@ -27,7 +27,7 @@ data class LazyToStringFileCollection(private val fileCollection: FileCollection
 }
 
 val detektTask = tasks.register<JavaExec>("detekt") {
-    dependsOn("testClasses", "assemble")
+    dependsOn("testClasses")
     mainClass.set("io.gitlab.arturbosch.detekt.cli.Main")
     classpath = detekt
 

--- a/build-logic/src/main/kotlin/com.draeger.medical.kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/com.draeger.medical.kotlin-conventions.gradle.kts
@@ -27,7 +27,7 @@ data class LazyToStringFileCollection(private val fileCollection: FileCollection
 }
 
 val detektTask = tasks.register<JavaExec>("detekt") {
-    dependsOn("assemble")
+    dependsOn("testClasses")
     mainClass.set("io.gitlab.arturbosch.detekt.cli.Main")
     classpath = detekt
 


### PR DESCRIPTION
Make Detekt depend on testClasses task not on assemble

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
