### PR TITLE
fix: log level in assertTestData methods

### DIFF
--- a/sdccc/src/main/java/com/draeger/medical/sdccc/tests/InjectorTestBase.java
+++ b/sdccc/src/main/java/com/draeger/medical/sdccc/tests/InjectorTestBase.java
@@ -52,7 +52,7 @@ public class InjectorTestBase {
      */
     public void assertTestData(final Collection<?> data, final String message) throws NoTestData {
         if (data.isEmpty()) {
-            LOG.error(message);
+            LOG.debug(message);
             throw new NoTestData(message);
         }
     }
@@ -66,7 +66,7 @@ public class InjectorTestBase {
      */
     public void assertTestData(final int data, final String message) throws NoTestData {
         if (data == 0) {
-            LOG.error(message);
+            LOG.debug(message);
             throw new NoTestData(message);
         }
     }
@@ -80,7 +80,7 @@ public class InjectorTestBase {
      */
     public void assertTestData(final boolean data, final String message) throws NoTestData {
         if (!data) {
-            LOG.error(message);
+            LOG.debug(message);
             throw new NoTestData(message);
         }
     }
@@ -94,7 +94,7 @@ public class InjectorTestBase {
      */
     public void assertTestDataNotNull(@Nullable final Object data, final String message) throws NoTestData {
         if (data == null) {
-            LOG.error(message);
+            LOG.debug(message);
             throw new NoTestData(message);
         }
     }


### PR DESCRIPTION
changed the log level in the assertTestData methods in InjectorTestBase.java to debug from error, to not invalidate the test run.

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [x] Reviewer
