### PR TITLE
fix gnu org too many requests, fix license file names

### DIFF
--- a/build-logic/src/main/kotlin/LicenseDownloaderRenderer.kt
+++ b/build-logic/src/main/kotlin/LicenseDownloaderRenderer.kt
@@ -53,7 +53,7 @@ class LicenseDownloaderRenderer(
         moduleData.poms.forEach { pomData ->
             pomData.licenses.forEach { license ->
                 val url = license.url?.trim()
-                val fileName = license.name ?: "LICENSE"
+                val fileName = license.name?.replace(Regex("""[/\\:*?"<>|]"""), "_") ?: "LICENSE"
                 if (!url.isNullOrEmpty()) {
                     licenseDetails.add(url to fileName)
                 }
@@ -93,5 +93,4 @@ class LicenseDownloaderRenderer(
 
         project.logger.lifecycle("Downloaded license for $moduleName from $licenseUrl to $file")
     }
-
 }

--- a/build-logic/src/main/kotlin/LicenseDownloaderRenderer.kt
+++ b/build-logic/src/main/kotlin/LicenseDownloaderRenderer.kt
@@ -68,6 +68,7 @@ class LicenseDownloaderRenderer(
         val url = URL(sanitizedUrl)
 
         val connection = url.openConnection()
+        connection.setRequestProperty("User-Agent", "LicenseDownloader")
         connection.connectTimeout = CONNECT_TIMEOUT
         connection.readTimeout = READ_TIMEOUT
         connection.connect()


### PR DESCRIPTION
Add a user agent which solves the HTTP response 429 from gnu.org. Add a sanitizer to remove illegal characters from filenames.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
