### PR TITLE
Add processAllRemoteMdibAccess with sequenceId to historian

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/MdibHistorian.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/util/MdibHistorian.java
@@ -652,6 +652,23 @@ public class MdibHistorian {
     }
 
     /**
+     * Processes each RemoteMdibAccess from the episodic report based histories
+     * for all known sequence ids using the provided processor.
+     *
+     * @param processor a BiConsumer that processes a RemoteMdibAccess and its associated sequence id.
+     */
+    public void processAllRemoteMdibAccess(final BiConsumer<RemoteMdibAccess, String> processor) throws IOException {
+        try (final Stream<String> sequenceIds = this.getKnownSequenceIds()) {
+            sequenceIds.forEach(sequenceId -> {
+                processRemoteMdibAccessForSequence(
+                        mdibAccess -> processor.accept(mdibAccess, sequenceId),
+                        sequenceId
+                );
+            });
+        }
+    }
+
+    /**
      * Processes each consecutive pair of RemoteMdibAccess instances from the episodic report based history
      * of the specified sequenceId using the provided processor.
      *


### PR DESCRIPTION
// Lets you process mdib history with sequenceId 

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
