### PR TITLE
Remove optional manipulation responses

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/FallbackManipulations.java
@@ -14,7 +14,6 @@ import com.google.inject.Singleton;
 import java.io.FilterInputStream;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import javax.xml.namespace.QName;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -139,7 +138,7 @@ public class FallbackManipulations implements Manipulations {
     }
 
     @Override
-    public ManipulationResponse<Optional<String>> createContextStateWithAssociation(
+    public ManipulationResponse<String> createContextStateWithAssociation(
             final String descriptorHandle, final ContextAssociation association) {
         final var interactionMessage = String.format(
                 "Create a NEW context state for the descriptor %s and set the context association to %s."
@@ -152,9 +151,9 @@ public class FallbackManipulations implements Manipulations {
                 })
                 .displayStringInputUserInteraction(interactionMessage);
         if (data == null || data.isBlank()) {
-            return ManipulationResponse.from(ResponseTypes.Result.RESULT_FAIL, Optional.empty());
+            return ManipulationResponse.fail(null);
         }
-        return ManipulationResponse.from(ResponseTypes.Result.RESULT_SUCCESS, Optional.of(data));
+        return ManipulationResponse.from(ResponseTypes.Result.RESULT_SUCCESS, data);
     }
 
     @Override

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/GRpcManipulations.java
@@ -197,7 +197,7 @@ public class GRpcManipulations implements Manipulations {
     }
 
     @Override
-    public ManipulationResponse<Optional<String>> createContextStateWithAssociation(
+    public ManipulationResponse<String> createContextStateWithAssociation(
             final String descriptorHandle, final ContextAssociation association) {
         final var request = ContextRequests.CreateContextStateWithAssociationRequest.newBuilder()
                 .setDescriptorHandle(descriptorHandle)
@@ -210,9 +210,9 @@ public class GRpcManipulations implements Manipulations {
                 response -> response.getStatus().getResult(),
                 msg -> {
                     if (msg.getContextStateHandle().isBlank()) {
-                        return ManipulationResponse.from(msg.getStatus(), Optional.empty());
+                        return ManipulationResponse.from(msg.getStatus(), null);
                     }
-                    return ManipulationResponse.from(msg.getStatus(), Optional.of(msg.getContextStateHandle()));
+                    return ManipulationResponse.from(msg.getStatus(), msg.getContextStateHandle());
                 },
                 ManipulationParameterUtil.buildContextAssociationManipulationParameterData(
                         descriptorHandle, association));

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationResponse.kt
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/ManipulationResponse.kt
@@ -69,34 +69,34 @@ data class ManipulationResponse<T>(
     /**
      * Response of the manipulation.
      */
-    val response: T
+    val response: T?
 ) : Response {
     companion object {
         /**
          * Creates a ManipulationResponse from a ResponseTypes.Result and response content.
          */
         @JvmStatic
-        fun <T> from(status: ResponseTypes.Result, response: T): ManipulationResponse<T> =
+        fun <T> from(status: ResponseTypes.Result, response: T?): ManipulationResponse<T> =
             ManipulationResponse(status, response)
 
         /**
          * Creates a ManipulationResponse from a BasicResponses.BasicResponse and response content.
          */
         @JvmStatic
-        fun <T> from(status: BasicResponses.BasicResponse, response: T): ManipulationResponse<T> =
+        fun <T> from(status: BasicResponses.BasicResponse, response: T?): ManipulationResponse<T> =
             from(status.result, response)
 
         /**
          * Creates a ManipulationResponse with [ResponseTypes.Result.RESULT_SUCCESS] and response content.
          */
         @JvmStatic
-        fun <T> success(response: T): ManipulationResponse<T> = from(ResponseTypes.Result.RESULT_SUCCESS, response)
+        fun <T> success(response: T?): ManipulationResponse<T> = from(ResponseTypes.Result.RESULT_SUCCESS, response)
 
         /**
          * Creates a ManipulationResponse with [ResponseTypes.Result.RESULT_FAIL] and response content.
          */
         @JvmStatic
-        fun <T> fail(response: T): ManipulationResponse<T> = from(ResponseTypes.Result.RESULT_FAIL, response)
+        fun <T> fail(response: T?): ManipulationResponse<T> = from(ResponseTypes.Result.RESULT_FAIL, response)
 
         /**
          * Deserializes a [ManipulationResponse] from a string.

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/Manipulations.java
@@ -8,7 +8,6 @@
 package com.draeger.medical.sdccc.manipulation;
 
 import java.util.List;
-import java.util.Optional;
 import javax.xml.namespace.QName;
 import org.somda.sdc.biceps.model.participant.AbstractDescriptor;
 import org.somda.sdc.biceps.model.participant.AlertActivation;
@@ -75,9 +74,9 @@ public interface Manipulations {
      *
      * @param descriptorHandle to associate a new context for
      * @param association      to set for new state
-     * @return result and handle of the newly created state, empty if unsuccessful
+     * @return result and handle of the newly created state, null if unsuccessful
      */
-    ManipulationResponse<Optional<String>> createContextStateWithAssociation(
+    ManipulationResponse<String> createContextStateWithAssociation(
             String descriptorHandle, ContextAssociation association);
 
     /**

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditions.java
@@ -128,7 +128,7 @@ public class ConditionalPreconditions {
                 manipulations.getRemovableDescriptorsOfClass().getResponse();
         logger.debug("Changing presence for descriptors {}", modifiableDescriptors);
 
-        if (modifiableDescriptors.isEmpty()) {
+        if (modifiableDescriptors == null) {
             logger.info("No modifiable descriptors available for manipulation");
             return false;
         }
@@ -422,7 +422,7 @@ public class ConditionalPreconditions {
             final List<String> removableMdsDescriptors = manipulations
                     .getRemovableDescriptorsOfClass(MdsDescriptor.class)
                     .getResponse();
-            if (removableMdsDescriptors.isEmpty()) {
+            if (removableMdsDescriptors == null) {
                 LOG.error("No removable MdsDescriptors could be found via the GetRemovableDescriptorsOfType "
                         + "manipulation. Please check if the test case applying this precondition is applicable to "
                         + "your device and if the GetRemovableDescriptorsOfType manipulation has been implemented "
@@ -860,9 +860,9 @@ public class ConditionalPreconditions {
                         contextStateClass);
 
                 // associate another one if the first one worked out
-                if (newStateHandle.isPresent()) {
+                if (newStateHandle != null) {
                     // add new state to known states
-                    originalStates.add(newStateHandle.orElseThrow());
+                    originalStates.add(newStateHandle);
                     newStateHandle = associateNewContextForHandle(
                             testClient.getSdcRemoteDevice(),
                             manipulations,
@@ -871,7 +871,7 @@ public class ConditionalPreconditions {
                             contextStateClass);
                 }
 
-                if (newStateHandle.isEmpty()) {
+                if (newStateHandle == null) {
                     testRunObserver.invalidateTestRun(
                             String.format("Associating a new context state for handle %s failed", entity.getHandle()));
                     return false;
@@ -890,7 +890,7 @@ public class ConditionalPreconditions {
          * @param contextStateClass    of the context state
          * @return handle of new valid state, or empty
          */
-        static Optional<String> associateNewContextForHandle(
+        static String associateNewContextForHandle(
                 final SdcRemoteDevice device,
                 final Manipulations manipulations,
                 final String handle,
@@ -900,17 +900,17 @@ public class ConditionalPreconditions {
             var stateHandle = manipulations
                     .createContextStateWithAssociation(handle, ContextAssociation.ASSOC)
                     .getResponse();
-            if (stateHandle.isEmpty()) {
+            if (stateHandle == null) {
                 LOG.error("Associating new context state failed for handle {}", handle);
-                return Optional.empty();
+                return null;
             }
-            LOG.debug("New context created, state handle is {}", stateHandle.orElseThrow());
+            LOG.debug("New context created, state handle is {}", stateHandle);
             final var validState = verifyStatePresentAndAssociated(
-                    device, handle, stateHandle.orElseThrow(), previousStateHandles, contextStateClass);
+                    device, handle, stateHandle, previousStateHandles, contextStateClass);
             if (!validState) {
                 LOG.error("Validation for new context state {} failed", stateHandle);
                 // remove state handle from return value in invalid cases
-                stateHandle = Optional.empty();
+                stateHandle = null;
             }
             return stateHandle;
         }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditions.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -136,7 +135,7 @@ public class ManipulationPreconditions {
 
         final var modifiableDescriptors =
                 manipulations.getRemovableDescriptorsOfClass().getResponse();
-        if (modifiableDescriptors.isEmpty()) {
+        if (modifiableDescriptors == null) {
             log.info("No modifiable descriptors available for manipulation");
             return false;
         }
@@ -278,9 +277,9 @@ public class ManipulationPreconditions {
                         originalStates);
 
                 // associate another one if the first one worked out
-                if (newStateHandle.isPresent()) {
+                if (newStateHandle != null) {
                     // add new state to known states
-                    originalStates.add(newStateHandle.orElseThrow());
+                    originalStates.add(newStateHandle);
                     newStateHandle = associateNewPatientForHandle(
                             testClient.getSdcRemoteDevice(),
                             manipulations,
@@ -288,7 +287,7 @@ public class ManipulationPreconditions {
                             originalStates);
                 }
 
-                if (newStateHandle.isEmpty()) {
+                if (newStateHandle == null) {
                     testRunObserver.invalidateTestRun(String.format(
                             "Associating a new patient for handle %s failed", patientContextEntity.getHandle()));
                     noEmptyStateEncountered = false;
@@ -307,7 +306,7 @@ public class ManipulationPreconditions {
          * @param previousStateHandles previously present state handles, to ensure new state is actually new
          * @return handle of new valid state, or empty
          */
-        static Optional<String> associateNewPatientForHandle(
+        static String associateNewPatientForHandle(
                 final SdcRemoteDevice device,
                 final Manipulations manipulations,
                 final String handle,
@@ -316,17 +315,16 @@ public class ManipulationPreconditions {
             var stateHandle = manipulations
                     .createContextStateWithAssociation(handle, ContextAssociation.ASSOC)
                     .getResponse();
-            if (stateHandle.isEmpty()) {
+            if (stateHandle == null) {
                 LOG.error("Associating new patient failed for handle {}", handle);
-                return Optional.empty();
+                return null;
             }
-            LOG.debug("New patient created, state handle is {}", stateHandle.orElseThrow());
-            final var validState =
-                    verifyStatePresentAndAssociated(device, handle, stateHandle.orElseThrow(), previousStateHandles);
+            LOG.debug("New patient created, state handle is {}", stateHandle);
+            final var validState = verifyStatePresentAndAssociated(device, handle, stateHandle, previousStateHandles);
             if (!validState) {
                 LOG.error("Validation for new context state {} failed", stateHandle);
                 // remove state handle from return value in invalid cases
-                stateHandle = Optional.empty();
+                stateHandle = null;
             }
             return stateHandle;
         }
@@ -479,9 +477,9 @@ public class ManipulationPreconditions {
                         originalStates);
 
                 // associate another one if the first one worked out
-                if (newStateHandle.isPresent()) {
+                if (newStateHandle != null) {
                     // add new state to known states
-                    originalStates.add(newStateHandle.orElseThrow());
+                    originalStates.add(newStateHandle);
                     newStateHandle = associateNewLocationForHandle(
                             testClient.getSdcRemoteDevice(),
                             testClient,
@@ -490,7 +488,7 @@ public class ManipulationPreconditions {
                             originalStates);
                 }
 
-                if (newStateHandle.isEmpty()) {
+                if (newStateHandle == null) {
                     testRunObserver.invalidateTestRun(String.format(
                             "Associating a new location for handle %s failed", locationContextEntity.getHandle()));
                     noEmptyStateEncountered = false;
@@ -509,7 +507,7 @@ public class ManipulationPreconditions {
          * @param previousStateHandles previously present state handles, to ensure new state is actually new
          * @return handle of new valid state, or empty
          */
-        static Optional<String> associateNewLocationForHandle(
+        static String associateNewLocationForHandle(
                 final SdcRemoteDevice device,
                 final TestClient testClient,
                 final Manipulations manipulations,
@@ -519,19 +517,18 @@ public class ManipulationPreconditions {
             var stateHandle = manipulations
                     .createContextStateWithAssociation(handle, ContextAssociation.ASSOC)
                     .getResponse();
-            if (stateHandle.isEmpty()) {
+            if (stateHandle == null) {
                 LOG.error("Associating new location failed for handle {}", handle);
-                return Optional.empty();
+                return null;
             }
-            waitForEpisodicContextReportToModifyStateHandle(testClient, stateHandle.orElseThrow());
+            waitForEpisodicContextReportToModifyStateHandle(testClient, stateHandle);
 
-            LOG.debug("New location created, state handle is {}", stateHandle.orElseThrow());
-            final var validState =
-                    verifyStatePresentAndAssociated(device, handle, stateHandle.orElseThrow(), previousStateHandles);
+            LOG.debug("New location created, state handle is {}", stateHandle);
+            final var validState = verifyStatePresentAndAssociated(device, handle, stateHandle, previousStateHandles);
             if (!validState) {
                 LOG.error("Validation for new context state {} failed", stateHandle);
                 // remove state handle from return value in invalid cases
-                stateHandle = Optional.empty();
+                stateHandle = null;
             }
             return stateHandle;
         }

--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTest.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTest.java
@@ -92,13 +92,12 @@ public class DirectParticipantModelContextStateTest extends InjectorTestBase {
         final var newHandle = manipulations
                 .createContextStateWithAssociation(contextDescriptor.getHandle(), ContextAssociation.ASSOC)
                 .getResponse();
-        assertTrue(
-                newHandle.isPresent(),
-                String.format("Manipulation was unsuccessful for handle %s", contextDescriptor.getHandle()));
-        final var newContextState = testClient
-                .getSdcRemoteDevice()
-                .getMdibAccess()
-                .getState(newHandle.orElseThrow(), AbstractContextState.class);
+
+        assertNotNull(
+                newHandle, String.format("Manipulation was unsuccessful for handle %s", contextDescriptor.getHandle()));
+
+        final var newContextState =
+                testClient.getSdcRemoteDevice().getMdibAccess().getState(newHandle, AbstractContextState.class);
 
         assertFalse(newContextState.isEmpty(), String.format("State with handle %s is not present", newHandle));
         assertSame(

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/GRpcManipulationsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/GRpcManipulationsTest.java
@@ -16,8 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -240,7 +240,7 @@ public class GRpcManipulationsTest {
             final var response = manipulations.getRemovableDescriptorsOfClass().getResponse();
             // fallback should not have been called here
             verifyNoInteractions(fallback);
-            assertTrue(response.isEmpty(), "manipulation succeeded but shouldn't have");
+            assertNull(response, "manipulation succeeded but shouldn't have");
         }
     }
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/GRpcManipulationsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/GRpcManipulationsTest.java
@@ -16,8 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -240,7 +240,8 @@ public class GRpcManipulationsTest {
             final var response = manipulations.getRemovableDescriptorsOfClass().getResponse();
             // fallback should not have been called here
             verifyNoInteractions(fallback);
-            assertNull(response, "manipulation succeeded but shouldn't have");
+
+            assertTrue(response == null || response.isEmpty(), "manipulation succeeded but shouldn't have");
         }
     }
 

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ConditionalPreconditionsTest.java
@@ -1745,7 +1745,7 @@ public class ConditionalPreconditionsTest {
 
         // Manipulation of WorkflowContext is not supported
         when(mockManipulations.createContextStateWithAssociation(eq(WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE), any()))
-                .thenReturn(ManipulationResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED, Optional.empty()));
+                .thenReturn(ManipulationResponse.from(ResponseTypes.Result.RESULT_NOT_SUPPORTED, null));
 
         final var expectedContextStateHandleCount = Map.of(
                 MEANS_CONTEXT_DESCRIPTOR_HANDLE, 2L,
@@ -1940,9 +1940,9 @@ public class ConditionalPreconditionsTest {
             // introduce error, manipulation returns same handle twice
             when(mockManipulations.createContextStateWithAssociation(
                             PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                    .thenReturn(ManipulationResponse.success(PATIENT_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.success(PATIENT_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.fail(null));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -1950,9 +1950,9 @@ public class ConditionalPreconditionsTest {
             associateAllContextStatesSetup();
             when(mockManipulations.createContextStateWithAssociation(
                             LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                    .thenReturn(ManipulationResponse.success(LOCATION_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.success(LOCATION_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.fail(null));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -1960,9 +1960,9 @@ public class ConditionalPreconditionsTest {
             associateAllContextStatesSetup();
             when(mockManipulations.createContextStateWithAssociation(
                             ENSEMBLE_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(ManipulationResponse.success(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.success(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                    .thenReturn(ManipulationResponse.success(ENSEMBLE_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.success(ENSEMBLE_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.fail(null));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -1970,9 +1970,9 @@ public class ConditionalPreconditionsTest {
             associateAllContextStatesSetup();
             when(mockManipulations.createContextStateWithAssociation(
                             MEANS_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(ManipulationResponse.success(Optional.of(MEANS_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.success(Optional.of(MEANS_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                    .thenReturn(ManipulationResponse.success(MEANS_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.success(MEANS_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.fail(null));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -1980,9 +1980,9 @@ public class ConditionalPreconditionsTest {
             associateAllContextStatesSetup();
             when(mockManipulations.createContextStateWithAssociation(
                             OPERATOR_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(ManipulationResponse.success(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.success(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                    .thenReturn(ManipulationResponse.success(OPERATOR_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.success(OPERATOR_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.fail(null));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -1990,9 +1990,9 @@ public class ConditionalPreconditionsTest {
             associateAllContextStatesSetup();
             when(mockManipulations.createContextStateWithAssociation(
                             WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                    .thenReturn(ManipulationResponse.success(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.success(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE)))
-                    .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                    .thenReturn(ManipulationResponse.success(WORKFLOW_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.success(WORKFLOW_CONTEXT_STATE_HANDLE))
+                    .thenReturn(ManipulationResponse.fail(null));
 
             allKindsOfContextStatesAssociatedManipulationFailed();
         }
@@ -2062,44 +2062,44 @@ public class ConditionalPreconditionsTest {
         // make manipulation return our two patient context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE2)))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.success(PATIENT_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.success(PATIENT_CONTEXT_STATE_HANDLE2))
+                .thenReturn(ManipulationResponse.fail(null));
 
         // make manipulation return our two location context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE2)))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.success(LOCATION_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.success(LOCATION_CONTEXT_STATE_HANDLE2))
+                .thenReturn(ManipulationResponse.fail(null));
 
         // make manipulation return our two ensemble context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         ENSEMBLE_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.success(Optional.of(ENSEMBLE_CONTEXT_STATE_HANDLE2)))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.success(ENSEMBLE_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.success(ENSEMBLE_CONTEXT_STATE_HANDLE2))
+                .thenReturn(ManipulationResponse.fail(null));
 
         // make manipulation return our two means context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         MEANS_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(MEANS_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.success(Optional.of(MEANS_CONTEXT_STATE_HANDLE2)))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.success(MEANS_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.success(MEANS_CONTEXT_STATE_HANDLE2))
+                .thenReturn(ManipulationResponse.fail(null));
 
         // make manipulation return our two operator context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         OPERATOR_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.success(Optional.of(OPERATOR_CONTEXT_STATE_HANDLE2)))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.success(OPERATOR_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.success(OPERATOR_CONTEXT_STATE_HANDLE2))
+                .thenReturn(ManipulationResponse.fail(null));
 
         // make manipulation return our two workflow context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.success(Optional.of(WORKFLOW_CONTEXT_STATE_HANDLE2)))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.success(WORKFLOW_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.success(WORKFLOW_CONTEXT_STATE_HANDLE2))
+                .thenReturn(ManipulationResponse.fail(null));
 
         // return mock states on request
         when(mockDevice.getMdibAccess().getState(PATIENT_CONTEXT_STATE_HANDLE, PatientContextState.class))

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/precondition/impl/ManipulationPreconditionsTest.java
@@ -236,9 +236,9 @@ public class ManipulationPreconditionsTest {
         // make manipulation return our two patient context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE2)))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.success(PATIENT_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.success(PATIENT_CONTEXT_STATE_HANDLE2))
+                .thenReturn(ManipulationResponse.fail(null));
 
         // return mock states on request
         when(mockDevice.getMdibAccess().getState(PATIENT_CONTEXT_STATE_HANDLE, PatientContextState.class))
@@ -267,9 +267,9 @@ public class ManipulationPreconditionsTest {
         // make manipulation return our two location context state handles and nothing afterwards
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE2)))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.success(LOCATION_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.success(LOCATION_CONTEXT_STATE_HANDLE2))
+                .thenReturn(ManipulationResponse.fail(null));
 
         // return mock states on request
         when(mockDevice.getMdibAccess().getState(LOCATION_CONTEXT_STATE_HANDLE, LocationContextState.class))
@@ -356,9 +356,9 @@ public class ManipulationPreconditionsTest {
         // introduce error, manipulation returns same handle twice
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.success(Optional.of(PATIENT_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.success(PATIENT_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.success(PATIENT_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.fail(null));
 
         assertFalse(
                 ManipulationPreconditions.AssociatePatientsManipulation.manipulation(injector),
@@ -805,9 +805,9 @@ public class ManipulationPreconditionsTest {
         // introduce error, manipulation returns same handle twice
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.success(Optional.of(LOCATION_CONTEXT_STATE_HANDLE)))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.success(LOCATION_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.success(LOCATION_CONTEXT_STATE_HANDLE))
+                .thenReturn(ManipulationResponse.fail(null));
 
         final MdibAccessObservable mockMdibAccessObservable = mock(MdibAccessObservable.class);
         when(mockTestClient.getSdcRemoteDevice().getMdibAccessObservable()).thenReturn(mockMdibAccessObservable);

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTestTest.java
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/tests/biceps/direct/DirectParticipantModelContextStateTestTest.java
@@ -193,22 +193,22 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_PATIENT_CONTEXT_STATE_HANDLE));
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_LOCATION_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_LOCATION_CONTEXT_STATE_HANDLE));
         when(mockManipulations.createContextStateWithAssociation(
                         ENSEMBLE_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_ENSEMBLE_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_ENSEMBLE_CONTEXT_STATE_HANDLE));
         when(mockManipulations.createContextStateWithAssociation(
                         MEANS_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_MEANS_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_MEANS_CONTEXT_STATE_HANDLE));
         when(mockManipulations.createContextStateWithAssociation(
                         OPERATOR_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_OPERATOR_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_OPERATOR_CONTEXT_STATE_HANDLE));
         when(mockManipulations.createContextStateWithAssociation(
                         WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_WORKFLOW_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_WORKFLOW_CONTEXT_STATE_HANDLE));
 
         testClass.testRequirement0125();
     }
@@ -248,10 +248,10 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_WORKFLOW_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_WORKFLOW_CONTEXT_STATE_HANDLE));
         when(mockManipulations.createContextStateWithAssociation(
                         WORKFLOW_CONTEXT_DESCRIPTOR_HANDLE2, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_WORKFLOW_CONTEXT_STATE_HANDLE2)));
+                .thenReturn(ManipulationResponse.success(NEW_WORKFLOW_CONTEXT_STATE_HANDLE2));
 
         testClass.testRequirement0125();
     }
@@ -289,10 +289,10 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_PATIENT_CONTEXT_STATE_HANDLE));
         when(mockManipulations.createContextStateWithAssociation(
                         OPERATOR_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_OPERATOR_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_OPERATOR_CONTEXT_STATE_HANDLE));
 
         testClass.testRequirement0125();
     }
@@ -314,8 +314,10 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.fail(Optional.empty()));
+                .thenReturn(ManipulationResponse.fail(null));
         final var error = assertThrows(AssertionError.class, testClass::testRequirement0125);
+        System.out.println(error.getMessage());
+        System.out.println(PATIENT_CONTEXT_DESCRIPTOR_HANDLE);
         assertTrue(error.getMessage().contains(PATIENT_CONTEXT_DESCRIPTOR_HANDLE));
     }
 
@@ -350,10 +352,10 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_PATIENT_CONTEXT_STATE_HANDLE));
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_LOCATION_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_LOCATION_CONTEXT_STATE_HANDLE));
 
         final var error = assertThrows(AssertionError.class, testClass::testRequirement0125);
         assertTrue(error.getMessage().contains(NEW_LOCATION_CONTEXT_STATE_HANDLE));
@@ -393,10 +395,10 @@ public class DirectParticipantModelContextStateTestTest {
 
         when(mockManipulations.createContextStateWithAssociation(
                         PATIENT_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_PATIENT_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_PATIENT_CONTEXT_STATE_HANDLE));
         when(mockManipulations.createContextStateWithAssociation(
                         LOCATION_CONTEXT_DESCRIPTOR_HANDLE, ContextAssociation.ASSOC))
-                .thenReturn(ManipulationResponse.success(Optional.of(NEW_LOCATION_CONTEXT_STATE_HANDLE)));
+                .thenReturn(ManipulationResponse.success(NEW_LOCATION_CONTEXT_STATE_HANDLE));
 
         assertThrows(AssertionError.class, testClass::testRequirement0125);
     }


### PR DESCRIPTION
Remove optional that can't be serialized by gson

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
