### PR TITLE
Feature to unmarshall SOAP messages with casting to a configurable class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - a command line parameter to not create subdirectories in the test run directory
 - a command line parameter to print the version of the sdccc test tool
 - add config parameter to set the minimum amount of time the test tool is supposed to collect data
-
+- unmarshal SOAP messages with casting to a configurable class
+- 
 ### Changed
 
 - the SoapMarshalling is now configurable regarding packages to scan for JAXB classes and the schemas for validation 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshalling.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshalling.java
@@ -152,15 +152,17 @@ public class SoapMarshalling {
         if (schema != null) {
             unmarshaller.setSchema(schema);
         }
-        final Object obj = unmarshaller.unmarshal(inputStream);
+        final Object unmarshalledObject = unmarshaller.unmarshal(inputStream);
 
-        if (obj instanceof JAXBElement) {
-            final Object castedElement = ((JAXBElement<?>) obj).getValue();
-            if (clazz.isInstance(castedElement)) {
-                return clazz.cast(castedElement);
-            }
+        final Object obj = (unmarshalledObject instanceof JAXBElement)
+                ? ((JAXBElement<?>) unmarshalledObject).getValue()
+                : unmarshalledObject;
+
+        if (!clazz.isInstance(obj)) {
+            throw new ClassCastException("Unmarshalled object is not of type " + clazz.getName() + ". Found: "
+                    + obj.getClass().getName());
         }
-        throw new ClassCastException("Unmarshalled object is not an instance of Envelope");
+        return clazz.cast(obj);
     }
 
     private Schema generateTopLevelSchema(final String schemaPath)

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshalling.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshalling.java
@@ -130,14 +130,35 @@ public class SoapMarshalling {
      *
      * @param inputStream the inputStream to unmarshal
      * @return an Envelope created from the inputstream
-     * @throws JAXBException if marshalling fails
+     * @throws JAXBException      if marshalling fails
+     * @throws ClassCastException if casting to Envelope fails
      */
     public Envelope unmarshal(final InputStream inputStream) throws JAXBException {
+        return unmarshalToGeneric(inputStream, Envelope.class);
+    }
+
+    /**
+     * Takes an InputStream and unmarshals it.
+     *
+     * @param inputStream the inputStream to unmarshal
+     * @param clazz       the class to cast the unmarshalled object to
+     * @param <T>         the type of the class
+     * @return an object of the give class, created from the input stream
+     * @throws JAXBException      if marshalling fails
+     * @throws ClassCastException if casting fails
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T unmarshalToGeneric(final InputStream inputStream, final Class<T> clazz) throws JAXBException {
         final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
         if (schema != null) {
             unmarshaller.setSchema(schema);
         }
-        return ((JAXBElement<Envelope>) (unmarshaller.unmarshal(inputStream))).getValue();
+        try {
+            return ((JAXBElement<T>) unmarshaller.unmarshal(inputStream)).getValue();
+        } catch (final ClassCastException e) {
+            LOG.error("Could not cast unmarshalled object to {}", clazz.getSimpleName(), e);
+            throw e;
+        }
     }
 
     private Schema generateTopLevelSchema(final String schemaPath)

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshalling.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshalling.java
@@ -157,7 +157,8 @@ public class SoapMarshalling {
         if (obj instanceof JAXBElement) {
             final Object castedElement = ((JAXBElement<?>) obj).getValue();
             if (clazz.isInstance(castedElement)) {
-                return clazz.cast(castedElement); }
+                return clazz.cast(castedElement);
+            }
         }
         throw new ClassCastException("Unmarshalled object is not an instance of Envelope");
     }

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshalling.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshalling.java
@@ -130,7 +130,7 @@ public class SoapMarshalling {
      *
      * @param inputStream the inputStream to unmarshal
      * @return an Envelope created from the inputstream
-     * @throws JAXBException      if marshalling fails
+     * @throws JAXBException      if unmarshalling fails
      * @throws ClassCastException if casting to Envelope fails
      */
     public Envelope unmarshal(final InputStream inputStream) throws JAXBException {
@@ -144,21 +144,22 @@ public class SoapMarshalling {
      * @param clazz       the class to cast the unmarshalled object to
      * @param <T>         the type of the class
      * @return an object of the give class, created from the input stream
-     * @throws JAXBException      if marshalling fails
+     * @throws JAXBException      if unmarshalling fails
      * @throws ClassCastException if casting fails
      */
-    @SuppressWarnings("unchecked")
     public <T> T unmarshalToGeneric(final InputStream inputStream, final Class<T> clazz) throws JAXBException {
         final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
         if (schema != null) {
             unmarshaller.setSchema(schema);
         }
-        try {
-            return ((JAXBElement<T>) unmarshaller.unmarshal(inputStream)).getValue();
-        } catch (final ClassCastException e) {
-            LOG.error("Could not cast unmarshalled object to {}", clazz.getSimpleName(), e);
-            throw e;
+        final Object obj = unmarshaller.unmarshal(inputStream);
+
+        if (obj instanceof JAXBElement) {
+            final Object castedElement = ((JAXBElement<?>) obj).getValue();
+            if (clazz.isInstance(castedElement)) {
+                return clazz.cast(castedElement); }
         }
+        throw new ClassCastException("Unmarshalled object is not an instance of Envelope");
     }
 
     private Schema generateTopLevelSchema(final String schemaPath)

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshallingTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshallingTest.kt
@@ -39,11 +39,7 @@ class SoapMarshallingTest {
 
         val unmarshaledEnvelope = soapMarshaller.unmarshal(rawEnvelope)
 
-        assertEquals(
-            Envelope::class.java,
-            unmarshaledEnvelope::class.java,
-            "The unmarshalled data is not of the expected type."
-        )
+        assertEquals(Envelope::class.java, unmarshaledEnvelope::class.java, ERROR_MESSAGE)
     }
 
     /**
@@ -59,11 +55,7 @@ class SoapMarshallingTest {
 
         val unmarshaledExtension = soapMarshaller.unmarshalToGeneric(xml.byteInputStream(), ExtensionType::class.java)
 
-        assertEquals(
-            ExtensionType::class.java,
-            unmarshaledExtension::class.java,
-            "The unmarshalled data is not of the expected type."
-        )
+        assertEquals(ExtensionType::class.java, unmarshaledExtension::class.java, ERROR_MESSAGE)
 
         assertEquals(1, unmarshaledExtension.any.size, "The unmarshalled data is not present.")
 
@@ -103,17 +95,18 @@ class SoapMarshallingTest {
 
         val unmarshaledExtension = soapMarshaller.unmarshalToGeneric(xml.byteInputStream(), GetMdibResponse::class.java)
 
-        assertEquals(
-            GetMdibResponse::class.java,
-            unmarshaledExtension::class.java,
-            "The unmarshalled data is not of the expected type."
-        )
+        assertEquals(GetMdibResponse::class.java, unmarshaledExtension::class.java, ERROR_MESSAGE)
     }
 
     companion object {
         /**
-         * Error message for failed assertions.
+         * Number of expected assertions in unmarshalled element.
          */
         const val EXPECTED_NUMBER_ATTRIBUTES = 3
+
+        /**
+         * Error message for failed assertions.
+         */
+        const val ERROR_MESSAGE = "The unmarshalled data is not of the expected type."
     }
 }

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshallingTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshallingTest.kt
@@ -1,0 +1,94 @@
+/*
+ * This Source Code Form is subject to the terms of the MIT License.
+ * Copyright (c) 2025 Draegerwerk AG & Co. KGaA.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.draeger.medical.sdccc.marshalling
+
+import com.draeger.medical.biceps.model.extension.ExtensionType
+import com.draeger.medical.dpws.soap.model.Envelope
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.w3c.dom.Element
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+/**
+ * Unit tests for the soap marshalling.
+ */
+class SoapMarshallingTest {
+    private lateinit var soapMarshaller: SoapMarshalling
+
+    @BeforeEach
+    fun setup() {
+        val marshallingInjector = MarshallingUtil.createMarshallingTestInjector(true)
+        soapMarshaller = marshallingInjector.getInstance(SoapMarshalling::class.java)
+    }
+
+    /**
+     * Test the unmarshalling with Envelop return type.
+     */
+    @Test
+    fun testUnmarshal() {
+        val rawEnvelope = SoapMarshallingTest::class.java.getResourceAsStream("SoapMarshallingTestData.xml")
+        assertNotNull(rawEnvelope, "The test data is not present.")
+
+        val unmarshaledExtension = soapMarshaller.unmarshal(rawEnvelope)
+
+        assertEquals(
+            Envelope::class.java,
+            unmarshaledExtension::class.java,
+            "The unmarshalled data is not of the expected type."
+        )
+    }
+
+    /**
+     * Test the unmarshalling with generic return type.
+     */
+    @Test
+    fun testUnmarshalToGeneric() {
+        val xml = """
+            <ns1:Extension xmlns:ns1="http://standards.ieee.org/downloads/11073/11073-10207-2017/extension">
+            <ns2:MyExt xmlns:ns2="http://biceps.extension" ns1:MustUnderstand="true">Youwillnotunderstandthis</ns2:MyExt>
+            </ns1:Extension>
+        """.trimIndent()
+
+        val unmarshaledExtension = soapMarshaller.unmarshalToGeneric(xml.byteInputStream(), ExtensionType::class.java)
+
+        assertEquals(
+            ExtensionType::class.java,
+            unmarshaledExtension::class.java,
+            "The unmarshaled data is not of the expected type."
+        )
+
+        assertEquals(1, unmarshaledExtension.any.size, "The unmarshaled data is not present.")
+
+        val myExt = unmarshaledExtension.any[0]
+        assertIs<Element>(myExt)
+
+        assertEquals("http://biceps.extension", myExt.namespaceURI, "namespaceURI is not as expected.")
+        assertEquals("MyExt", myExt.localName, "localName is not as expected.")
+        assertEquals(EXPECTED_NUMBER_ATTRIBUTES, myExt.attributes.length, "attributes length is not as expected.")
+
+        val mustUndertand = myExt.attributes.getNamedItemNS(
+            "http://standards.ieee.org/downloads/11073/11073-10207-2017/extension",
+            "MustUnderstand"
+        )
+        assertEquals("true", mustUndertand.nodeValue, "value of attribute MustUnderstand is not as expected.")
+        assertEquals(
+            "Youwillnotunderstandthis",
+            (myExt.firstChild ?: error("The child element is not expected to be null")).nodeValue,
+            "The text of the extension element is not as expected."
+        )
+    }
+
+    companion object {
+        /**
+         * Error message for failed assertions.
+         */
+        const val EXPECTED_NUMBER_ATTRIBUTES = 3
+    }
+}

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshallingTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshallingTest.kt
@@ -36,11 +36,11 @@ class SoapMarshallingTest {
         val rawEnvelope = SoapMarshallingTest::class.java.getResourceAsStream("SoapMarshallingTestData.xml")
         assertNotNull(rawEnvelope, "The test data is not present.")
 
-        val unmarshaledExtension = soapMarshaller.unmarshal(rawEnvelope)
+        val unmarshaledEnvelope = soapMarshaller.unmarshal(rawEnvelope)
 
         assertEquals(
             Envelope::class.java,
-            unmarshaledExtension::class.java,
+            unmarshaledEnvelope::class.java,
             "The unmarshalled data is not of the expected type."
         )
     }
@@ -77,6 +77,7 @@ class SoapMarshallingTest {
             "http://standards.ieee.org/downloads/11073/11073-10207-2017/extension",
             "MustUnderstand"
         )
+        assertNotNull(mustUndertand, "The attribute MustUnderstand is not present.")
         assertEquals("true", mustUndertand.nodeValue, "value of attribute MustUnderstand is not as expected.")
         assertEquals(
             "Youwillnotunderstandthis",

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshallingTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshallingTest.kt
@@ -8,6 +8,7 @@
 package com.draeger.medical.sdccc.marshalling
 
 import com.draeger.medical.biceps.model.extension.ExtensionType
+import com.draeger.medical.biceps.model.message.GetMdibResponse
 import com.draeger.medical.dpws.soap.model.Envelope
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -46,13 +47,13 @@ class SoapMarshallingTest {
     }
 
     /**
-     * Test the unmarshalling with generic return type.
+     * Test the unmarshalling with generic return type - ExtensionType is not a registered class.
      */
     @Test
-    fun testUnmarshalToGeneric() {
+    fun testUnmarshalToGenericExtensionType() {
         val xml = """
             <ns1:Extension xmlns:ns1="http://standards.ieee.org/downloads/11073/11073-10207-2017/extension">
-            <ns2:MyExt xmlns:ns2="http://biceps.extension" ns1:MustUnderstand="true">Youwillnotunderstandthis</ns2:MyExt>
+            <ns2:MyExt xmlns:ns2="http://biceps.extension" ns1:MustUnderstand="true">Youwillnotunderstand</ns2:MyExt>
             </ns1:Extension>
         """.trimIndent()
 
@@ -61,10 +62,10 @@ class SoapMarshallingTest {
         assertEquals(
             ExtensionType::class.java,
             unmarshaledExtension::class.java,
-            "The unmarshaled data is not of the expected type."
+            "The unmarshalled data is not of the expected type."
         )
 
-        assertEquals(1, unmarshaledExtension.any.size, "The unmarshaled data is not present.")
+        assertEquals(1, unmarshaledExtension.any.size, "The unmarshalled data is not present.")
 
         val myExt = unmarshaledExtension.any[0]
         assertIs<Element>(myExt)
@@ -80,9 +81,32 @@ class SoapMarshallingTest {
         assertNotNull(mustUndertand, "The attribute MustUnderstand is not present.")
         assertEquals("true", mustUndertand.nodeValue, "value of attribute MustUnderstand is not as expected.")
         assertEquals(
-            "Youwillnotunderstandthis",
+            "Youwillnotunderstand",
             (myExt.firstChild ?: error("The child element is not expected to be null")).nodeValue,
             "The text of the extension element is not as expected."
+        )
+    }
+
+    /**
+     * Test the unmarshalling with generic return type - GetMdibResponse is a registered class.
+     */
+    @Test
+    fun testUnmarshalToGeneric() {
+        val xml = """
+            <msg:GetMdibResponse MdibVersion="1" SequenceId="urn:uuid:16115207-2e9e-4193-aa36-111111111111"
+                                 xmlns:pm="http://standards.ieee.org/downloads/11073/11073-10207-2017/participant"
+                                 xmlns:msg="http://standards.ieee.org/downloads/11073/11073-10207-2017/message">
+                <msg:Mdib MdibVersion="1" SequenceId="urn:uuid:16115207-2e9e-4193-aa36-111111111111">
+                </msg:Mdib>
+            </msg:GetMdibResponse>
+        """.trimIndent()
+
+        val unmarshaledExtension = soapMarshaller.unmarshalToGeneric(xml.byteInputStream(), GetMdibResponse::class.java)
+
+        assertEquals(
+            GetMdibResponse::class.java,
+            unmarshaledExtension::class.java,
+            "The unmarshalled data is not of the expected type."
         )
     }
 

--- a/sdccc/src/test/resources/com/draeger/medical/sdccc/marshalling/SoapMarshallingTestData.xml
+++ b/sdccc/src/test/resources/com/draeger/medical/sdccc/marshalling/SoapMarshallingTestData.xml
@@ -1,0 +1,62 @@
+<!--
+~ This Source Code Form is subject to the terms of the MIT License.
+~ Copyright (c) 2025 Draegerwerk AG & Co. KGaA.
+~
+~ SPDX-License-Identifier: MIT
+-->
+
+
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope"
+                   xmlns:pm="http://standards.ieee.org/downloads/11073/11073-10207-2017/participant"
+                   xmlns:wsa5="http://www.w3.org/2005/08/addressing"
+                   xmlns:msg="http://standards.ieee.org/downloads/11073/11073-10207-2017/message"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <SOAP-ENV:Header>
+        <wsa5:MessageID>urn:uuid:748b1111-1111-1111-1111-111111112345</wsa5:MessageID>
+        <wsa5:RelatesTo>urn:uuid:bc032222-2222-2222-2222-167322222222</wsa5:RelatesTo>
+        <wsa5:Action SOAP-ENV:mustUnderstand="true">
+            http://standards.ieee.org/downloads/11073/11073-20701-2018/GetService/GetMdibResponse
+        </wsa5:Action>
+    </SOAP-ENV:Header>
+    <SOAP-ENV:Body>
+        <msg:GetMdibResponse MdibVersion="19516" SequenceId="urn:uuid:16115207-2e9e-4193-aa36-172864ab8073">
+            <msg:Mdib MdibVersion="19516" SequenceId="urn:uuid:16115207-2e9e-4193-aa36-172864ab8073">
+                <pm:MdDescription DescriptionVersion="1">
+                    <pm:Mds Handle="mds0" DescriptorVersion="1" SafetyClassification="MedC">
+                        <pm:Type Code="130535">
+                            <pm:ConceptDescription Lang="en-US">not settable metrics</pm:ConceptDescription>
+                        </pm:Type>
+                        <pm:AlertSystem Handle="asy.mds0" DescriptorVersion="0" SafetyClassification="MedA"
+                                        SelfCheckPeriod="P0Y0M0DT0H0M5.0S" xsi:type="pm:AlertSystemDescriptor">
+                            <pm:AlertCondition Handle="ac0.mds0" DescriptorVersion="0" SafetyClassification="MedA"
+                                               Kind="Phy" Priority="Me" xsi:type="pm:AlertConditionDescriptor">
+                                <pm:Type Code="262108">
+                                    <pm:ConceptDescription Lang="en-US">dummy condition</pm:ConceptDescription>
+                                </pm:Type>
+                                <pm:Source>mds0</pm:Source>
+                            </pm:AlertCondition>
+                            <pm:AlertSignal Handle="as0.mds0" DescriptorVersion="0" SafetyClassification="MedA"
+                                            ConditionSignaled="ac0.mds0" Manifestation="Aud" Latching="false"
+                                            xsi:type="pm:AlertSignalDescriptor"/>
+                        </pm:AlertSystem>
+                    </pm:Mds>
+                </pm:MdDescription>
+                <pm:MdState StateVersion="1">
+                    <pm:State xsi:type="pm:MdsState" DescriptorVersion="0" StateVersion="0" OperatingMode="Nml"
+                              Lang="en" DescriptorHandle="mds0"/>
+                    <pm:State xsi:type="pm:AlertSystemState" DescriptorVersion="0" StateVersion="0" ActivationState="On"
+                              LastSelfCheck="1579170442507" SelfCheckCount="40"
+                              PresentPhysiologicalAlarmConditions="ac0.mds0" PresentTechnicalAlarmConditions=""
+                              DescriptorHandle="asy.mds0">
+                        <pm:SystemSignalActivation Manifestation="Aud" State="Psd"/>
+                    </pm:State>
+                    <pm:State xsi:type="pm:AlertConditionState" DescriptorVersion="0" StateVersion="0"
+                              ActivationState="On" DeterminationTime="1579170442508" Presence="true"
+                              DescriptorHandle="ac0.mds0"/>
+                    <pm:State xsi:type="pm:AlertSignalState" DescriptorVersion="0" StateVersion="0" ActivationState="On"
+                              Presence="On" DescriptorHandle="as0.mds0"/>
+                </pm:MdState>
+            </msg:Mdib>
+        </msg:GetMdibResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
Feature to unmarshall SOAP messages with casting to a configurable class

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [ ] Reviewer
