### PR TITLE
Update dependency that causes capability conflict

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ org-apache-httpclient = "4.5.14"
 org-apache-httpcore = "4.4.16"
 org-apache-logging-log4j = "2.24.1"
 org-apache-logging-log4j-log4j-api-kotlin = "1.4.0"
-org-bouncycastle = "1.67"
+org-bouncycastle = "1.78.1"
 org-glassfish-jaxb = "4.0.5"
 org-hibernate-core = "5.4.24.Final"
 org-jetbrains-kotlin = "1.9.23"
@@ -89,8 +89,8 @@ org-apache-logging-log4j-log4j-api = { module = "org.apache.logging.log4j:log4j-
 org-apache-logging-log4j-log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "org-apache-logging-log4j" }
 org-apache-logging-log4j-log4j-slf4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j-impl", version.ref = "org-apache-logging-log4j" }
 org-apache-logging-log4j-log4j-api-kotlin = { module = "org.apache.logging.log4j:log4j-api-kotlin", version.ref = "org-apache-logging-log4j-log4j-api-kotlin" }
-org-bouncycastle-bcpkix-jdk15on = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "org-bouncycastle" }
-org-bouncycastle-bcprov-jdk15on = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "org-bouncycastle" }
+org-bouncycastle-bcpkix-jdk15on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "org-bouncycastle" }
+org-bouncycastle-bcprov-jdk15on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "org-bouncycastle" }
 org-hibernate-hibernate-core = { module = "org.hibernate:hibernate-core", version.ref = "org-hibernate-core" }
 org-jetbrains-kotlin-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "org-jetbrains-kotlin" }
 org-jetbrains-kotlin-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "org-jetbrains-kotlin" }

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/GsonManipulationSerializerTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/manipulation/GsonManipulationSerializerTest.kt
@@ -8,8 +8,8 @@ package com.draeger.medical.sdccc.manipulation
 
 import com.draeger.medical.t2iapi.ResponseTypes
 import com.google.gson.Gson
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 /**
  * Test class for de-/serialization testing.

--- a/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshallingTest.kt
+++ b/sdccc/src/test/java/com/draeger/medical/sdccc/marshalling/SoapMarshallingTest.kt
@@ -9,12 +9,12 @@ package com.draeger.medical.sdccc.marshalling
 import com.draeger.medical.biceps.model.extension.ExtensionType
 import com.draeger.medical.biceps.model.message.GetMdibResponse
 import com.draeger.medical.dpws.soap.model.Envelope
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.w3c.dom.Element
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
 
 /**
  * Unit tests for the soap marshalling.
@@ -58,8 +58,10 @@ class SoapMarshallingTest {
 
         assertEquals(1, unmarshaledExtension.any.size, "The unmarshalled data is not present.")
 
-        val myExt = unmarshaledExtension.any[0]
-        assertIs<Element>(myExt)
+        val extension = unmarshaledExtension.any[0]
+        assertInstanceOf(Element::class.java, extension)
+        // added a null check before casting to avoid detekt finding CastNullableToNonNullableType
+        val myExt = (extension ?: error("Extension is null")) as Element
 
         assertEquals("http://biceps.extension", myExt.namespaceURI, "namespaceURI is not as expected.")
         assertEquals("MyExt", myExt.localName, "localName is not as expected.")


### PR DESCRIPTION
- Updated org.bouncycastle:bcpkix-jdk15on and org.bouncycastle:bcprov-jdk15on to org.bouncycastle:bcpkix-jdk18on and org.bouncycastle:bcprov-jdk18on to avoid capability conflict
- use org.junit.jupiter.api.Assertions instead of kotlin.test

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Adherence to javadoc conventions
  * [x] Pull Request Assignee
  * [x] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [x] Pull Request Assignee
  * [ ] Reviewer
