### PR TITLE
add implementation version to manifest.

### DIFF
--- a/build-logic/src/main/kotlin/com.draeger.medical.version-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/com.draeger.medical.version-conventions.gradle.kts
@@ -11,3 +11,10 @@ val actualChangeList = checkNotNull(project.findProperty("changelist")) { "No ch
 
 group = "com.draeger.medical"
 version = "$actualRevision$actualChangeList"
+
+tasks.withType<Jar> {
+    manifest {
+        attributes["Implementation-Title"] = project.name
+        attributes["Implementation-Version"] = project.version
+    }
+}


### PR DESCRIPTION
// Add implementation version to manifest so that the version gets printed when running SDCcc

# Checklist

The following aspects have been respected by the author of this pull request, confirmed by both pull request assignee **and** reviewer:

* Adherence to coding conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Adherence to javadoc conventions
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* README update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* config update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
* SDCcc executable ran against a test device (if necessary)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
